### PR TITLE
Bugfix: tool_init use from_work_dir only if file in command.

### DIFF
--- a/docs/writing/seqtk_seq_v2.xml
+++ b/docs/writing/seqtk_seq_v2.xml
@@ -12,7 +12,7 @@
         <param type="data" name="input1" format="fastq" />
     </inputs>
     <outputs>
-        <data name="output1" format="fasta" from_work_dir="2.fasta" />
+        <data name="output1" format="fasta" />
     </outputs>
     <help><![CDATA[
         TODO: Fill in help.

--- a/docs/writing/seqtk_seq_v3.xml
+++ b/docs/writing/seqtk_seq_v3.xml
@@ -12,7 +12,7 @@
         <param type="data" name="input1" format="fastq" />
     </inputs>
     <outputs>
-        <data name="output1" format="fasta" from_work_dir="2.fasta" />
+        <data name="output1" format="fasta" />
     </outputs>
     <tests>
         <test>

--- a/docs/writing/seqtk_seq_v4.xml
+++ b/docs/writing/seqtk_seq_v4.xml
@@ -23,7 +23,7 @@
                value="255" min="0" max="255" help="(-X)" />
     </inputs>
     <outputs>
-        <data name="output1" format="fasta" from_work_dir="2.fasta" />
+        <data name="output1" format="fasta" />
     </outputs>
     <tests>
         <test>

--- a/docs/writing/seqtk_seq_v5.xml
+++ b/docs/writing/seqtk_seq_v5.xml
@@ -43,7 +43,7 @@
         </conditional>
     </inputs>
     <outputs>
-        <data name="output1" format="fasta" from_work_dir="2.fasta" />
+        <data name="output1" format="fasta" />
     </outputs>
     <tests>
         <test>

--- a/docs/writing/seqtk_seq_v6.xml
+++ b/docs/writing/seqtk_seq_v6.xml
@@ -55,7 +55,7 @@
         </conditional>
     </inputs>
     <outputs>
-        <data name="output1" format="fasta" from_work_dir="2.fasta" />
+        <data name="output1" format="fasta" />
     </outputs>
     <tests>
         <test>

--- a/docs/writing/seqtk_seq_with_macros.xml
+++ b/docs/writing/seqtk_seq_with_macros.xml
@@ -11,7 +11,7 @@
         <param type="data" name="input1" format="fastq" />
     </inputs>
     <outputs>
-        <data name="output1" format="fasta" from_work_dir="2.fasta" />
+        <data name="output1" format="fasta" />
     </outputs>
     <tests>
         <test>

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -155,7 +155,12 @@ def build(**kwds):
     del kwds["example_output"]
     for i, output_file in enumerate(example_outputs or []):
         name = "output%d" % (i + 1)
-        output = Output(name=name, from_path=output_file)
+        from_path = output_file
+        if output_file in command:
+            # Actually found the file in the command, assume it can
+            # be specified directly and skip from_work_dir.
+            from_path = None
+        output = Output(name=name, from_path=from_path)
         outputs.append(output)
         test_case.outputs.append((name, output_file))
         command = _replace_file_in_command(command, output_file, output.name)


### PR DESCRIPTION
Fixes bug in the resulting tools using the output directly but having dummy from_work_dir files that are largely ignored by Galaxy under normal operation (but causing a somewhat more undefined behavior with Pulsar for instance). The updated example tools clarify this I think.

See also #276 (ping @lecorguille).