### PR TITLE
Fix for subbing None templates. Happens when e.g. a test-data directory cannot be found.

### DIFF
--- a/planemo/galaxy_config.py
+++ b/planemo/galaxy_config.py
@@ -301,4 +301,6 @@ def __handle_kwd_overrides(properties, kwds):
 
 
 def __sub(template, args):
+    if template is None:
+        return ''
     return Template(template).safe_substitute(args)


### PR DESCRIPTION
...is not available.
