### PR TITLE
Make bwa data_collection example consistent.

### DIFF
--- a/docs/_writing_collections.rst
+++ b/docs/_writing_collections.rst
@@ -67,7 +67,7 @@ pairs of datasets can also process single datasets. The following
         <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset" help="Specify dataset with single reads"/>
       </when>
       <when value="paired_collection">
-        <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" />
+        <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" label="Select dataset pair" help="Specify paired dataset collection containing paired reads"/>
       </when>
     </conditional>
 

--- a/docs/writing/bwa-mem_v3.xml
+++ b/docs/writing/bwa-mem_v3.xml
@@ -38,7 +38,7 @@
                  <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset" help="Specify dataset with single reads"/>
             </when>
             <when value="paired_collection">
-                 <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select dataset pair" help="Specify paired dataset collection containing paired reads" />
+                 <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" label="Select dataset pair" help="Specify paired dataset collection containing paired reads"/>
             </when>
         </conditional>
     </inputs>

--- a/docs/writing/bwa-mem_v4.xml
+++ b/docs/writing/bwa-mem_v4.xml
@@ -38,7 +38,7 @@
                  <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset" help="Specify dataset with single reads"/>
             </when>
             <when value="paired_collection">
-                 <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select dataset pair" help="Specify paired dataset collection containing paired reads" />
+                 <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" label="Select dataset pair" help="Specify paired dataset collection containing paired reads"/>
             </when>
         </conditional>
     </inputs>

--- a/docs/writing/bwa-mem_v5.xml
+++ b/docs/writing/bwa-mem_v5.xml
@@ -42,7 +42,7 @@
                  <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset" help="Specify dataset with single reads"/>
             </when>
             <when value="paired_collection">
-                 <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select dataset pair" help="Specify paired dataset collection containing paired reads" />
+                 <param name="fastq_input" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" label="Select dataset pair" help="Specify paired dataset collection containing paired reads"/>
             </when>
         </conditional>
         <conditional name="algorithm">


### PR DESCRIPTION
The XML examples were missing collection_type=paired (spotted by @jmchilton during the GCC2015 training day) while the RST file was missing the help attribute.