### PR TITLE
Warn on empty citations block.

### DIFF
--- a/planemo_ext/galaxy/tools/linters/citations.py
+++ b/planemo_ext/galaxy/tools/linters/citations.py
@@ -24,4 +24,5 @@ def lint_citations(tool_xml, lint_ctx):
 
     if valid_citations > 0:
         lint_ctx.valid("Found %d likely valid citations.", valid_citations)
-
+    else:
+        lint_ctx.warn("No valid citation elements found in <citations> block.")


### PR DESCRIPTION
See https://github.com/galaxyproject/tools-iuc/commit/9107450a9a95db3dd7d99999d6cc2f745f759771#commitcomment-10962483.

I think there needs to be a way to tell planemo that it is fine that tool doesn't use citations - e.g.

```
<!-- NOLINT:CITATIONS - common unix utility doesn't need citation. -->
<!-- NOLINT:CITATIONS - I wrote it and I don't want people to know -->
```

so if people would instead to prefer to wait for that to be availabe before this gets merged that would be acceptable.