### PR TITLE
Attempt to parse json returned for toolshed errors

### DIFF
--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -8,6 +8,7 @@ from planemo import shed
 from planemo.io import error
 from planemo.io import info
 from planemo.io import shell
+import json
 
 import fnmatch
 import os
@@ -117,7 +118,12 @@ def __handle_upload(ctx, path, **kwds):
     try:
         tsi.repositories.update_repository(repo_id, tar_path, **update_kwds)
     except Exception as e:
-        error("Could not update %s" % path)
-        error(e.read())
+        exception_content = e.read()
+        try:
+            upstream_error = json.loads(exception_content)
+            error(upstream_error['err_msg'])
+        except:
+            error("Could not update %s" % path)
+            error(exception_content)
         return -1
     info("Repository %s updated successfully." % path)

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -115,9 +115,10 @@ def __handle_upload(ctx, path, **kwds):
         try:
             upstream_error = json.loads(exception_content)
             error(upstream_error['err_msg'])
-        except:
+        except Exception as e2:
             error("Could not update %s" % path)
             error(exception_content)
+            error(e2.read())
         return -1
     info("Repository %s updated successfully." % path)
 
@@ -134,8 +135,8 @@ def __find_repository(ctx, tsi, path, **kwds):
         error("Could not update %s" % path)
         try:
             error(e.read())
-        except:
+        except Exception as e2:
             # I've seen a case where the error couldn't be read, so now
             # wrapped in try/except
-            pass
+            error(e2.read())
     return None

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -103,16 +103,9 @@ def __handle_upload(ctx, path, **kwds):
     message = kwds.get("message", None)
     if message:
         update_kwds["commit_message"] = message
-    try:
-        repo_id = shed.find_repository_id(ctx, tsi, path, **kwds)
-    except Exception as e:
-        error("Could not update %s" % path)
-        try:
-            error(e.read())
-        except:
-            # I've seen a case where the error couldn't be read, so now
-            # wrapped in try/except
-            pass
+
+    repo_id = __find_repository(ctx, tsi, path, kwds)
+    if repo_id is None:
         return -1
 
     try:
@@ -127,3 +120,22 @@ def __handle_upload(ctx, path, **kwds):
             error(exception_content)
         return -1
     info("Repository %s updated successfully." % path)
+
+
+def __find_repository(ctx, tsi, path, **kwds):
+    """Extracted into separate function to reduce complexity though it's not a
+    really sensible change since we now have to catch the error code separately
+    whenever we call this function elsewhere.
+    """
+    try:
+        repo_id = shed.find_repository_id(ctx, tsi, path, **kwds)
+        return repo_id
+    except Exception as e:
+        error("Could not update %s" % path)
+        try:
+            error(e.read())
+        except:
+            # I've seen a case where the error couldn't be read, so now
+            # wrapped in try/except
+            pass
+    return None


### PR DESCRIPTION
Instead of erroring with some ugly json, print just the more useful error message from upstream.

I'm not fantastically happy about all the exit codes from this function being -1, it's pretty unhelpful. That said no matter what they are if it isn't a perfectly successful exit from this function, recursive uploads will reduce this to an error exit no matter what, so not really sure what to do about that.

This fixes #67 (writing again because apparently the first one doesn't xref properly)