### PR TITLE
More test output configuration updates.

### DIFF
--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -15,14 +15,24 @@ This section is auto-generated from the help text for the planemo command
 Run the tests in the specified tool tests in a Galaxy instance.
 
 All referenced tools (by default all the tools in the current working
-directory) will be tested and the resulted disposited in path specified
-with ``--test_output`` (defaults to tool_test_output.html).
+directory) will be tested and the results quickly summarized.
 
 To run these tests planemo needs a Galaxy instance to utilize, planemo
 will search parent directories to see if any is a Galaxy instance
 - but one can pick the Galaxy instance to use with the --galaxy_root
 option or force planemo to download a disposable instance with the
 ``--install_galaxy`` flag.
+
+In additon to to quick summary printed to the console - various detailed
+output summaries can be configured. ``tool_test_output.html`` (settable
+via ``--test_output``) will contain a human consumable HTML report
+describing the test run. A JSON file (settable via ``--test_output_json``
+and defaulting to ``tool_test_output.json``) will also be created. These
+files can can be disabled by passing in empty arguments or globally by
+setting the values ``default_test_output`` and/or
+``default_test_output_json`` in ``~/.planemo.yml`` to ``null``. For
+continuous integration testing a xUnit-style report can be confiured using
+the ``--test_output_xunit``.
 
 planemo uses temporarily generated config files and environment variables
 to attempt to shield this execution of Galaxy from manually launched runs
@@ -32,10 +42,12 @@ please careful and do not try this against production Galaxy instances.
 **Options**::
 
 
-      --test_output PATH              Output test report (HTML - for humans).
+      --test_output PATH              Output test report (HTML - for humans)
+                                      defaults to tool_test_output.html.
       --test_output_xunit PATH        Output test report (xUnit style - for
                                       computers).
-      --test_output_json PATH         Output test report (planemo json).
+      --test_output_json PATH         Output test report (planemo json) defaults
+                                      to tool_test_output.json.
       --job_output_files DIRECTORY    Write job outputs to specified directory.
       --update_test_data              Update test-data directory with job outputs
                                       (normally written to directory

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -95,14 +95,24 @@ def cli(ctx, path, **kwds):
     """Run the tests in the specified tool tests in a Galaxy instance.
 
     All referenced tools (by default all the tools in the current working
-    directory) will be tested and the resulted disposited in path specified
-    with ``--test_output`` (defaults to tool_test_output.html).
+    directory) will be tested and the results quickly summarized.
 
     To run these tests planemo needs a Galaxy instance to utilize, planemo
     will search parent directories to see if any is a Galaxy instance
     - but one can pick the Galaxy instance to use with the --galaxy_root
     option or force planemo to download a disposable instance with the
     ``--install_galaxy`` flag.
+
+    In additon to to quick summary printed to the console - various detailed
+    output summaries can be configured. ``tool_test_output.html`` (settable
+    via ``--test_output``) will contain a human consumable HTML report
+    describing the test run. A JSON file (settable via ``--test_output_json``
+    and defaulting to ``tool_test_output.json``) will also be created. These
+    files can can be disabled by passing in empty arguments or globally by
+    setting the values ``default_test_output`` and/or
+    ``default_test_output_json`` in ``~/.planemo.yml`` to ``null``. For
+    continuous integration testing a xUnit-style report can be confiured using
+    the ``--test_output_xunit``.
 
     planemo uses temporarily generated config files and environment variables
     to attempt to shield this execution of Galaxy from manually launched runs


### PR DESCRIPTION
Allow disabling JSON generation or configuring different defaults via `~/.planemo.yml` and update documentation for recent changes.