### PR TITLE
recursive shed_diff with directories not yet in Tool Shed

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -226,6 +226,13 @@ def _diff_in(ctx, working, realized_repository, **kwds):
     other = os.path.join(working, label_b)
 
     tsi = tool_shed_client(ctx, read_only=True, **kwds)
+    # In order to download the tarball, require repository ID...
+    repo_id = realized_repository.find_repository_id(ctx, tsi)
+    if repo_id is None:
+        error("Repository [%s] does not exist in the targeted Tool Shed, can't do shed_diff"
+              % realized_repository.name)
+        # TODO - Should this return an error code which can be checked for in recursive mode?
+        return 0
     download_tarball(
         ctx,
         tsi,

--- a/planemo/shed/diff.py
+++ b/planemo/shed/diff.py
@@ -21,11 +21,10 @@ def diff_and_remove(working, label_a, label_b, f):
 
     repos_diff = 0
     if os.path.exists(a_repos) and os.path.exists(b_repos):
-        repos_diff = _shed_diff(a_repos, b_repos, f)
+        repos_diff &= _shed_diff(a_repos, b_repos, f)
         os.remove(a_repos)
         os.remove(b_repos)
-
-    return deps_diff and repos_diff
+    return deps_diff
 
 
 def _shed_diff(file_a, file_b, f=sys.stdout):


### PR DESCRIPTION
Previously this error condition would mean a recursive ``planemo shed_diff`` would fail on repository not yet uploaded to the Tool Shed. It now prints an error message but continues.

Resolves GitHub issue #201

TODO: Ensure that shed_diff on a single repository gives an error return code, e.g.

```
$ planemo shed_diff ~/repositories/pico_galaxy/tools/seq_concatenate/ && echo "$? returned"
Repository [seq_concatenate] does not exist in the targeted Tool Shed, can't do shed_diff
0 returned
```