### PR TITLE
Avoid ambigous destination value in test case...

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -902,6 +902,7 @@ class RealizedFile(object):
         if not isinstance(include_info, dict):
             include_info = {"source": include_info}
         source = include_info.get("source")
+        abs_source = os.path.join(path, source)
         destination = include_info.get("destination", None)
         strip_components = include_info.get("strip_components", 0)
         if destination is None:
@@ -909,7 +910,11 @@ class RealizedFile(object):
             destination_specified = False
         else:
             destination_specified = True
-        abs_source = os.path.join(path, source)
+        if not destination.endswith("/"):
+            # Check if source using wildcards (directory gets implicit wildcard)
+            # Should we use a regular exoression to catch [A-Z] style patterns?
+            if "*" in source or "?" in source or os.path.isdir(abs_source):
+                raise ValueError("destination must be a directory (with trailing slash) if source is a folder or uses wildcards")
         dest_is_file = destination_specified and os.path.isfile(abs_source)
         realized_files = []
         for globbed_file in _glob(path, source):

--- a/tests/data/repos/multi_repos_flat_configured_complex/.shed.yml
+++ b/tests/data/repos/multi_repos_flat_configured_complex/.shed.yml
@@ -14,7 +14,7 @@ repositories:
         destination: CITATION.txt
       - source: ../shared_files/extra_test_data/**
         strip_components: 3  # drop "..", "shared_files", "extra_test_data" from source
-        destination: test-data
+        destination: test-data/
   cs-cat2:
     description: "The tool Cat 2 from the cat tool suite."
     include:


### PR DESCRIPTION
Suggestion: If the ``source`` has any wildcards (or is a folder with an implicit wildcard), then ``destination`` must be a directory given with trailing slash (otherwise error).

The include source of "../shared_files/extra_test_data/**" would only find "../shared_files/extra_test_data/extra_test_file.txt" which after strip_components 3 gives "extra_test_file.txt"

Question: did the ".shed.yml" destination of "test-data" mean call this file "test-data" [sic] or use "test-data/extra_test_file.txt" instead? Why?

What if the include source glob matches multiple files? Then might expect destination must be a folder - since alternative means trying to map multiple input files to one in the tar-ball/

Using destination "test-data/" seem unambiguous and preferable.

(I found this issue during re-factoring while working on #180)