### PR TITLE
Improved Travis CI integration.

### DIFF
--- a/planemo/commands/cmd_travis_before_install.py
+++ b/planemo/commands/cmd_travis_before_install.py
@@ -1,13 +1,27 @@
+import os
+import string
+
 import click
 
 from planemo.cli import pass_context
-from galaxy.tools.deps.commands import shell
+from planemo.io import shell
+
+SETUP_FILE_NAME = "setup_custom_dependencies.bash"
+SAMTOOLS_URL = (
+    "http://archive.ubuntu.com/ubuntu/pool/universe/"
+    "s/samtools/samtools_0.1.19-1_amd64.deb"
+)
 
 FIX_EGGS_DIR = 'mkdir -p "$HOME/.python-eggs"; chmod 700 "$HOME/.python-eggs"'
-CUSTOM_DEPS = (
-    '[ -e ${TRAVIS_BUILD_DIR}/.travis/setup_custom_dependencies.bash ] && '
-    '. ${TRAVIS_BUILD_DIR}/.travis/setup_custom_dependencies.bash'
-)
+# samtools essentially required by Galaxy
+INSTALL_SAMTOOLS = (
+    "wget %s; "
+    "sudo dpkg -i samtools_0.1.19-1_amd64.deb"
+) % SAMTOOLS_URL
+
+BUILD_ENVIRONMENT_TEMPLATE = """
+export PATH=$PATH:${BUILD_BIN_DIR}
+"""
 
 
 @click.command('travis_before_install')
@@ -16,5 +30,34 @@ def cli(ctx):
     """This command is used internally by planemo to assist in contineous testing
     of tools with Travis CI (https://travis-ci.org/).
     """
+    build_dir = os.environ.get("TRAVIS_BUILD_DIR", None)
+    if not build_dir:
+        raise Exception("Failed to determine ${TRAVIS_BUILD_DIR}")
+
+    build_travis_dir = os.path.join(build_dir, ".travis")
+    if not os.path.exists(build_travis_dir):
+        os.makedirs(build_travis_dir)
+
+    build_bin_dir = os.path.join(build_travis_dir, "bin")
+    if not os.path.exists(build_bin_dir):
+        os.makedirs(build_bin_dir)
+
+    build_env_path = os.path.join(build_travis_dir, "env.sh")
+    template_vars = {
+        "BUILD_TRAVIS_DIR": build_travis_dir,
+        "BUILD_BIN_DIR": build_bin_dir,
+        "BUILD_ENV_PATH": build_env_path,
+    }
+    build_env = string.Template(BUILD_ENVIRONMENT_TEMPLATE).safe_substitute(
+        **template_vars
+    )
+    open(build_env_path, "a").write(build_env)
+
     shell(FIX_EGGS_DIR)
-    shell(CUSTOM_DEPS)
+    shell(INSTALL_SAMTOOLS)
+    setup_file = os.path.join(build_travis_dir, SETUP_FILE_NAME)
+    if os.path.exists(setup_file):
+        shell(
+            ". %s && bash -x %s" % (build_env_path, setup_file),
+            env=template_vars
+        )

--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -3,9 +3,17 @@ import os
 import click
 
 from planemo.cli import pass_context
-from planemo.io import warn
+from planemo.io import warn, info
 from planemo import options
 from galaxy.tools.deps.commands import shell
+
+PREPARE_MESSAGE = (
+    "Place commands to prepare an Ubuntu VM for use with your tool(s) "
+    "in the .travis/setup_custom_dependencies.bash shell script. Be sure to"
+    "add these new files to your git repository with 'git add .travis "
+    ".travis.yml' and then commit. You will also need to register your github "
+    "tool project with Travi CI by visiting https://travis-ci.org/."
+)
 
 TRAVIS_YML = """
 # This is a special configuration file to run tests on Travis-CI via
@@ -27,9 +35,9 @@ install:
  - . planemo-venv/bin/activate
  - pip install git+https://github.com/jmchilton/planemo.git
  - planemo travis_before_install
+ - . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source enviornment created by planemo
 
 script:
- - . planemo-venv/bin/activate
  - planemo test --install_galaxy ${TRAVIS_BUILD_DIR}
 """
 
@@ -60,3 +68,4 @@ def cli(ctx, path):
         warn(".travis.yml file already exists, not overwriting.")
     if not os.path.exists(setup_sh):
         open(setup_sh, "w").write("#!/bin/bash\n")
+    info(PREPARE_MESSAGE)

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -2,9 +2,9 @@ import click
 from galaxy.tools.deps import commands
 
 
-def shell(cmds):
+def shell(cmds, **kwds):
     info(cmds)
-    return commands.shell(cmds)
+    return commands.shell(cmds, **kwds)
 
 
 def info(message, *args):


### PR DESCRIPTION
- Install samtools - needed for bams. Going with version 0.1.19 - newish but not too new.
- More of a framework for installation of dependencies - provide scripts with some place on the PATH to put things (namely ${BUILD_BIN_DIR} which gets injected into the script runtime).
- Run install script with -x so the actual commands get printed, should help with debugging.
- Prettier reporting of commands being run by planemo at runtime.
- More output information at repo init time - tell developer where install script is and how to register with Travis CI.
