### PR TITLE
Trim generated .travis.yml by fetching install script dynmically.

### DIFF
--- a/planemo/__init__.py
+++ b/planemo/__init__.py
@@ -1,3 +1,10 @@
 # -*- coding: utf-8 -*-
 
 __version__ = '0.0.1'
+
+
+PROJECT_NAME = "planemo"
+PROJECT_USERAME = "jmchilton"
+RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
+    PROJECT_USERAME, PROJECT_NAME
+)

--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -5,6 +5,7 @@ import click
 from planemo.cli import pass_context
 from planemo.io import warn, info
 from planemo import options
+from planemo import RAW_CONTENT_URL
 from galaxy.tools.deps.commands import shell
 
 PREPARE_MESSAGE = (
@@ -15,6 +16,7 @@ PREPARE_MESSAGE = (
     "tool project with Travi CI by visiting https://travis-ci.org/."
 )
 
+TRAVIS_TEST_SCRIPT_URL = RAW_CONTENT_URL + "scripts/travis_test.sh"
 TRAVIS_YML = """
 # This is a special configuration file to run tests on Travis-CI via
 # GitHub notifications when changes are committed.
@@ -29,17 +31,9 @@ TRAVIS_YML = """
 # (which will still have a system python installed).
 language: java
 
-install:
- - sudo apt-get install -y python-virtualenv
- - virtualenv planemo-venv
- - . planemo-venv/bin/activate
- - pip install git+https://github.com/jmchilton/planemo.git
- - planemo travis_before_install
- - . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source enviornment created by planemo
-
 script:
- - planemo test --install_galaxy ${TRAVIS_BUILD_DIR}
-"""
+ - wget -O- %s | /bin/bash -x
+""" % TRAVIS_TEST_SCRIPT_URL
 
 
 @click.command('travis_init')
@@ -59,6 +53,9 @@ def cli(ctx, path):
     These tests were inspired by work original done and documented by Peter
     Cock here http://bit.ly/gxtravisci.
     """
+    # TODO: Option --verbose_travis_yaml to unroll travis_test.sh line by line
+    # and place all but last in 'install' section and last in 'script'. Would
+    # require a yaml dependency though.
     shell("mkdir -p '%s/.travis'" % path)
     travis_yml = os.path.join(path, ".travis.yml")
     setup_sh = os.path.join(path, ".travis", "setup_custom_dependencies.bash")

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+sudo apt-get install -y python-virtualenv
+virtualenv planemo-venv
+. planemo-venv/bin/activate
+pip install git+https://github.com/jmchilton/planemo.git
+planemo travis_before_install
+ . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source enviornment created by planemo
+planemo test --install_galaxy ${TRAVIS_BUILD_DIR}


### PR DESCRIPTION
Not sure of the wisdom of this - one one hand we can fix things in planemo as time goes on and that is good and may prove needed since we are targeting galaxy-central. On the other hand this is less tweakable and may in fact be more likely to break - hard to say.

Example of workin generated .travis.yml file here https://github.com/jmchilton/bwa-mem/commit/c7a5133f1d3574079c40f8e2c20b9202fb8f72af.
