### PR TITLE
Implement --update_test_data flag for test command.

### DIFF
--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -33,7 +33,10 @@ please careful and do not try this against production Galaxy instances.
 
 
       --test_output PATH              Output test report.
-      --job_output_files DIRECTORY    Write job outputs to directory.
+      --job_output_files DIRECTORY    Write job outputs to specified directory.
+      --update_test_data              Update test-data directory with job outputs
+                                      (normally written to directory
+                                      --job_output_files if specified.)
       --galaxy_root DIRECTORY         Root of development galaxy directory to
                                       execute command with.
       --install_galaxy                Download and configure a disposable copy of

--- a/planemo/galaxy_config.py
+++ b/planemo/galaxy_config.py
@@ -67,7 +67,7 @@ FAILED_TO_FIND_GALAXY_EXCEPTION = (
 
 GalaxyConfig = namedtuple(
     'GalaxyConfig',
-    ['galaxy_root', 'config_directory', 'env']
+    ['galaxy_root', 'config_directory', 'env', 'test_data_dir']
 )
 
 
@@ -226,7 +226,7 @@ def galaxy_config(tool_path, for_tests=False, **kwds):
         open(tool_conf, "w").write(tool_conf_contents)
         open(empty_tool_conf, "w").write(EMPTY_TOOL_CONF_TEMPLATE)
 
-        yield GalaxyConfig(galaxy_root, config_directory, env)
+        yield GalaxyConfig(galaxy_root, config_directory, env, test_data_dir)
     finally:
         if created_config_directory:
             shutil.rmtree(config_directory)


### PR DESCRIPTION
When planemo test is called with this flag - the outputs of the tests are copied back into the files they are compared against in test-data. This is useful for updating these files automatically with small differences during minor updates.

Please review these changes carefully though and only use this option when you are sure the tool is correct - otherwise these tests are not useful for verifying correctness (only for reproducibility across systems) since they will just be comparing the tool against data the tool generated.
