### PR TITLE
More linting configurablity.

### DIFF
--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -13,12 +13,13 @@ from planemo.tool_lint import lint_tools_on_path
 @options.optional_tools_arg()
 @options.report_level_option()
 @options.fail_level_option()
+@options.skip_option()
 @options.lint_xsd_option()
 @pass_context
 def cli(ctx, path, **kwds):
     """Check specified tool(s) for common errors and adherence to best
     practices.
     """
-    lint_args = build_lint_args(**kwds)
+    lint_args = build_lint_args(ctx, **kwds)
     exit = lint_tools_on_path(ctx, path, lint_args)
     sys.exit(exit)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -278,6 +278,17 @@ def report_level_option():
     )
 
 
+def skip_option():
+    return click.option(
+        "-s",
+        "--skip",
+        default=None,
+        help=("Comma-separated list of lint tests to skip (e.g send ."
+              "--skip 'citations,xml_order' to skip linting of citations "
+              "and best-practice XML ordering.")
+    )
+
+
 def fail_level_option():
     return click.option(
         '--fail_level',

--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -39,7 +39,7 @@ VALID_REPOSITORY_TYPES = [
 
 def lint_repository(ctx, path, **kwds):
     info("Linting repository %s" % path)
-    lint_args = build_lint_args(**kwds)
+    lint_args = build_lint_args(ctx, **kwds)
     lint_ctx = LintContext(lint_args["level"])
     lint_ctx.lint(
         "tool_dependencies",

--- a/planemo/tool_lint.py
+++ b/planemo/tool_lint.py
@@ -38,13 +38,21 @@ def yield_tool_xmls(ctx, path):
         yield (tool_path, tool_xml)
 
 
-def build_lint_args(**kwds):
+def build_lint_args(ctx, **kwds):
     report_level = kwds.get("report_level", "all")
     fail_level = kwds.get("fail_level", "warn")
+    skip = kwds.get("skip", None)
+    if skip is None:
+        skip = ctx.global_config.get("lint_skip", "")
+        if isinstance(skip, list):
+            skip = ",".join(skip)
+
+    skip_types = [s.strip() for s in skip.split(",")]
     lint_args = dict(
         level=report_level,
         fail_level=fail_level,
-        extra_modules=_lint_extra_modules(**kwds)
+        extra_modules=_lint_extra_modules(**kwds),
+        skip_types=skip_types,
     )
     return lint_args
 

--- a/planemo_ext/galaxy/tools/lint.py
+++ b/planemo_ext/galaxy/tools/lint.py
@@ -7,8 +7,8 @@ LEVEL_WARN = "warn"
 LEVEL_ERROR = "error"
 
 
-def lint_xml(tool_xml, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[]):
-    lint_context = LintContext(level=level)
+def lint_xml(tool_xml, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[], skip_types=[]):
+    lint_context = LintContext(level=level, skip_types=skip_types)
     lint_xml_with(lint_context, tool_xml, extra_modules)
     return not lint_context.failed(fail_level)
 
@@ -25,13 +25,16 @@ def lint_xml_with(lint_context, tool_xml, extra_modules=[]):
 
 class LintContext(object):
 
-    def __init__(self, level):
+    def __init__(self, level, skip_types=[]):
+        self.skip_types = skip_types
         self.level = level
         self.found_errors = False
         self.found_warns = False
 
     def lint(self, name, lint_func, lint_target):
-        name = name.replace("tsts", "tests")
+        name = name.replace("tsts", "tests")[len("lint_"):]
+        if name in self.skip_types:
+            return
         self.printed_linter_info = False
         self.valid_messages = []
         self.info_messages = []
@@ -42,7 +45,6 @@ class LintContext(object):
         if self.error_messages:
             status = "FAIL"
         elif self.warn_messages:
-
             status = "WARNING"
         else:
             status = "CHECK"

--- a/tests/data/tools/fail_citation.xml
+++ b/tests/data/tools/fail_citation.xml
@@ -1,0 +1,26 @@
+<tool id="copy" name="Copy Dataset" version="1.0">
+    <description>copies a dataset</description>
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input1" type="data" format="txt" label="Concatenate Dataset"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="1">
+            <param name="input1" value="1.bed"/>
+            <assert_stdout>
+                <has_line line="Indexed 0 sequences" />
+            </assert_stdout>
+            <assert_stderr>
+                <has_line line="Identifier 'gi|16127999|ref|NP_414546.1|' not found in sequence file" />
+            </assert_stderr>
+      </test>
+    </tests>
+    <help>
+        Some Awesome Help!
+    </help>
+</tool>

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,3 +1,4 @@
+import os
 import glob
 
 from .test_utils import CliTestCase
@@ -17,3 +18,15 @@ class LintTestCase(CliTestCase):
         for fail_tool in fail_tools:
             lint_cmd = ["lint", fail_tool]
             self._check_exit_code(lint_cmd, exit_code=1)
+
+    def test_skips(self):
+        fail_citation = os.path.join(TEST_TOOLS_DIR, "fail_citation.xml")
+        lint_cmd = ["lint", fail_citation]
+        self._check_exit_code(lint_cmd, exit_code=1)
+
+        lint_cmd = ["lint", "--skip", "citations", fail_citation]
+        self._check_exit_code(lint_cmd, exit_code=0)
+
+        # Check string splitting and stuff.
+        lint_cmd = ["lint", "--skip", "xml_order, citations", fail_citation]
+        self._check_exit_code(lint_cmd, exit_code=0)


### PR DESCRIPTION
Add ``--skip`` argument to ``lint`` and ``shed_lint`` to pass in modules to skip while linting - I think the common ones are going to be ``citations`` and ``xml_order`` - so that would be ``--skip 'citations,xml_order'`` for instance. (TODO: Probably worth still catching unknown top-level tags even if xml_order is disabled - so those should be split out I guess).

A default value for skip can be specified on a per-user basis by specifying a list of items in ``~/.planemo.yml`` under a ``lint_skip`` key.

This commit also improves the display of linting so the short name is what is display - e.g. user will now see "Applying linter citations" and not "Appling linter lint_citations".