### PR TITLE
Fix test-data handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean-test:
 	rm -fr htmlcov/
 
 lint:
-	flake8 --max-complexity 12 planemo tests
+	flake8 --max-complexity 11 planemo tests
 
 test:
 	python setup.py test

--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -16,6 +16,9 @@ from galaxy.tools.deps.commands import shell
 @options.galaxy_root_option()
 @options.install_galaxy_option()
 @options.test_data_option()
+@options.dependency_resolvers_option()
+@options.job_config_option()
+@options.tool_dependency_dir_option()
 @pass_context
 def cli(ctx, path, **kwds):
     """Launch a Galaxy instance with the specified tool in the tool panel.

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -27,6 +27,9 @@ RUN_TESTS_CMD = (
 @options.galaxy_root_option()
 @options.install_galaxy_option()
 @options.test_data_option()
+@options.dependency_resolvers_option()
+@options.job_config_option()
+@options.tool_dependency_dir_option()
 @pass_context
 def cli(ctx, path, **kwds):
     """Run the tests in the specified tool tests in a Galaxy instance.

--- a/planemo/galaxy_run.py
+++ b/planemo/galaxy_run.py
@@ -7,7 +7,7 @@ DEACTIVATE_COMMAND = "type deactivate >/dev/null 2>&1 && deactivate"
 # server because run.sh does this).
 ACTIVATE_COMMAND = "[ -e .venv ] && . .venv/bin/activate"
 
-
+# TODO: Mac-y curl variant of this.
 DOWNLOAD_GALAXY = (
     "wget https://codeload.github.com/jmchilton/galaxy-central/tar.gz/master"
 )

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -20,6 +20,45 @@ def galaxy_root_option():
     )
 
 
+def dependency_resolvers_option():
+    return click.option(
+        "--dependency_resolvers_config_file",
+        type=click.Path(
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            resolve_path=True
+        ),
+        help="Dependency resolver configuration for Galaxy to target.",
+    )
+
+
+def job_config_option():
+    return click.option(
+        "--job_config_file",
+        type=click.Path(
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            resolve_path=True
+        ),
+        help="Job configuration file for Galaxy to target.",
+    )
+
+
+def tool_dependency_dir_option():
+    return click.option(
+        "--tool_dependency_dir",
+        type=click.Path(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True
+        ),
+        help="Tool dependency dir for Galaxy to target.",
+    )
+
+
 def install_galaxy_option():
     return click.option(
         "--install_galaxy",


### PR DESCRIPTION
Will now use test-data in tool directory if available.

Print's a red warning message if tes-data is unavailable. New command-line options for things interesting to tool development - tool dependency directory, job conf, and tool dependency resolvers.

While in galaxy_config.py did refactoring to get cyclomatic complexity down - shifted maximal allowed complexity down to 11 in `Makefile`.
