### PR TITLE
Add -m as alias for --message in planemo shed_upload

### DIFF
--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -20,6 +20,7 @@ tar_path = click.Path(
 @click.command("shed_upload")
 @options.shed_project_arg()
 @click.option(
+    '-m',
     '--message',
     help="Commit message for tool shed upload."
 )


### PR DESCRIPTION
This matches the ``git commit`` argument for a commit message, and thus should be natural and familiar to planemo users too.

(I found myself trying to use ``planemo shed_upload ... -m "v1.2.3 adding cool stuff"`` and it didn't work)