### PR TITLE
Allow include source to be a list of filenames/patterns.

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -803,6 +803,8 @@ class RawRepositoryDirectory(object):
         realized_files = []
         missing = []
         for include_info in config["include"]:
+            if not isinstance(include_info, dict):
+                include_info = {"source": include_info}
             source_list = include_info.get("source")
             if not isinstance(source_list, list):
                 source_list = [source_list]

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -802,12 +802,20 @@ class RawRepositoryDirectory(object):
         config = self._realize_config(name)
         realized_files = []
         missing = []
-        for include in config["include"]:
-            included = RealizedFile.realized_files_for(self.path, include)
-            if not included:
-                missing.append(include)
-            else:
-                realized_files.extend(included)
+        for include_info in config["include"]:
+            source_list = include_info.get("source")
+            if not isinstance(source_list, list):
+                source_list = [source_list]
+            # Preprocess any entries with a source list into copies
+            # with a single source entry:
+            for source in source_list:
+                include = include_info.copy()
+                include["source"] = source
+                included = RealizedFile.realized_files_for(self.path, include)
+                if not included:
+                    missing.append(include)
+                else:
+                    realized_files.extend(included)
         return RealizedFiles(realized_files, missing)
 
     def _realize_config(self, name):
@@ -872,6 +880,10 @@ class RealizedFile(object):
         if os.path.islink(source_path):
             source_path = os.path.realpath(source_path)
         relative_dest = self.relative_dest
+        if relative_dest == ".":
+            # The target folder likely exists,
+            # but would still want to make symlink...
+            relative_dest = os.path.split(source_path)[1]
         target_path = os.path.join(directory, relative_dest)
         target_exists = os.path.exists(target_path)
         if not target_exists:


### PR DESCRIPTION
This allows nesting within the include setting of ``.shed.yml`` for example if you have a batch of files with the same ``strip_components`` setting.

See GitHub issue #180, and #160 which would no longer be needed for my use cases https://github.com/peterjc/galaxy_blast and https://github.com/peterjc/pico_galaxy ).

The ``relative_dest == "."`` check was needed for this example ``.shed.yml`` to work, otherwise the four files under ``tools/venn_list/*`` were ignored:

```
$ tail  ~/repositories/pico_galaxy/tools/venn_list/.shed.yml
include:
- strip_components: 2
  source:
  - ../../tools/venn_list/README.rst
  - ../../tools/venn_list/venn_list.py
  - ../../tools/venn_list/venn_list.xml
  - ../../tools/venn_list/tool_dependencies.xml
  - ../../test-data/magic.pdf
  - ../../test-data/venn_list.tabular
  - ../../test-data/rhodopsin_proteins.fasta
$ planemo shed_upload --tar_only  ~/repositories/pico_galaxy/tools/venn_list/ && tar -tzf shed_upload.tar.gz 
cp '/tmp/tmpkASHOo' 'shed_upload.tar.gz'
README.rst
test-data/magic.pdf
test-data/rhodopsin_proteins.fasta
test-data/venn_list.tabular
tool_dependencies.xml
venn_list.py
venn_list.xml
```

As per the suggestion on #180, this approach leaves the missing include detection added in #158 working:

```
$ tail  ~/repositories/pico_galaxy/tools/venn_list/.shed.yml
include:
- strip_components: 2
  source:
  - ../../tools/venn_list/README.rst
  - ../../tools/venn_list/venn_list_with_typo.py
  - ../../tools/venn_list/venn_list.xml
  - ../../tools/venn_list/tool_dependencies.xml
  - ../../test-data/magic.pdf
  - ../../test-data/venn_list.tabular
  - ../../test-data/rhodopsin_proteins.fasta
(.venv)[galaxy@ppserver planemo]$ planemo shed_upload --tar_only  ~/repositories/pico_galaxy/tools/venn_list/ && tar -tzf shed_upload.tar.gz 
Failed to include files for [{'source': '../../tools/venn_list/venn_list_with_typo.py', 'strip_components': 2}]
Problem encountered executing action for one or more repositories.
```
