### PR TITLE
Implement ``shed_update`` to upload & update repo metadata.

### DIFF
--- a/docs/publishing.rst
+++ b/docs/publishing.rst
@@ -91,7 +91,6 @@ metadata in ``.shed.yml`` and the second uploads your actual artifacts to it.
 ::
 
     planemo shed_create --shed_target testtoolshed
-    planemo shed_upload --shed_target testtoolshed
 
 
 Updating a Repository
@@ -119,7 +118,10 @@ Modified artifacts can be uploaded using the following command.
 
 ::
 
-    planemo shed_upload --shed_target testtoolshed
+    planemo shed_update --check_diff --shed_target testtoolshed
+
+The ``--check_diff`` option here will ensure there are significant differnces
+before uploading new contents to the tool shed.
 
 Once your artifacts are ready for publication to the main Tool Shed, the
 following commands to create a repository there and populate it with your
@@ -127,8 +129,7 @@ repository contents.
 
 ::
 
-    planemo shed_create --shed_target toolshed
-    planemo shed_upload --shed_target toolshed
+    planemo shed_create
 
 Advanced Usage
 =============================

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -12,6 +12,8 @@ from planemo.io import info
 
 @click.command("shed_create")
 @options.shed_publish_options()
+@options.shed_message_option()
+@options.shed_skip_upload()
 @pass_context
 def cli(ctx, paths, **kwds):
     """Create a repository in a Galaxy Tool Shed from a ``.shed.yml`` file.
@@ -23,7 +25,12 @@ def cli(ctx, paths, **kwds):
         if repo_id is None:
             if realized_repository.create(ctx, tsi):
                 info("Repository created")
-                return 0
+                if not kwds["skip_upload"]:
+                    return shed.upload_repository(
+                        ctx, realized_repository, **kwds
+                    )
+                else:
+                    return 0
             else:
                 return 2
         else:

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -38,12 +38,13 @@ def cli(ctx, paths, **kwds):
 
         % planemo shed_update --shed_target testtoolshed path/to/repo
 
-    Another important option is ``--check_diff`` - this will check for
-    differences before uploading new contents to the tool shed. This may
-    important because the tool shed will automatically populate certain
-    attributes in tool shed artifact files (such as ``tool_dependencies.xml``)
-    and this may cause unwanted installable revisions to be created when
-    there are no important changes.
+    Another important option is ``--check_diff`` - this doesn't affect the
+    updating of shed metadata but it will check for differences before
+    uploading new contents to the tool shed. This may important because the
+    tool shed will automatically populate certain attributes in tool shed
+    artifact files (such as ``tool_dependencies.xml``) and this may
+    cause unwanted installable revisions to be created when there are no
+    important changes.
 
     The lower-level ``shed_upload`` command should be used instead if
     the repository doesn't define complete metadata in a ``.shed.yml``.

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -1,0 +1,74 @@
+"""
+"""
+import sys
+
+import click
+
+from planemo.cli import pass_context
+from planemo import options
+from planemo import shed
+from planemo.io import info, error
+
+
+@click.command("shed_update")
+@options.shed_publish_options()
+@options.shed_upload_options()
+@options.shed_skip_upload()
+@options.shed_skip_metadata()
+@pass_context
+def cli(ctx, paths, **kwds):
+    """Update repository in shed from a ``.shed.yml`` file.
+
+    By default this command will update both repository metadata
+    from ``.shed.yml`` and upload new contents from the repository
+    directory.
+
+    ::
+
+        % planemo shed_update
+
+    This will update the main tool shed with the repository defined
+    by a ``.shed.yml`` file in the current working directory. Both
+    the location of the ``.shed.yml`` and the tool shed to upload to
+    can be easily configured. For instance, the following command can
+    be used if ``.shed.yml`` if contained in ``path/to/repo`` and the
+    desire is to update the test tool shed.
+
+    ::
+
+        % planemo shed_update --shed_target testtoolshed path/to/repo
+
+    Another important option is ``--check_diff`` - this will check for
+    differences before uploading new contents to the tool shed. This may
+    important because the tool shed will automatically populate certain
+    attributes in tool shed artifact files (such as ``tool_dependencies.xml``)
+    and this may cause unwanted installable revisions to be created when
+    there are no important changes.
+
+    The lower-level ``shed_upload`` command should be used instead if
+    the repository doesn't define complete metadata in a ``.shed.yml``.
+    """
+    tsi = shed.tool_shed_client(ctx, **kwds)
+
+    def update(realized_reposiotry):
+        upload_ok = True
+        if not kwds["skip_upload"]:
+            upload_ok = not shed.upload_repository(
+                ctx, realized_reposiotry, **kwds
+            )
+        repo_id = realized_reposiotry.find_repository_id(ctx, tsi)
+        metadata_ok = True
+        if not kwds["skip_metadata"]:
+            metadata_ok = realized_reposiotry.update(ctx, tsi, repo_id)
+        if metadata_ok:
+            info("Repository metadata updated.")
+        else:
+            error("Failed to update repository metadata.")
+        if metadata_ok and upload_ok:
+            return 0
+        else:
+            error("Failed to update a repository.")
+            return 1
+
+    exit_code = shed.for_each_repository(ctx, update, paths, **kwds)
+    sys.exit(exit_code)

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -19,11 +19,7 @@ tar_path = click.Path(
 
 @click.command("shed_upload")
 @options.shed_publish_options()
-@click.option(
-    '-m',
-    '--message',
-    help="Commit message for tool shed upload."
-)
+@options.shed_upload_options()
 @click.option(
     '--tar_only',
     is_flag=True,
@@ -36,23 +32,24 @@ tar_path = click.Path(
     type=tar_path,
     default=None,
 )
-@click.option(
-    '--force_repository_creation',
-    help="If a repository cannot be found for the specified user/repo name "
-         "pair, then automatically create the repository in the toolshed.",
-    is_flag=True,
-    default=False
-)
-@click.option(
-    "--check_diff",
-    is_flag=True,
-    help="Skip uploading if the shed_diff detects there would be no "
-         "'difference' (only attributes populated by the shed would would "
-         "be updated.)"
-)
 @pass_context
 def cli(ctx, paths, **kwds):
-    """Handle possible recursion through paths for uploading files to a toolshed
+    """Low-level command for uploading tar balls to a shed.
+
+    Generally, ``shed_update`` should be used instead since it also updates
+    both tool shed contents (via tar ball generation and upload) as well as
+    metadata (to handle metadata changes in ``.shed.yml`` files).
+
+    ::
+
+        % planemo shed_upload --tar_only  ~/
+        % tar -tzf shed_upload.tar.gz
+        test-data/blastdb.loc
+        ...
+        tools/ncbi_blast_plus/tool_dependencies.xml
+        % tar -tzf shed_upload.tar.gz | wc -l
+        117
+
     """
     def upload(realized_repository):
         return shed.upload_repository(ctx, realized_repository, **kwds)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -358,7 +358,7 @@ def shed_check_diff_option():
         is_flag=True,
         help=("Skip uploading if the shed_diff detects there would be no "
               "'difference' (only attributes populated by the shed would "
-              "would be updated.)")
+              "be updated.)")
     )
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -315,6 +315,61 @@ def shed_password_option():
     )
 
 
+def shed_skip_upload():
+    return click.option(
+        "--skip_upload",
+        is_flag=True,
+        help=("Skip upload contents as part of operation, only update "
+              "metadata.")
+    )
+
+
+def shed_skip_metadata():
+    return click.option(
+        "--skip_metadata",
+        is_flag=True,
+        help=("Skip metadata update as part of operation, only upload "
+              "new contents.")
+    )
+
+
+def shed_message_option():
+    return click.option(
+        '-m',
+        '--message',
+        help="Commit message for tool shed upload."
+    )
+
+
+def shed_force_create_option():
+    return click.option(
+        '--force_repository_creation',
+        help=("If a repository cannot be found for the specified user/repo "
+              "name pair, then automatically create the repository in the "
+              "toolshed."),
+        is_flag=True,
+        default=False
+    )
+
+
+def shed_check_diff_option():
+    return click.option(
+        "--check_diff",
+        is_flag=True,
+        help=("Skip uploading if the shed_diff detects there would be no "
+              "'difference' (only attributes populated by the shed would "
+              "would be updated.)")
+    )
+
+
+def shed_upload_options():
+    return _compose(
+        shed_message_option(),
+        shed_force_create_option(),
+        shed_check_diff_option(),
+    )
+
+
 def shed_realization_options():
     return _compose(
         shed_project_arg(multiple=True),

--- a/tests/shed_app.py
+++ b/tests/shed_app.py
@@ -35,6 +35,15 @@ def create_repository():
     return json.dumps(model.get_repository(id))
 
 
+@app.route('/api/repositories/<id>', methods=['PUT'])
+def update_repository(id):
+    repo = _request_post_message()
+    repo["owner"] = "iuc"
+    model = app.config["model"]
+    model.update_repository(id, **repo)
+    return json.dumps(model.get_repository(id))
+
+
 @app.route('/api/repositories/<id>/changeset_revision', methods=['POST'])
 def update_repository_contents(id):
     updated_tar = request.files['file']
@@ -110,6 +119,12 @@ class InMemoryShedDataModel(object):
         return self
 
     def add_repository(self, id, **kwds):
+        repo_metadata = kwds.copy()
+        repo_metadata["id"] = id
+        self._repositories[id] = repo_metadata
+        return self
+
+    def update_repository(self, id, **kwds):
         repo_metadata = kwds.copy()
         repo_metadata["id"] = id
         self._repositories[id] = repo_metadata

--- a/tests/test_shed_create.py
+++ b/tests/test_shed_create.py
@@ -11,13 +11,13 @@ class ShedCreateTestCase(CliShedTestCase):
 
     def test_create_single(self):
         with self._isolate_repo("single_tool"):
-            create_command = ["shed_create"]
+            create_command = ["shed_create", "--skip_upload"]
             create_command.extend(self._shed_args())
             self._check_exit_code(create_command)
 
     def test_create_multiple(self):
         with self._isolate_repo("multi_repos_nested"):
-            create_command = ["shed_create", "-r"]
+            create_command = ["shed_create", "--skip_upload", "-r"]
             create_command.extend(self._shed_args())
             self._check_exit_code(create_command)
 
@@ -38,7 +38,7 @@ class ShedCreateTestCase(CliShedTestCase):
             assert suite_repo["type"] == "repository_suite_definition"
 
     def _multi_repo_create_and_verify(self):
-        create_command = ["shed_create", "-r"]
+        create_command = ["shed_create", "--skip_upload", "-r"]
         create_command.extend(self._shed_args())
         self._check_exit_code(create_command)
         cat1_repo = self._get_repo_info("cs-cat1")

--- a/tests/test_shed_upload.py
+++ b/tests/test_shed_upload.py
@@ -26,10 +26,16 @@ class ShedUploadTestCase(CliShedTestCase):
             upload_command.extend(self._shed_args())
             self._check_exit_code(upload_command, exit_code=-1)
 
+    def test_update_not_exists(self):
+        with self._isolate_repo("single_tool"):
+            upload_command = ["shed_update"]
+            upload_command.extend(self._shed_args())
+            self._check_exit_code(upload_command, exit_code=-1)
+
     def test_upload_with_check_diff(self):
         with self._isolate_repo("single_tool") as f:
             upload_command = [
-                "shed_upload", "--force_repository_creation", "--check_diff"
+                "shed_update", "--force_repository_creation", "--check_diff"
             ]
             upload_command.extend(self._shed_args())
             self._check_exit_code(upload_command)
@@ -49,7 +55,7 @@ class ShedUploadTestCase(CliShedTestCase):
 
     def test_upload_with_force_create(self):
         with self._isolate_repo("single_tool") as f:
-            upload_command = ["shed_upload", "--force_repository_creation"]
+            upload_command = ["shed_update", "--force_repository_creation"]
             upload_command.extend(self._shed_args())
             self._check_exit_code(upload_command)
             self._verify_single_uploaded(f)
@@ -65,7 +71,7 @@ class ShedUploadTestCase(CliShedTestCase):
                 "git commit -m 'initial commit'"
             ]))
             upload_command = [
-                "shed_upload", "--force_repository_creation",
+                "shed_update", "--force_repository_creation",
                 "git+single_tool/.git"
             ]
             upload_command.extend(self._shed_args())
@@ -84,7 +90,7 @@ class ShedUploadTestCase(CliShedTestCase):
             ]))
             rev = git.rev(None, "single_tool")
             upload_command = [
-                "shed_upload", "--force_repository_creation",
+                "shed_update", "--force_repository_creation",
                 "git+single_tool/.git"
             ]
             upload_command.extend(self._shed_args())
@@ -107,6 +113,13 @@ class ShedUploadTestCase(CliShedTestCase):
             self._check_exit_code(upload_command)
             self._verify_single_uploaded(f)
 
+    def test_create_with_upload(self):
+        with self._isolate_repo("single_tool") as f:
+            create_command = ["shed_create"]
+            create_command.extend(self._shed_args())
+            self._check_exit_code(create_command)
+            self._verify_single_uploaded(f)
+
     def test_cannont_recreate(self):
         with self._isolate_repo("single_tool"):
             create_command = ["shed_create"]
@@ -123,7 +136,7 @@ class ShedUploadTestCase(CliShedTestCase):
     def test_upload_recusrive(self):
         with self._isolate_repo("multi_repos_nested") as f:
             upload_command = [
-                "shed_upload", "-r", "--force_repository_creation"
+                "shed_update", "-r", "--force_repository_creation"
             ]
             upload_command.extend(self._shed_args())
             self._check_exit_code(upload_command)


### PR DESCRIPTION
This should replace ``shed_upload`` in many potential workflows - but this does require a ``.shed.yml`` file with all metadata populated so ``shed_upload`` is still useful for directly uploading custom tar files for instance. I have filled out the documentation on ``shed_upload`` and ``shed_update`` to reflect this.

Additionally, for consistency with the new ``shed_update`` operation - ``shed_create`` now also performs an upload in addition to simply populating the metadata for a new remote repository. The old behavior of ``shed_create`` can be obtained by supplying a new ``--skip_upload`` flag. ``shed_create`` can also take in a ``-m/--message`` option now as well to reflect this new behavior.

Updated ``publish.rst`` to reflect these simplifications (instructions now easier).

Closes #199.