### PR TITLE
Smart shed_diff.

### DIFF
--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -29,6 +29,12 @@ from planemo import shed
          " this to testtoolshed.",
     default=None,
 )
+@click.option(
+    "--raw",
+    is_flag=True,
+    help="Do not attempt smart diff of XML to filter out attributes "
+         "populated by the Tool Shed.",
+)
 @options.recursive_shed_option()
 @pass_context
 def cli(ctx, path, **kwds):
@@ -53,7 +59,7 @@ def cli(ctx, path, **kwds):
     def diff(realized_repository):
         working = tempfile.mkdtemp(prefix="tool_shed_diff_")
         try:
-            shed.diff_in(ctx, working, realized_repository, **kwds)
+            return shed.diff_in(ctx, working, realized_repository, **kwds)
         finally:
             shutil.rmtree(working)
 

--- a/planemo/shed/diff.py
+++ b/planemo/shed/diff.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+
+import os
+import sys
+from xml.etree import ElementTree
+
+from planemo.xml import diff
+
+
+def diff_and_remove(working, label_a, label_b, f):
+    a_deps = os.path.join(working, label_a, "tool_dependencies.xml")
+    b_deps = os.path.join(working, label_b, "tool_dependencies.xml")
+    a_repos = os.path.join(working, label_a, "repository_dependencies.xml")
+    b_repos = os.path.join(working, label_b, "repository_dependencies.xml")
+
+    deps_diff = 0
+    if os.path.exists(a_deps) and os.path.exists(b_deps):
+        deps_diff = _shed_diff(a_deps, b_deps, f)
+        os.remove(a_deps)
+        os.remove(b_deps)
+
+    repos_diff = 0
+    if os.path.exists(a_repos) and os.path.exists(b_repos):
+        repos_diff = _shed_diff(a_repos, b_repos, f)
+        os.remove(a_repos)
+        os.remove(b_repos)
+
+    return deps_diff and repos_diff
+
+
+def _shed_diff(file_a, file_b, f=sys.stdout):
+    xml_a = ElementTree.parse(file_a).getroot()
+    xml_b = ElementTree.parse(file_b).getroot()
+    _strip_shed_attributes(xml_a)
+    _strip_shed_attributes(xml_b)
+    return diff.diff(xml_a, xml_b, reporter=f.write)
+
+
+def _strip_shed_attributes(xml_element):
+    if xml_element.tag == "repository":
+        _remove_attribs(xml_element)
+    children = xml_element.getchildren()
+    if len(children) > 0:
+        for child in children:
+            _strip_shed_attributes(child)
+
+
+def _remove_attribs(xml_element):
+    for attrib in ["changeset_revision", "toolshed"]:
+        if attrib in xml_element.attrib:
+            del xml_element.attrib[attrib]

--- a/planemo/xml/diff.py
+++ b/planemo/xml/diff.py
@@ -1,0 +1,56 @@
+
+def diff(x1, x2, reporter=None):
+    return 0 if xml_compare(x1, x2, reporter) else 1
+
+
+# From
+# bitbucket.org/ianb/formencode/src/tip/formencode/doctest_xml_compare.py
+# with (PSF license)
+def xml_compare(x1, x2, reporter=None):
+    if reporter is None:
+        def report(x):
+            return None
+
+    if x1.tag != x2.tag:
+        reporter('Tags do not match: %s and %s' % (x1.tag, x2.tag))
+        return False
+    for name, value in x1.attrib.items():
+        if x2.attrib.get(name) != value:
+            reporter('Attributes do not match: %s=%r, %s=%r'
+                     % (name, value, name, x2.attrib.get(name)))
+            return False
+    for name in x2.attrib.keys():
+        if name not in x1.attrib:
+            reporter('x2 has an attribute x1 is missing: %s'
+                     % name)
+            return False
+    if not text_compare(x1.text, x2.text):
+        reporter('text: %r != %r' % (x1.text, x2.text))
+        return False
+    if not text_compare(x1.tail, x2.tail):
+        reporter('tail: %r != %r' % (x1.tail, x2.tail))
+        return False
+    return _compare_children(x1, x2, reporter)
+
+
+def _compare_children(x1, x2, reporter):
+    cl1 = x1.getchildren()
+    cl2 = x2.getchildren()
+    if len(cl1) != len(cl2):
+        reporter('children length differs, %i != %i'
+                 % (len(cl1), len(cl2)))
+        return False
+    i = 0
+    for c1, c2 in zip(cl1, cl2):
+        i += 1
+        if not xml_compare(c1, c2, reporter=reporter):
+            reporter('children %i do not match: %s'
+                     % (i, c1.tag))
+            return False
+    return True
+
+
+def text_compare(t1, t2):
+    if not t1 and not t2:
+        return True
+    return (t1 or '').strip() == (t2 or '').strip()

--- a/planemo/xml/diff.py
+++ b/planemo/xml/diff.py
@@ -8,7 +8,7 @@ def diff(x1, x2, reporter=None):
 # with (PSF license)
 def xml_compare(x1, x2, reporter=None):
     if reporter is None:
-        def report(x):
+        def reporter(x):
             return None
 
     if x1.tag != x2.tag:

--- a/tests/data/repos/suite_auto/.shed.yml
+++ b/tests/data/repos/suite_auto/.shed.yml
@@ -1,4 +1,4 @@
-owner: devteam
+owner: iuc
 suite:
   name: suite_1
   description: "A suite of Galaxy tools designed to work with version 1.2 of the SAMtools package."

--- a/tests/repository_dependencies.xml
+++ b/tests/repository_dependencies.xml
@@ -6,9 +6,8 @@
     <repository name="samtools_bedcov" owner="devteam" />
     <repository name="samtools_calmd" owner="devteam" />
     <repository name="samtools_flagstat" owner="devteam" />
-    <repository name="samtools_idxstat" owner="devteam" />
+    <repository name="samtools_idxstats" owner="devteam" />
     <repository name="samtools_mpileup" owner="devteam" />
-    <repository name="samtools_phase" owner="devteam" />
     <repository name="samtools_reheader" owner="devteam" />
     <repository name="samtools_rmdup" owner="devteam" />
     <repository name="samtools_slice_bam" owner="devteam" />

--- a/tests/repository_dependencies_shed.xml
+++ b/tests/repository_dependencies_shed.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<repositories description="A suite of Galaxy tools designed to work with version 1.2 of the SAMtools package.">
+    <repository changeset_revision="cf875cbe2df4" name="data_manager_sam_fasta_index_builder" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="af7c50162f0b" name="bam_to_sam" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="d04d9f1c6791" name="sam_to_bam" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="8c3472790020" name="samtools_bedcov" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="1ebb4ecdc1ef" name="samtools_calmd" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="0072bf593791" name="samtools_flagstat" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="87398ae795c7" name="samtools_idxstats" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="c6fdfe3331d6" name="samtools_mpileup" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="020e144b5f78" name="samtools_reheader" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="3735f950b2f5" name="samtools_rmdup" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="2b474ebbfc7d" name="samtools_slice_bam" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="a430da4f04cd" name="samtools_sort" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="57f3e32f809d" name="samtools_split" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+    <repository changeset_revision="0d71d9467847" name="samtools_stats" owner="devteam" toolshed="https://toolshed.g2.bx.psu.edu" />
+</repositories>

--- a/tests/test_shed_diff.py
+++ b/tests/test_shed_diff.py
@@ -23,11 +23,38 @@ class ShedUploadTestCase(CliShedTestCase):
             with open(os.path.join(f, "related_file"), "w") as r_f:
                 r_f.write("A related non-tool file (modified).\n")
 
-            diff_command = ["shed_diff", "-o", "diff"]
+            self._check_diff(f, True)
+            self._check_diff(f, False)
+
+    def test_shed_diff_raw(self):
+        with self._isolate_repo("suite_auto"):
+            upload_command = [
+                "shed_upload", "--force_repository_creation",
+            ]
+            upload_command.extend(self._shed_args())
+            self._check_exit_code(upload_command)
+
+            diff_command = [
+                "shed_diff", "-o", "diff"
+            ]
+            diff_command.append("--raw")
             diff_command.extend(self._shed_args(read_only=True))
-            self._check_exit_code(diff_command)
-            diff_path = os.path.join(f, "diff")
-            with open(diff_path, "r") as diff_f:
-                diff = diff_f.read()
-            for diff_line in DIFF_LINES:
-                assert diff_line in diff
+            self._check_exit_code(diff_command, exit_code=-1)
+
+            diff_command = [
+                "shed_diff", "-o", "diff"
+            ]
+            diff_command.extend(self._shed_args(read_only=True))
+            self._check_exit_code(diff_command, exit_code=0)
+
+    def _check_diff(self, f, raw):
+        diff_command = ["shed_diff", "-o", "diff"]
+        if raw:
+            diff_command.append("--raw")
+        diff_command.extend(self._shed_args(read_only=True))
+        self._check_exit_code(diff_command, exit_code=-1)
+        diff_path = os.path.join(f, "diff")
+        with open(diff_path, "r") as diff_f:
+            diff = diff_f.read()
+        for diff_line in DIFF_LINES:
+            assert diff_line in diff

--- a/tests/test_shed_diff_xml.py
+++ b/tests/test_shed_diff_xml.py
@@ -1,0 +1,10 @@
+import os
+
+from .test_utils import TEST_DIR
+from planemo.shed import diff
+
+
+def test_compare():
+    local = os.path.join(TEST_DIR, "repository_dependencies.xml")
+    shed = os.path.join(TEST_DIR, "repository_dependencies_shed.xml")
+    assert not diff._shed_diff(local, shed)

--- a/tests/test_shed_upload.py
+++ b/tests/test_shed_upload.py
@@ -77,7 +77,7 @@ class ShedUploadTestCase(CliShedTestCase):
             upload_command = ["shed_upload", "--tar_only"]
             upload_command.extend(self._shed_args())
             self._check_exit_code(upload_command)
-            target = self._untar(f, "shed_upload_suite_1.tar.gz")
+            target = self._untar(f, "shed_upload.tar.gz")
             # Only one file was in archive
             assert_exists(join(target, "repository_dependencies.xml"))
 

--- a/tests/test_xml_diff.py
+++ b/tests/test_xml_diff.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+from .test_utils import TEST_DIR
+from xml.etree import ElementTree
+
+
+from planemo.xml.diff import diff
+
+
+def test_diff():
+    # Check with and without reporter.
+    _check(sys.stdout.write)
+    _check(None)
+
+
+def _check(reporter):
+    assert not diff(ElementTree.fromstring("<moo>cow</moo>"),
+                    ElementTree.fromstring("<moo>cow</moo>"),
+                    reporter)
+    assert diff(ElementTree.fromstring("<moo>cow</moo>"),
+                ElementTree.fromstring("<moo>cow1</moo>"),
+                reporter)
+    assert diff(ElementTree.fromstring("<moo><c/><c1/></moo>"),
+                ElementTree.fromstring("<moo><c/></moo>"),
+                reporter)
+    assert diff(ElementTree.fromstring("<moo><c/></moo>"),
+                ElementTree.fromstring("<moo><c/>a</moo>"),
+                reporter)
+    assert diff(ElementTree.fromstring("<moo>*</moo>"),
+                ElementTree.fromstring("<moo>*a</moo>"),
+                reporter)
+    assert not diff(_root("repository_dependencies.xml"),
+                    _root("repository_dependencies.xml"),
+                    reporter)
+    assert not diff(_root("repository_dependencies_shed.xml"),
+                    _root("repository_dependencies_shed.xml"),
+                    reporter)
+    assert diff(_root("repository_dependencies.xml"),
+                _root("repository_dependencies_shed.xml"),
+                reporter)
+    assert diff(_root("repository_dependencies.xml"),
+                _root("tool_dependencies_good_1.xml"),
+                reporter)
+    assert diff(_root("tool_dependencies_good_1.xml"),
+                _root("tool_dependencies_good_2.xml"),
+                reporter)
+
+
+def _root(*args):
+    return ElementTree.parse(os.path.join(TEST_DIR, *args)).getroot()


### PR DESCRIPTION
 - Fix ``shed_diff`` so its exit code actually is non-zero if there are differences.
 - By default - don't report differences for tool shed populates attributes (``toolshed``, ``changeset_revision``). This can be disabled with ``--raw``.
 - Tests for ensure ``--raw`` and smart differencing are working and exit codes are fixed.
 - Update shed test webapp to inject the tool shed populated fields into respective arguments.

Implements #141.