### PR TITLE
Make config_path default to None.

### DIFF
--- a/planemo/config.py
+++ b/planemo/config.py
@@ -5,7 +5,7 @@ DEFAULT_CONFIG = {
 }
 
 
-def global_config_path(config_path):
+def global_config_path(config_path=None):
     if not config_path:
         config_path = os.environ.get(
             "PLANEMO_GLOBAL_CONFIG_PATH",


### PR DESCRIPTION
This should fix the following error:

```
bag@bag ~/temp % planemo config_init       
/home/bag/temp
Traceback (most recent call last):
  File "/home/bag/.local/bin//planemo", line 11, in <module>
    sys.exit(planemo())
  File "/home/bag/.local/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/bag/.local/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/bag/.local/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/bag/.local/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/bag/.local/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/bag/.local/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/bag/.local/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/bag/.local/lib/python2.7/site-packages/planemo/commands/cmd_config_init.py", line 54, in cli
    config_path = config.global_config_path()
TypeError: global_config_path() takes exactly 1 argument (0 given)

```