### PR TITLE
Ignore list of files/directories that are specified in .shed.yml

### DIFF
--- a/planemo/shed.py
+++ b/planemo/shed.py
@@ -123,8 +123,8 @@ def build_tarball(tool_path):
     fd, temp_path = mkstemp()
     repo_config = shed_repo_config(tool_path)
     ignore_list = []
-    for shed_ignore in repo_config.get('shed_ignore', []):
-        ignore_list.extend( glob.glob( os.path.join(tool_path, shed_ignore) ) )
+    for shed_ignore in repo_config.get('ignore', []):
+        ignore_list.extend(glob.glob(os.path.join(tool_path, shed_ignore)))
     try:
         with tarfile.open(temp_path, "w:gz") as tar:
             for name in os.listdir(tool_path):

--- a/planemo/shed.py
+++ b/planemo/shed.py
@@ -2,6 +2,8 @@ import os
 from tempfile import mkstemp
 import tarfile
 import yaml
+import glob
+
 try:
     from bioblend import toolshed
 except ImportError:
@@ -119,14 +121,19 @@ def build_tarball(tool_path):
     responsible for deleting this file.
     """
     fd, temp_path = mkstemp()
+    repo_config = shed_repo_config(tool_path)
+    ignore_list = []
+    for shed_ignore in repo_config.get('shed_ignore', []):
+        ignore_list.extend( glob.glob( os.path.join(tool_path, shed_ignore) ) )
     try:
         with tarfile.open(temp_path, "w:gz") as tar:
             for name in os.listdir(tool_path):
-                if os.path.islink(name):
-                    path = os.path.realpath(name)
-                else:
-                    path = os.path.join(tool_path, name)
-                tar.add(path, name, recursive=True, exclude=_tar_excludes)
+                if not os.path.join(tool_path, name) in ignore_list:
+                    if os.path.islink(name):
+                        path = os.path.realpath(name)
+                    else:
+                        path = os.path.join(tool_path, name)
+                    tar.add(path, name, recursive=True, exclude=_tar_excludes)
     finally:
         os.close(fd)
     return temp_path


### PR DESCRIPTION
The new section "ignore" can contain a list of files, directories or patterns that will not be included in the created tarball.
This is useful if you have some admin scripts included in this repository that are not intended for uploading into the Tool Shed.

Short example `.shed.yml` file:

```yaml
# repository published to https://toolshed.g2.bx.psu.edu/repos/galaxyp/peptideshaker
owner: galaxyp
name: peptideshaker
ignore:
    - admin_scripts
    - '*.gz'
```