### PR TITLE
shed_upload include with strip_components and '..' in paths

### DIFF
--- a/tests/data/repos/up_root/.shed.yml
+++ b/tests/data/repos/up_root/.shed.yml
@@ -1,0 +1,18 @@
+name: up_root
+owner: iuc
+descrption: A dummy tool for Planemo include testing
+long_description: |
+  The purpose of this tool is to test advanced include settings
+  in the Planemo .shed.yml file which can be used to support a
+  development model where test files (etc) are kept in folders
+  above the tool folder itself.
+type: unrestricted
+remote_repository_url: "https://github.com/galaxyproject/planemo/tree/master/tests/data/repos/up_root"
+homepage_url: "http://planemo.readthedocs.org/en/latest/"
+include:
+- strip_components: 1
+  source:
+  - ../up_root/**
+  - ../up_root/cat.xml
+  - ../up_root/README.rst
+  - ../shared_files/extra_test_data/extra_test_file.txt

--- a/tests/data/repos/up_root/README.rst
+++ b/tests/data/repos/up_root/README.rst
@@ -1,0 +1,7 @@
+A dummy tool for Planemo include testing
+========================================
+
+The purpose of this tool is to test advanced include settings
+in the Planemo .shed.yml file which can be used to support a
+development model where test files (etc) are kept in folders
+abovethe tool folderitself.

--- a/tests/data/repos/up_root/cat.xml
+++ b/tests/data/repos/up_root/cat.xml
@@ -1,0 +1,23 @@
+<tool id="cat" name="Concatenate datasets (for test workflows)" version="1.0">
+    <description>tail-to-head</description>
+    <command>
+        cat $input1 #for $q in $queries# ${q.input2} #end for# > $out_file1
+    </command>
+    <inputs>
+        <param name="input1" type="data" label="Concatenate Dataset"/>
+        <repeat name="queries" title="Dataset">
+            <param name="input2" type="data" label="Select" />
+        </repeat>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="input" metadata_source="input1"/>
+    </outputs>
+    <tests>
+      <test>
+        <param name="input1" value="1.bed"/>
+        <output name="out_file1" file="1.bed"/>
+      </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/tests/test_shed_upload.py
+++ b/tests/test_shed_upload.py
@@ -249,6 +249,22 @@ class ShedUploadTestCase(CliShedTestCase):
                 assert 'owner="devteam" name="cat_legacy"' in repo_xml
                 assert 'owner="iuc" name="cs-cat2"' in repo_xml
 
+    def test_upload_with_double_dot(self):
+        with self._isolate() as f:
+            self._copy_repo("up_root/", join(f, "up_root/"))
+            self._copy_repo("shared_files/", join(f, "shared_files/"))
+            upload_command = ["shed_upload", "--tar_only"]
+            upload_command.extend(self._shed_args())
+            self._check_exit_code(upload_command)
+            self._check_tar(
+                f, "shed_upload.tar.gz",
+                contains=[
+                    "up_root/README.rst",
+                    "up_root/cat.xml",
+                    "shared_files/extra_test_data/extra_test_file.txt",
+                ],
+                not_contains=[])
+
     def _verify_expansion(self, f, name=None):
         upload_command = ["shed_upload", "--tar_only"]
         upload_command.extend(self._shed_args())


### PR DESCRIPTION
In order to handle include source paths combining ``..`` and ``strip_components``, the path manipulation must be done before calculating relative paths (which drops the ``..`` entries). The easiest way to do this seemed to me to move all the path realisation out of the ``RealizedFile`` object, thus the refactoring.

(This is a corner case I missed while working on #185)

Motivating example https://github.com/peterjc/pico_galaxy/commit/1029aa9106060215fa1f9620255702917ba8d3db which wasn't working as expected.

i.e. With this ``.shed.yml`` include block:

```
$ tail ~/repositories/pico_galaxy/tools/venn_list/.shed.yml
include:
- strip_components: 2
  source:
  - ../../tools/venn_list/README.rst
  - ../../tools/venn_list/tool_dependencies.xml
  - ../../tools/venn_list/venn_list.py
  - ../../tools/venn_list/venn_list.xml
  - ../../test-data/magic.pdf
  - ../../test-data/venn_list.tabular
  - ../../test-data/rhodopsin_proteins.fasta
```

Before this fix:

```
$ planemo shed_upload --tar_only ~/repositories/pico_galaxy/tools/venn_list/ && tar -tzf shed_upload.tar.gz
cp '/tmp/tmpdjKBhQ' 'shed_upload.tar.gz'
README.rst
test-data/magic.pdf
test-data/rhodopsin_proteins.fasta
test-data/venn_list.tabular
tool_dependencies.xml
venn_list.py
venn_list.xml
```

With this fix:

```
$ planemo shed_upload --tar_only ~/repositories/pico_galaxy/tools/venn_list/ && tar -tzf  shed_upload.tar.gz
cp '/tmp/tmpvOdqFl' 'shed_upload.tar.gz'
test-data/magic.pdf
test-data/rhodopsin_proteins.fasta
test-data/venn_list.tabular
tools/venn_list/README.rst
tools/venn_list/tool_dependencies.xml
tools/venn_list/venn_list.py
tools/venn_list/venn_list.xml
```

Note: The test case may well be not quite as @jmchilton would write it - I was attempting to model it after the existing complex repository examples.