### PR TITLE
Fix stuff breaking my TTS pusher

### DIFF
--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -135,8 +135,8 @@ def __find_repository(ctx, tsi, path, **kwds):
         error("Could not update %s" % path)
         try:
             error(e.read())
-        except Exception as e2:
+        except AttributeError:
             # I've seen a case where the error couldn't be read, so now
             # wrapped in try/except
-            error(e2.read())
+            error("Could not find repository in toolshed")
     return None


### PR DESCRIPTION
So at some point a completely empty exception is thrown,
(I get the feeling it's from bioblend), and the exception
thrown by that has an AttributeError on the 'read' attribute
so we catch that and just leave an error message at that point

Rejection with comments welcome, I need to debug where the issue is originating from but I haven't had time yet.