### PR TITLE
Handle empty tar-balls gracefully on old Python

### DIFF
--- a/tests/test_shed_upload.py
+++ b/tests/test_shed_upload.py
@@ -309,7 +309,13 @@ class ShedUploadTestCase(CliShedTestCase):
         if exists(target):
             shutil.rmtree(target)
         os.makedirs(target)
-        tar = tarfile.open(path, "r:gz")
+        try:
+            tar = tarfile.open(path, "r:gz")
+        except tarfile.ReadError as e:
+            # Fixed in later version of Python, see
+            # http://bugs.python.org/issue6123
+            assert str(e) == "empty header", e
+            return target  # note contained no files!
         tar.extractall(path=target)
         tar.close()
         tar = tarfile.open(path, "r:gz")


### PR DESCRIPTION
This is a workaround for http://bugs.python.org/issue6123 where older versions of Python fail to handle an empty tar-ball.

(I found this during re-factoring where an error elsewhere in the shed_upload logic was resulting in empty tar-balls being generated)