### PR TITLE
Not all exceptions will have a .read() method.

### DIFF
--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -96,16 +96,20 @@ def __handle_upload(ctx, realized_repository, **kwds):
     try:
         tsi.repositories.update_repository(repo_id, tar_path, **update_kwds)
     except Exception as e:
-        exception_content = e.read()
-        try:
-            # Galaxy passes nice JSON messages as their errors, which bioblend
-            # blindly returns. Attempt to parse those.
-            upstream_error = json.loads(exception_content)
-            error(upstream_error['err_msg'])
-        except Exception as e2:
+        if hasattr(e, "read"):
+            exception_content = e.read()
+            try:
+                # Galaxy passes nice JSON messages as their errors, which bioblend
+                # blindly returns. Attempt to parse those.
+                upstream_error = json.loads(exception_content)
+                error(upstream_error['err_msg'])
+            except Exception as e2:
+                error("Could not update %s" % realized_repository.name)
+                error(exception_content)
+                error(e2.read())
+        else:
             error("Could not update %s" % realized_repository.name)
-            error(exception_content)
-            error(e2.read())
+            error(str(e))
         return -1
     info("Repository %s updated successfully." % realized_repository.name)
     return 0


### PR DESCRIPTION
Intended to partly address GitHub issue #116 (but the exception handling is still nasty). Before this change,

```
$ planemo shed_upload --shed_target testtoolshed --message "v0.0.8a again (testing uploads via planemo with API key)" --tar ~/toolshed_archives/venn_list_v0.0.8a.tar.gz ~/repositories/pico_galaxy/tools/venn_list
Traceback (most recent call last):
  File "/mnt/galaxy/repositories/planemo/.venv/bin/planemo", line 9, in <module>
    load_entry_point('planemo==0.9.0.dev0', 'console_scripts', 'planemo')()
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/click-4.0-py2.6.egg/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/planemo-0.9.0.dev0-py2.6.egg/planemo/commands/cmd_shed_upload.py", line 63, in cli
    exit_code = shed.for_each_repository(upload, path, **kwds)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/planemo-0.9.0.dev0-py2.6.egg/planemo/shed.py", line 422, in for_each_repository
    function(realized_repository)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/planemo-0.9.0.dev0-py2.6.egg/planemo/commands/cmd_shed_upload.py", line 61, in upload
    return __handle_upload(ctx, realized_repository, **kwds)
  File "/mnt/galaxy/repositories/planemo/.venv/lib/python2.6/site-packages/planemo-0.9.0.dev0-py2.6.egg/planemo/commands/cmd_shed_upload.py", line 99, in __handle_upload
    exception_content = e.read()
AttributeError: 'ConnectionError' object has no attribute 'read'
```

With this fix:

```
$ planemo shed_upload --shed_target testtoolshed --message "v0.0.8a again (testing uploads via planemo with API key)" --tar ~/toolshed_archives/venn_list_v0.0.8a.tar.gz ~/repositories/pico_galaxy/tools/venn_list
Could not update venn_list
Unexpected response from galaxy: 400: {"content_alert": "", "err_msg": "No changes to repository."}
```

Clearly still room for improvement - this looks like JSON so we ought to be able to pull out the error message as the older error handling code tries to do.