### PR TITLE
Fixed detection of venv in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clean-test:
 	rm -fr htmlcov/
 
 setup-venv:
-	if [ -f $(VENV) ]; then virtualenv $(VENV); fi;
+	if [ ! -d $(VENV) ]; then virtualenv $(VENV); exit; fi;
 	$(IN_VENV) pip install -r requirements.txt && pip install -r dev-requirements.txt
 
 setup-git-hook-lint:


### PR DESCRIPTION
The setup-venv function in the Makefile was not properly detecting the need to create a venv and thus resulted in installing all the packages in the environment that make was executed in.