### PR TITLE
* Edited NO_TEST_DATA_MESSAGE to refer to --test_data, not --test-data

### DIFF
--- a/planemo/galaxy_config.py
+++ b/planemo/galaxy_config.py
@@ -16,7 +16,7 @@ from planemo.io import shell
 
 NO_TEST_DATA_MESSAGE = (
     "planemo couldn't find a target test-data directory, you should likely "
-    "create a test-data directory or pass an explicit path using --test-data."
+    "create a test-data directory or pass an explicit path using --test_data."
 )
 
 WEB_SERVER_CONFIG_TEMPLATE = """


### PR DESCRIPTION
0.3.0 (2015-02-13) changed --test-data to --test_data, but the NO_TEST_DATA_MESSAGE was referring to --test-data.

The code still looks for a default directory called test-data though. Perhaps this should be changed to test_data or it should look for both test-data and test_data?