### PR TITLE
Shed diff report

### DIFF
--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -7,6 +7,7 @@ import click
 from planemo.cli import pass_context
 from planemo import options
 from planemo import shed
+from planemo.reports import build_report
 
 
 @click.command("shed_diff")
@@ -29,6 +30,13 @@ from planemo import shed
     is_flag=True,
     help="Do not attempt smart diff of XML to filter out attributes "
          "populated by the Tool Shed.",
+)
+@click.option(
+    "--report_xunit",
+    type=click.Path(file_okay=True, resolve_path=True),
+    help="Output diff as a faked XUnit report, useful when you want to "
+         "automatically diff repositories and be warned when out-of-date.",
+    default=None,
 )
 @pass_context
 def cli(ctx, paths, **kwds):
@@ -61,8 +69,39 @@ def cli(ctx, paths, **kwds):
     difference applies only to the file contents of files that would actually be
     uploaded to the repository.
     """
+
+    # In a little bit of cheating, we're defining this variable here to collect
+    # a "report" on our shed_diff
+    collected_data = {
+        'results': {
+            'total': 0,
+            'errors': 0,
+            'failures': 0,
+            'skips': 0,
+        },
+        'tests': [],
+    }
+
     def diff(realized_repository):
-        return shed.diff_repo(ctx, realized_repository, **kwds)
+        result = shed.diff_repo(ctx, realized_repository, **kwds)
+        # Collect data about what happened
+        collected_data['results']['total'] += 1
+        if result >= 200:
+            collected_data['results']['errors'] += 1
+        elif result > 0:
+            collected_data['results']['failures'] += 1
+        collected_data['tests'].append({
+            'classname': realized_repository.name,
+            'result': result,
+        })
+
+        return result
 
     exit_code = shed.for_each_repository(ctx, diff, paths, **kwds)
+
+    if 'report_xunit' in kwds:
+        with open(kwds['report_xunit'], 'w') as handle:
+            handle.write(build_report.template_data(
+                collected_data, template_name='diff_xunit.tpl'))
+
     sys.exit(exit_code)

--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -94,12 +94,11 @@ def cli(ctx, paths, **kwds):
             'classname': realized_repository.name,
             'result': result,
         })
-
         return result
 
     exit_code = shed.for_each_repository(ctx, diff, paths, **kwds)
 
-    if 'report_xunit' in kwds:
+    if kwds.get('report_xunit', False):
         with open(kwds['report_xunit'], 'w') as handle:
             handle.write(build_report.template_data(
                 collected_data, template_name='diff_xunit.tpl'))

--- a/planemo/reports/build_report.py
+++ b/planemo/reports/build_report.py
@@ -1,15 +1,13 @@
-import json
 from pkg_resources import resource_string
 from jinja2 import Environment, PackageLoader
 env = Environment(loader=PackageLoader('planemo', 'reports'))
-TITLE = "Tool Test Results (powered by Planemo)"
 
 
 def build_report(structured_data, report_type="html", **kwds):
-    """ Use report_template.html to build HTML page for report.
+    """ Use report_{report_type}.tpl to build page for report.
     """
     environment = dict(
-        title=TITLE,
+        title="Tool Test Results (powered by Planemo)",
         raw_data=structured_data,
     )
 
@@ -22,10 +20,15 @@ def build_report(structured_data, report_type="html", **kwds):
             'bootstrap_style': __style("bootstrap.min.css"),
             'jquery_script': __script("jquery.min"),
             'bootstrap_script': __script("bootstrap.min"),
-            'json_test_data': json.dumps(structured_data),
         })
 
-    template = env.get_template('report_%s.tpl' % report_type)
+    return template_data(environment, 'report_%s.tpl' % report_type)
+
+
+def template_data(environment, template_name="report_html.tpl", **kwds):
+    """Build an arbitrary templated page.
+    """
+    template = env.get_template(template_name)
     return template.render(**environment)
 
 

--- a/planemo/reports/diff_xunit.tpl
+++ b/planemo/reports/diff_xunit.tpl
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="planemodiff"
+           tests="{{ results.total }}"
+           errors="{{ results.errors }}"
+           failures="{{ results.failures }}"
+           skip="{{ results.skips }}">
+    {% for testcase in tests %}
+    <testcase classname="{{ testcase.classname }}" name="recursive_diff" time="{{ testcase.time }}"/>
+        {% if testcase.result == 1 %}
+            <error type="planemo.Different" message="Repository is different">
+                <!-- TODO: copy of diff output -->
+            </error>
+        {% endif %}
+        {% if testcase.result == 2 %}
+            <error type="planemo.RepoDoesNotExit" message="Target repository does not exist">
+                <!-- TODO: copy of diff output -->
+            </error>
+        {% endif %}
+        {% if testcase.result > 2 %}
+            <error type="planemo.DiffError" message="Error executing diff">
+                <!-- TODO: copy of diff output -->
+            </error>
+        {% endif %}
+    {% endfor %}
+</testsuite>

--- a/planemo/reports/diff_xunit.tpl
+++ b/planemo/reports/diff_xunit.tpl
@@ -5,7 +5,7 @@
            failures="{{ results.failures }}"
            skip="{{ results.skips }}">
     {% for testcase in tests %}
-    <testcase classname="{{ testcase.classname }}" name="recursive_diff" time="{{ testcase.time }}"/>
+    <testcase classname="{{ testcase.classname }}" name="recursive_diff" time="{{ testcase.time }}">
         {% if testcase.result == 1 %}
             <error type="planemo.Different" message="Repository is different">
                 <!-- TODO: copy of diff output -->
@@ -21,5 +21,6 @@
                 <!-- TODO: copy of diff output -->
             </error>
         {% endif %}
+    </testcase>
     {% endfor %}
 </testsuite>

--- a/planemo/reports/report_html.tpl
+++ b/planemo/reports/report_html.tpl
@@ -78,7 +78,7 @@
         .success(function(content) { renderTestResults( $.parseJSON(content) ); })
         .failure(function() { alert("Failed to load test data.")} );
       } else {
-        var test_data = {{ json_test_data }};
+        var test_data = {{ raw_data | to_json }};
         renderTestResults(test_data);
       }
     </script>

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -785,6 +785,7 @@ def _find_raw_repositories(path, **kwds):
     shed_file_dirs = []
     if recursive:
         for base_path, dirnames, filenames in os.walk(path):
+            dirnames.sort()
             for filename in fnmatch.filter(filenames, SHED_CONFIG_NAME):
                 shed_file_dirs.append(base_path)
     elif os.path.exists(os.path.join(path, SHED_CONFIG_NAME)):

--- a/tests/data/repos/multi_repos_nested.xunit-bad.xml
+++ b/tests/data/repos/multi_repos_nested.xunit-bad.xml
@@ -4,9 +4,11 @@
            errors="0"
            failures="1"
            skip="0">
-    <testcase classname="cat2" name="recursive_diff" time=""/>
     <testcase classname="cat1" name="recursive_diff" time="">
         <error type="planemo.Different" message="Repository is different">
+            <!-- TODO: copy of diff output -->
         </error>
+    </testcase>
+    <testcase classname="cat2" name="recursive_diff" time="">
     </testcase>
 </testsuite>

--- a/tests/data/repos/multi_repos_nested.xunit-bad.xml
+++ b/tests/data/repos/multi_repos_nested.xunit-bad.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="planemodiff"
+           tests="2"
+           errors="0"
+           failures="1"
+           skip="0">
+    <testcase classname="cat2" name="recursive_diff" time=""/>
+    <testcase classname="cat1" name="recursive_diff" time="">
+        <error type="planemo.Different" message="Repository is different">
+        </error>
+    </testcase>
+</testsuite>

--- a/tests/data/repos/multi_repos_nested.xunit.xml
+++ b/tests/data/repos/multi_repos_nested.xunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="planemodiff"
+           tests="2"
+           errors="0"
+           failures="0"
+           skip="0">
+    <testcase classname="cat2" name="recursive_diff" time=""/>
+    <testcase classname="cat1" name="recursive_diff" time=""/>
+</testsuite>

--- a/tests/data/repos/multi_repos_nested.xunit.xml
+++ b/tests/data/repos/multi_repos_nested.xunit.xml
@@ -4,6 +4,6 @@
            errors="0"
            failures="0"
            skip="0">
-    <testcase classname="cat2" name="recursive_diff" time=""/>
     <testcase classname="cat1" name="recursive_diff" time=""/>
+    <testcase classname="cat2" name="recursive_diff" time=""/>
 </testsuite>

--- a/tests/test_shed_diff.py
+++ b/tests/test_shed_diff.py
@@ -6,6 +6,12 @@ from .test_utils import (
     CliShedTestCase,
 )
 from planemo import io
+import tempfile
+import sys
+import os
+from xml.etree import ElementTree
+from planemo.xml.diff import diff
+from .test_utils import TEST_REPOS_DIR
 
 DIFF_LINES = [
     "diff -r _local_/related_file _custom_shed_/related_file",
@@ -15,6 +21,63 @@ DIFF_LINES = [
 
 
 class ShedDiffTestCase(CliShedTestCase):
+
+    # def test_shed_diff(self):
+        # with self._isolate_repo("single_tool") as f:
+            # upload_command = ["shed_upload", "--force_repository_creation"]
+            # upload_command.extend(self._shed_args())
+            # self._check_exit_code(upload_command)
+            # io.write_file(
+                # join(f, "related_file"),
+                # "A related non-tool file (modified).\n",
+            # )
+            # self._check_diff(f, True)
+            # self._check_diff(f, False)
+
+    # def test_diff_doesnt_exist(self):
+        # with self._isolate_repo("multi_repos_nested"):
+            # diff_command = ["shed_diff"]
+            # diff_command.extend(self._shed_args(read_only=True))
+            # self._check_exit_code(diff_command, exit_code=2)
+
+    # def test_diff_recursive(self):
+        # with self._isolate_repo("multi_repos_nested") as f:
+            # upload_command = [
+                # "shed_upload", "-r", "--force_repository_creation"
+            # ]
+            # upload_command.extend(self._shed_args())
+            # self._check_exit_code(upload_command)
+
+            # diff_command = ["shed_diff", "-r"]
+            # diff_command.extend(self._shed_args(read_only=True))
+            # self._check_exit_code(diff_command, exit_code=0)
+
+            # io.write_file(
+                # join(f, "cat1", "related_file"),
+                # "A related non-tool file (modified).\n",
+            # )
+            # self._check_exit_code(diff_command, exit_code=1)
+
+    # def test_shed_diff_raw(self):
+        # with self._isolate_repo("suite_auto"):
+            # upload_command = [
+                # "shed_upload", "--force_repository_creation",
+            # ]
+            # upload_command.extend(self._shed_args())
+            # self._check_exit_code(upload_command)
+
+            # diff_command = [
+                # "shed_diff", "-o", "diff"
+            # ]
+            # diff_command.append("--raw")
+            # diff_command.extend(self._shed_args(read_only=True))
+            # self._check_exit_code(diff_command, exit_code=1)
+
+            # diff_command = [
+                # "shed_diff", "-o", "diff"
+            # ]
+            # diff_command.extend(self._shed_args(read_only=True))
+            # self._check_exit_code(diff_command, exit_code=0)
 
     def test_shed_diff(self):
         with self._isolate_repo("single_tool") as f:
@@ -72,6 +135,56 @@ class ShedDiffTestCase(CliShedTestCase):
             ]
             diff_command.extend(self._shed_args(read_only=True))
             self._check_exit_code(diff_command, exit_code=0)
+>>>>>>> 244acb0... Whoops, revert the commenting
+
+    def test_diff_xunit(self):
+        with self._isolate_repo("multi_repos_nested") as f:
+            upload_command = [
+                "shed_upload", "-r", "--force_repository_creation"
+            ]
+            upload_command.extend(self._shed_args())
+            self._check_exit_code(upload_command)
+
+            xunit_report = tempfile.NamedTemporaryFile(delete=False)
+            xunit_report.flush()
+            xunit_report.close()
+            diff_command = ["shed_diff", "-r", "--report_xunit", xunit_report.name]
+            diff_command.extend(self._shed_args(read_only=True))
+            known_good_xunit_report = os.path.join(TEST_REPOS_DIR,
+                                                   'multi_repos_nested.xunit.xml')
+            known_bad_xunit_report = os.path.join(TEST_REPOS_DIR,
+                                                  'multi_repos_nested.xunit-bad.xml')
+            self._check_exit_code(diff_command, exit_code=0)
+
+            compare = open(xunit_report.name, 'r').read()
+            if not diff(
+                ElementTree.parse(known_good_xunit_report).getroot(),
+                ElementTree.fromstring(compare),
+                reporter=sys.stdout.write
+            ):
+                self.assertTrue(True)
+            else:
+                sys.stdout.write(compare)
+                self.assertTrue(False)
+
+            io.write_file(
+                join(f, "cat1", "related_file"),
+                "A related non-tool file (modified).\n",
+            )
+            self._check_exit_code(diff_command, exit_code=1)
+
+            compare = open(xunit_report.name, 'r').read()
+            if not diff(
+                ElementTree.parse(known_bad_xunit_report).getroot(),
+                ElementTree.fromstring(compare),
+                reporter=sys.stdout.write
+            ):
+                self.assertTrue(True)
+            else:
+                sys.stdout.write(compare)
+                self.assertTrue(False)
+
+            os.unlink(xunit_report.name)
 
     def _check_diff(self, f, raw):
         diff_command = ["shed_diff", "-o", "diff"]

--- a/tests/test_shed_diff.py
+++ b/tests/test_shed_diff.py
@@ -22,63 +22,6 @@ DIFF_LINES = [
 
 class ShedDiffTestCase(CliShedTestCase):
 
-    # def test_shed_diff(self):
-        # with self._isolate_repo("single_tool") as f:
-            # upload_command = ["shed_upload", "--force_repository_creation"]
-            # upload_command.extend(self._shed_args())
-            # self._check_exit_code(upload_command)
-            # io.write_file(
-                # join(f, "related_file"),
-                # "A related non-tool file (modified).\n",
-            # )
-            # self._check_diff(f, True)
-            # self._check_diff(f, False)
-
-    # def test_diff_doesnt_exist(self):
-        # with self._isolate_repo("multi_repos_nested"):
-            # diff_command = ["shed_diff"]
-            # diff_command.extend(self._shed_args(read_only=True))
-            # self._check_exit_code(diff_command, exit_code=2)
-
-    # def test_diff_recursive(self):
-        # with self._isolate_repo("multi_repos_nested") as f:
-            # upload_command = [
-                # "shed_upload", "-r", "--force_repository_creation"
-            # ]
-            # upload_command.extend(self._shed_args())
-            # self._check_exit_code(upload_command)
-
-            # diff_command = ["shed_diff", "-r"]
-            # diff_command.extend(self._shed_args(read_only=True))
-            # self._check_exit_code(diff_command, exit_code=0)
-
-            # io.write_file(
-                # join(f, "cat1", "related_file"),
-                # "A related non-tool file (modified).\n",
-            # )
-            # self._check_exit_code(diff_command, exit_code=1)
-
-    # def test_shed_diff_raw(self):
-        # with self._isolate_repo("suite_auto"):
-            # upload_command = [
-                # "shed_upload", "--force_repository_creation",
-            # ]
-            # upload_command.extend(self._shed_args())
-            # self._check_exit_code(upload_command)
-
-            # diff_command = [
-                # "shed_diff", "-o", "diff"
-            # ]
-            # diff_command.append("--raw")
-            # diff_command.extend(self._shed_args(read_only=True))
-            # self._check_exit_code(diff_command, exit_code=1)
-
-            # diff_command = [
-                # "shed_diff", "-o", "diff"
-            # ]
-            # diff_command.extend(self._shed_args(read_only=True))
-            # self._check_exit_code(diff_command, exit_code=0)
-
     def test_shed_diff(self):
         with self._isolate_repo("single_tool") as f:
             upload_command = ["shed_upload", "--force_repository_creation"]
@@ -135,7 +78,6 @@ class ShedDiffTestCase(CliShedTestCase):
             ]
             diff_command.extend(self._shed_args(read_only=True))
             self._check_exit_code(diff_command, exit_code=0)
->>>>>>> 244acb0... Whoops, revert the commenting
 
     def test_diff_xunit(self):
         with self._isolate_repo("multi_repos_nested") as f:

--- a/tests/test_shed_diff.py
+++ b/tests/test_shed_diff.py
@@ -34,7 +34,7 @@ class ShedDiffTestCase(CliShedTestCase):
             diff_command.extend(self._shed_args(read_only=True))
             self._check_exit_code(diff_command, exit_code=2)
 
-    def test_diff_recusrive(self):
+    def test_diff_recursive(self):
         with self._isolate_repo("multi_repos_nested") as f:
             upload_command = [
                 "shed_upload", "-r", "--force_repository_creation"


### PR DESCRIPTION
This produces a (fake) XUnit report for the shed_diff command. It's not complete as-is, but it'll provide essential functionality immediately. The XUnit reports will tell you if a shed diff returned a repository as being identical, different (failure), or if the diff command failed (error). It will not show a copy of the diff as I couldn't figure out how to cleanly extract that.

@jmchilton if you have suggestions for [how this should be better implemented](https://github.com/galaxyproject/planemo/commit/9813ef0c1e2e249e35dc85ada8b713eae405b43a), please let me know. I see that most of the commands are pretty small and most of that functionality is tucked away in `planemo.shed` and friends, but here I went with the implementation I was comfortable with. If you have suggestions how I should get at the diff output I'd be happy to make another PR with those (or update this one).

- [x] Depends on #304 

(I branched off of that branch, I didn't want to deal with merge issues since these both needed common changes to the code, blargh.)