### PR TITLE
Rename shed_repo_create to just shed_create.

### DIFF
--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -14,7 +14,7 @@ import json
 
 # TODO: Implement alternative tool per repo upload strategy.
 # TODO: Use git commit hash and origin to generated commit message.
-@click.command("shed_repo_create")
+@click.command("shed_create")
 @options.optional_project_arg(exists=True)
 @options.shed_owner_option()
 @options.shed_name_option()

--- a/tests/test_shed.py
+++ b/tests/test_shed.py
@@ -42,7 +42,7 @@ class ShedTestCase(CliTestCase):
             )
             open(".shed.yml", "w").write(shed_yml_contents)
             init_cmd = [
-                "shed_repo_create",
+                "shed_create",
                 "--shed_key", shed_api_key,
                 "--shed_target", shed_url
             ]


### PR DESCRIPTION
Repo breaks pattern or other shed commands - shed_diff is a repo diff but is not called shed_repo_diff. Same applies to shed_upload and shed_download.

Ping @erasche  - any objections to me making this modification to your command?