### PR TITLE
Add ``--ensure_metadata`` option to ``shed_lint``.

### DIFF
--- a/planemo/commands/cmd_shed_lint.py
+++ b/planemo/commands/cmd_shed_lint.py
@@ -18,6 +18,13 @@ from planemo import shed_lint
     help=("Lint tools discovered in the process of linting repositories.")
 )
 @options.lint_xsd_option()
+@options.click.option(
+    '--ensure_metadata',
+    is_flag=True,
+    default=False,
+    help=("Ensure .shed.yml files contain enough metadata for each repository "
+          "to allow automated creation and/or updates.")
+)
 @pass_context
 def cli(ctx, paths, **kwds):
     """Check a Tool Shed repository for common problems.

--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -34,6 +34,14 @@ VALID_REPOSITORY_TYPES = [
     REPO_TYPE_SUITE,
 ]
 
+SHED_METADATA = [
+    "description",
+    "long_description",
+    "remote_repository_url",
+    "homepage_url",
+    "categories",
+]
+
 
 def lint_repository(ctx, realized_repository, **kwds):
     # TODO: this really needs to start working with realized path.
@@ -85,6 +93,12 @@ def lint_repository(ctx, realized_repository, **kwds):
                 tool_xml,
                 extra_modules=lint_args["extra_modules"]
             )
+    if kwds["ensure_metadata"]:
+        lint_ctx.lint(
+            "lint_shed_metadata",
+            lint_shed_metadata,
+            realized_repository,
+        )
     failed = lint_ctx.failed(lint_args["fail_level"])
     if failed:
         error("Failed linting")
@@ -98,6 +112,21 @@ def lint_expansion(realized_repository, lint_ctx):
         lint_ctx.warn(msg)
     else:
         lint_ctx.info("Included files all found.")
+
+
+def lint_shed_metadata(realized_repository, lint_ctx):
+    found_all = True
+    for key in SHED_METADATA:
+        if key not in realized_repository.config:
+            found_all = False
+            lint_ctx.warn(
+                "Missing shed metadata field [%s] for repository" % key
+            )
+    if found_all:
+        lint_ctx.info(
+            "Found all shed metadata fields required for automated repository "
+            "creation and/or updates."
+        )
 
 
 def lint_readme(path, lint_ctx):

--- a/tests/test_shed_lint.py
+++ b/tests/test_shed_lint.py
@@ -55,3 +55,10 @@ class ShedLintTestCase(CliTestCase):
             r = self._check_exit_code(["shed_lint", "--fail_fast"],
                                       exit_code=-1)
             assert isinstance(r.exception, RuntimeError)
+
+    def test_ensure_metadata(self):
+        with self._isolate_repo("single_tool"):
+            self._check_exit_code(["shed_lint"])
+        with self._isolate_repo("single_tool_exclude"):
+            self._check_exit_code(["shed_lint", "--ensure_metadata"],
+                                  exit_code=-1)


### PR DESCRIPTION
To ensure ``.shed.yml`` has complete metadata it needs for automated repository creation and/or updates.

See https://github.com/galaxyproject/tools-iuc/issues/129#issuecomment-103635134.

Ping @erasche.