### PR TITLE
Add code of conduct for the project.

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,34 @@
+Contributor Code of Conduct
+===========================
+
+As contributors and maintainers of this project, we pledge to respect
+all people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches,
+and other activities.
+
+We are committed to making participation in this project a
+harassment-free experience for everyone, regardless of level of
+experience, gender, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of
+sexual language or imagery, derogatory comments or personal attacks,
+trolling, public or private harassment, insults, or other unprofessional
+conduct.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct. Project
+maintainers or contributors who do not follow the Code of Conduct may be
+removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by emailing `John Chilton <jmchilton@gmail.com>`__. To
+report an issue involving John Chilton please email both `Dave Clements 
+<mailto:clements@galaxyproject.org>`__ (the Outreach Coordinator for
+the Galaxy project) and `Anton Nekrutenko <mailto:anton@bx.psu.edu>`__
+(John Chilton's supervisor and a principle investigator for the Galaxy
+project).
+
+This Code of Conduct is adapted from the `khmer Contributor Code of Conduct
+<https://github.com/ged-lab/khmer/blob/master/CODE_OF_CONDUCT.rst>`__.

--- a/docs/conduct.rst
+++ b/docs/conduct.rst
@@ -1,0 +1,1 @@
+.. include:: ../CODE_OF_CONDUCT.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents:
    appliance
    writing
    commands
+   conduct
    contributing
    developing
    history


### PR DESCRIPTION
Inspired (entirely stolen) from khmer (https://github.com/ged-lab/khmer/blob/master/CODE_OF_CONDUCT.rst). What I like about the khmer code of conduct that is missing from a lot of code of conduct documents (including the http://contributor-covenant.org/ template khmer's is based upon) is specific recourse actions are listed in the document itself.