### PR TITLE
Print linting error if there are XML loading problems with tools.

### DIFF
--- a/galaxy/tools/loader_directory.py
+++ b/galaxy/tools/loader_directory.py
@@ -2,14 +2,28 @@ import glob
 import os
 from ..tools import loader
 
+import sys
+
+import logging
+log = logging.getLogger(__name__)
+
 PATH_DOES_NOT_EXIST_ERROR = "Could not load tools from path [%s] - this path does not exist."
+LOAD_FAILURE_ERROR = "Failed to load tool with path %s."
 
 
-def load_tool_elements_from_path(path):
+def load_exception_handler(path, exc_info):
+    log.warn(LOAD_FAILURE_ERROR % path, exc_info=exc_info)
+
+
+def load_tool_elements_from_path(path, load_exception_handler=load_exception_handler):
     tool_elements = []
     for file in __find_tool_files(path):
         if __looks_like_a_tool(file):
-            tool_elements.append((file, loader.load_tool(file)))
+            try:
+                tool_elements.append((file, loader.load_tool(file)))
+            except Exception:
+                exc_info = sys.exc_info()
+                load_exception_handler(file, exc_info)
     return tool_elements
 
 

--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -1,8 +1,10 @@
 import sys
+import traceback
 import click
 
 from planemo.cli import pass_context
 from planemo.io import info
+from planemo.io import error
 from planemo import options
 
 from galaxy.tools.loader_directory import load_tool_elements_from_path
@@ -31,7 +33,8 @@ def cli(ctx, path, report_level="all", fail_level="warn"):
     """
     exit = 0
     lint_args = dict(level=report_level, fail_level=fail_level)
-    for (tool_path, tool_xml) in load_tool_elements_from_path(path):
+    tools = load_tool_elements_from_path(path, load_exception_handler)
+    for (tool_path, tool_xml) in tools:
         if tool_xml.getroot().tag != "tool":
             if ctx.verbose:
                 info(SKIP_XML_MESSAGE % tool_path)
@@ -40,3 +43,8 @@ def cli(ctx, path, report_level="all", fail_level="warn"):
         if not lint_xml(tool_xml, **lint_args):
             exit = 1
     sys.exit(exit)
+
+
+def load_exception_handler(path, exc_info):
+    error("Error loading tool with path %s" % path)
+    traceback.print_exception(*exc_info, limit=1, file=sys.stderr)


### PR DESCRIPTION
Kind of a stop gap - this should be handled for all the operations and a prettier, more complete error should be printed - I think the tool shed actually does a good job with these errors so we should steal that code and move it into tool loader.
