### PR TITLE
Add --from_work_dir option in init_tool

### DIFF
--- a/planemo/commands/cmd_tool_init.py
+++ b/planemo/commands/cmd_tool_init.py
@@ -84,6 +84,13 @@ REUSING_MACROS_MESSAGE = ("Macros file macros.xml already exists, assuming "
           "with a data input parameter)."),
 )
 @click.option(
+    "--from_work_dir",
+    is_flag=True,
+    default=None,
+    prompt=False,
+    help=("Hardcode the output name"),
+)
+@click.option(
     "--example_output",
     type=click.STRING,
     default=None,

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -155,7 +155,10 @@ def build(**kwds):
     del kwds["example_output"]
     for i, output_file in enumerate(example_outputs or []):
         name = "output%d" % (i + 1)
-        output = Output(name=name, from_path=output_file)
+        if kwds["from_work_dir"]:
+            output = Output(name=name, from_path=output_file)
+        else:
+            output = Output(name=name)
         outputs.append(output)
         test_case.outputs.append((name, output_file))
         command = _replace_file_in_command(command, output_file, output.name)


### PR DESCRIPTION
The first part of my first contribution.

I just add an option --from_work_dir because we often succeed  to avoid from_workr_dir argument.

Without --from_work_dir
```
    <command><![CDATA[
        samtools sort -o "$input1" > "$output1"
    ]]></command>
    <outputs>
        <data name="output1" format="bam" from_work_dir="1_sorted.bam" />
    </outputs>
```

With --from_work_dir
```
    <command><![CDATA[
        samtools sort -o "$input1" > "$output1"
    ]]></command>
    <outputs>
        <data name="output1" format="bam" />
    </outputs>
```

I hope I follow enough the good practice to not waste your time. Planemo, git and GitHub were almost new for me 2 days ago :)

Let me know if I was on the wrong way.

Gildas