### PR TITLE
Allow the shed_ operations to consume git URLs instead of paths.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   - TOX_ENV=py27
 
 install:
+  # Setup git to allow git operations.
+  - git config --global user.name "Travis Test User"
+  - git config --global user.email "planemo_test@galaxyproject.org"
   - pip install tox coveralls
 
 script: tox -e $TOX_ENV

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -19,6 +19,7 @@ from planemo.io import info
 @options.shed_email_option()
 @options.shed_password_option()
 @options.recursive_shed_option()
+@options.shed_fail_fast_option()
 @pass_context
 def cli(ctx, path, **kwds):
     """Create a repository in a Galaxy Tool Shed from a ``.shed.yml`` file.

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -11,7 +11,7 @@ from planemo.io import info
 
 
 @click.command("shed_create")
-@options.optional_project_arg(exists=True)
+@options.shed_project_arg()
 @options.shed_owner_option()
 @options.shed_name_option()
 @options.shed_target_option()

--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -12,7 +12,7 @@ from planemo import shed
 
 
 @click.command("shed_diff")
-@options.optional_project_arg(exists=True)
+@options.shed_project_arg()
 @options.shed_owner_option()
 @options.shed_name_option()
 @options.shed_target_option()

--- a/planemo/commands/cmd_shed_download.py
+++ b/planemo/commands/cmd_shed_download.py
@@ -16,7 +16,7 @@ target_path = click.Path(
 
 
 @click.command("shed_download")
-@options.optional_project_arg(exists=True)
+@options.shed_project_arg()
 @click.option(
     '--destination',
     default="shed_download.tar.gz",

--- a/planemo/commands/cmd_shed_lint.py
+++ b/planemo/commands/cmd_shed_lint.py
@@ -8,7 +8,7 @@ from planemo import shed_lint
 
 
 @click.command('shed_lint')
-@options.optional_project_arg(exists=True)
+@options.shed_project_arg()
 @options.report_level_option()
 @options.fail_level_option()
 @options.click.option(

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -18,7 +18,7 @@ tar_path = click.Path(
 
 
 @click.command("shed_upload")
-@options.optional_project_arg(exists=True)
+@options.shed_project_arg()
 @click.option(
     '--message',
     help="Commit message for tool shed upload."

--- a/planemo/galaxy_config.py
+++ b/planemo/galaxy_config.py
@@ -15,6 +15,7 @@ import click
 from planemo import galaxy_run
 from planemo.io import warn
 from planemo.io import shell
+from planemo import git
 
 NO_TEST_DATA_MESSAGE = (
     "planemo couldn't find a target test-data directory, you should likely "
@@ -331,7 +332,7 @@ def _install_galaxy_via_git(ctx, config_directory, kwds):
     _ensure_galaxy_repository_available(ctx)
     workspace = ctx.workspace
     gx_repo = os.path.join(workspace, "gx_repo")
-    command = "git clone %s galaxy-dev" % (gx_repo)
+    command = git.command_clone(ctx, gx_repo, "galaxy-dev")
     _install_with_command(config_directory, command)
 
 
@@ -354,7 +355,8 @@ def _ensure_galaxy_repository_available(ctx):
         shell("git --git-dir %s fetch >/dev/null 2>&1" % gx_repo)
     else:
         remote_repo = "https://github.com/galaxyproject/galaxy"
-        shell("git clone --bare %s %s" % (remote_repo, gx_repo))
+        command = git.command_clone(ctx, remote_repo, gx_repo, bare=True)
+        shell(command)
 
 
 def _build_env_for_galaxy(properties, template_args):

--- a/planemo/git.py
+++ b/planemo/git.py
@@ -1,0 +1,18 @@
+""" Utilities for interacting with git using planemo abstractions.
+"""
+
+from planemo import io
+
+
+def command_clone(ctx, src, dest, bare=False):
+    """ Take in ctx to allow more configurability down the road.
+    """
+    bare_arg = ""
+    if bare:
+        bare_arg = "--bare "
+    return "git clone%s '%s' '%s'" % (bare_arg, src, dest)
+
+
+def clone(*args, **kwds):
+    command = command_clone(*args, **kwds)
+    return io.shell(command)

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -63,7 +63,7 @@ def untar_to(url, path, tar_args):
         shell("%s > '%s'" % (download_cmd, path))
 
 
-@contextlib.contextmanager()
+@contextlib.contextmanager
 def temp_directory():
     temp_dir = tempfile.mkdtemp()
     try:

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
+import contextlib
 import os
+import shutil
 import sys
+import tempfile
 
 import click
 from galaxy.tools.deps import commands
@@ -58,3 +61,12 @@ def untar_to(url, path, tar_args):
         shell("%s | %s" % (download_cmd, untar_cmd))
     else:
         shell("%s > '%s'" % (download_cmd, path))
+
+
+@contextlib.contextmanager()
+def temp_directory():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -165,6 +165,34 @@ def optional_tools_arg(multiple=False):
     )
 
 
+class ProjectOrRepositry(click.Path):
+
+    def __init__(self, **kwds):
+        super(ProjectOrRepositry, self).__init__(**kwds)
+
+    def convert(self, value, param, ctx):
+        if value and value.startswith("git:") or value.startswith("git+"):
+            return value
+        else:
+            return super(ProjectOrRepositry, self).convert(value, param, ctx)
+
+
+def shed_project_arg():
+    arg_type = ProjectOrRepositry(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
+    )
+    return click.argument(
+        'path',
+        metavar="PROJECT",
+        default=".",
+        type=arg_type,
+    )
+
+
 def optional_project_arg(exists=True):
     arg_type = click.Path(
         exists=exists,

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -482,7 +482,7 @@ def build_tarball(realized_path, **kwds):
 
 def for_each_repository(function, path, **kwds):
     ret_codes = []
-    effective_repositories = realize_effective_repositories(path, **kwds)
+    effective_repositories = _realize_effective_repositories(path, **kwds)
     try:
         for realized_repository in effective_repositories:
             ret_codes.append(
@@ -519,7 +519,7 @@ def _tool_shed_url(kwds):
     return url
 
 
-def realize_effective_repositories(path, **kwds):
+def _realize_effective_repositories(path, **kwds):
     """ Expands folders in a source code repository into tool shed
     repositories.
 

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -459,12 +459,6 @@ def build_tarball(realized_path, **kwds):
     """Build a tool-shed tar ball for the specified path, caller is
     responsible for deleting this file.
     """
-
-    # Not really how realize_effective_repositories was meant to be used.
-    # It should be pushed up a level into the thing that is uploading tar
-    # balls to iterate over them - but placing it here for now because
-    # it address some bugs.
-
     # Simplest solution to sorting the files is to use a list,
     files = []
     for dirpath, dirnames, filenames in os.walk(realized_path):


### PR DESCRIPTION
create, upload, download, diff, and lint projects directly from Github - closes #169.

Inputs starting with ``git+`` (e.g. git+/path/to/repo.git) with will have the ``git+`` stripped and passed directly to the ``git`` command-line. Alternatively URLs starting with `git:` will be passed as is to the ``git`` command-line. This seems to roughly correspond to ``pip``.
