### PR TITLE
Sort planemo shed_upload tar-ball by filename

### DIFF
--- a/planemo/shed.py
+++ b/planemo/shed.py
@@ -397,18 +397,21 @@ def build_tarball(realized_path, **kwds):
     # It should be pushed up a level into the thing that is uploading tar
     # balls to iterate over them - but placing it here for now because
     # it address some bugs.
+
+    # Simplest solution to sorting the files is to use a list,
+    files = []
+    for dirpath, dirnames, filenames in os.walk(realized_path):
+        for f in filenames:
+            files.append(os.path.join(dirpath, f))
+    files.sort()
+
     fd, temp_path = mkstemp()
     try:
         tar = tarfile.open(temp_path, "w:gz", dereference=True)
         try:
-            # File system order essentially random, so at least sort
-            # top level entries by name:
-            for name in sorted(os.listdir(realized_path)):
-                tar.add(
-                    os.path.join(realized_path, name),
-                    arcname=name,
-                    recursive=True,
-                )
+            for raw in files:
+                name = os.path.relpath(raw, realized_path)
+                tar.add(os.path.join(realized_path, name), arcname=name)
         finally:
             tar.close()
     finally:


### PR DESCRIPTION
This would resolve issue #159 by the simple expedient of building a list of all the files in the staging directory, and using the sorted list to build the tar-ball.

Note this does not explicitly handle directories, thus any empty directory would be missing from the tar-ball. Since the Tool Shed uses hg internally this does not matter (same for git too).

e.g. silly test case showing the desired sorting:

```
$ planemo shed_upload --tar_only  ~/repositories/pico_galaxy/tools/venn_list && tar -tzf shed_upload.tar.gz
cp /tmp/tmpYAjHCW shed_upload.tar.gz
aaa
test-data/magic.pdf
test-data/rhodopsin_proteins.fasta
test-data/venn_list.tabular
test-dataAAA
tools/venn_list/README.rst
tools/venn_list/tool_dependencies.xml
tools/venn_list/venn_list.py
tools/venn_list/venn_list.xml
toolsAAA
zzz
```