### PR TITLE
Relax path checking for tool_dependencies.xml etc

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -837,15 +837,15 @@ class RawRepositoryDirectory(object):
     def _implicit_ignores(self, relative_path):
         # Filter out "unwanted files" :) like READMEs for special
         # repository types.
+        name = os.path.basename(relative_path)
         if self.type == REPO_TYPE_TOOL_DEP:
-            if relative_path != TOOL_DEPENDENCIES_CONFIG_NAME:
+            if name != TOOL_DEPENDENCIES_CONFIG_NAME:
                 return True
 
         if self.type == REPO_TYPE_SUITE:
-            if relative_path != REPO_DEPENDENCIES_CONFIG_NAME:
+            if name != REPO_DEPENDENCIES_CONFIG_NAME:
                 return True
 
-        name = os.path.basename(relative_path)
         if relative_path.startswith(".git"):
             return True
 


### PR DESCRIPTION
Solved problem I had on a branch with ``'./tool_dependencies.xml'`` being ignored for a tool package because it only allowed the exact match ``'tool_dependencies.xml'`` (likewise for tool suites).

On the other hand, with this change these special files don't have to be at the top level of the Tool Shed tar-ball any more. Is a sub-folder acceptable?