### PR TITLE
Implement profiles in sheds section of the ~/.planemo.yml.

### DIFF
--- a/docs/.planemo.yml
+++ b/docs/.planemo.yml
@@ -8,7 +8,6 @@
 #  password: <password>
 
 sheds:
-  username: "<TODO>"
   # For each Tool Shed you wish to target enter the API key
   # or both email and password.
   toolshed:
@@ -21,5 +20,10 @@ sheds:
     #password: "<TODO>"
   local:
     key: "<TODO>"
+    #email: "<TODO>"
+    #password: "<TODO>"
+  custom_shed:
+    key: "<TODO>"
+    url: "http://customurl/"
     #email: "<TODO>"
     #password: "<TODO>"

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -18,12 +18,12 @@ from planemo.io import info
 def cli(ctx, paths, **kwds):
     """Create a repository in a Galaxy Tool Shed from a ``.shed.yml`` file.
     """
-    tsi = shed.tool_shed_client(ctx, **kwds)
+    shed_context = shed.get_shed_context(ctx, **kwds)
 
     def create(realized_repository):
-        repo_id = realized_repository.find_repository_id(ctx, tsi)
+        repo_id = realized_repository.find_repository_id(ctx, shed_context)
         if repo_id is None:
-            if realized_repository.create(ctx, tsi):
+            if realized_repository.create(ctx, shed_context):
                 info("Repository created")
                 if not kwds["skip_upload"]:
                     return shed.upload_repository(

--- a/planemo/commands/cmd_shed_download.py
+++ b/planemo/commands/cmd_shed_download.py
@@ -33,10 +33,10 @@ def cli(ctx, paths, **kwds):
     """Download a tool repository as a tarball from the tool shed and extract
     to the specified directory.
     """
-    tsi = shed.tool_shed_client(ctx, read_only=True, **kwds)
+    shed_context = shed.get_shed_context(ctx, read_only=True, **kwds)
 
     def download(realized_repository):
-        return shed.download_tarball(ctx, tsi, realized_repository, **kwds)
+        return shed.download_tarball(ctx, shed_context, realized_repository, **kwds)
 
     exit_code = shed.for_each_repository(ctx, download, paths, **kwds)
     sys.exit(exit_code)

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -49,7 +49,7 @@ def cli(ctx, paths, **kwds):
     The lower-level ``shed_upload`` command should be used instead if
     the repository doesn't define complete metadata in a ``.shed.yml``.
     """
-    tsi = shed.tool_shed_client(ctx, **kwds)
+    shed_context = shed.get_shed_context(ctx, **kwds)
 
     def update(realized_repository):
         upload_ret_code = 0
@@ -63,10 +63,10 @@ def cli(ctx, paths, **kwds):
             error("Failed to update repository it does not exist "
                   "in target ToolShed.")
             return upload_ret_code
-        repo_id = realized_repository.find_repository_id(ctx, tsi)
+        repo_id = realized_repository.find_repository_id(ctx, shed_context)
         metadata_ok = True
         if not kwds["skip_metadata"]:
-            metadata_ok = realized_repository.update(ctx, tsi, repo_id)
+            metadata_ok = realized_repository.update(ctx, shed_context, repo_id)
         if metadata_ok:
             info("Repository metadata updated.")
         else:

--- a/planemo/galaxy_config.py
+++ b/planemo/galaxy_config.py
@@ -133,7 +133,7 @@ def galaxy_config(ctx, tool_paths, for_tests=False, **kwds):
         database_location = config_join("galaxy.sqlite")
         shed_tools_path = config_join("shed_tools")
         sheds_config_path = _configure_sheds_config_file(
-            config_directory, **kwds
+            ctx, config_directory, **kwds
         )
         preseeded_database = True
         master_api_key = kwds.get("master_api_key", "test_key")
@@ -450,11 +450,11 @@ def _search_tool_path_for(path, target, extra_paths=[]):
     return None
 
 
-def _configure_sheds_config_file(config_directory, **kwds):
+def _configure_sheds_config_file(ctx, config_directory, **kwds):
     if "shed_target" not in kwds:
         kwds = kwds.copy()
         kwds["shed_target"] = "toolshed"
-    shed_target_url = tool_shed_url(kwds)
+    shed_target_url = tool_shed_url(ctx, **kwds)
     contents = _sub(TOOL_SHEDS_CONF, {"shed_target_url": shed_target_url})
     tool_sheds_conf = os.path.join(config_directory, "tool_sheds_conf.xml")
     write_file(tool_sheds_conf, contents)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -311,8 +311,8 @@ def shed_target_option():
         "-t",
         "--shed_target",
         help="Tool Shed to target (this can be 'toolshed', 'testtoolshed', "
-             "'local' (alias for http://localhost:9009/) or an arbitrary"
-             "url).",
+             "'local' (alias for http://localhost:9009/), an arbitrary url "
+             "or mappings defined ~/.planemo.yml.",
         default=None,
         callback=validate_shed_target_callback,
     )

--- a/tests/test_shed_operations.py
+++ b/tests/test_shed_operations.py
@@ -4,17 +4,17 @@ import os
 
 from .test_utils import (
     TEST_REPOS_DIR,
-    mock_shed_client,
+    mock_shed_context,
 )
 
 from planemo import shed
 
 
 def test_find_repository_id():
-    with mock_shed_client() as tsi:
+    with mock_shed_context() as shed_context:
         repo_id = shed.find_repository_id(
             ctx=None,
-            tsi=tsi,
+            shed_context=shed_context,
             path=".",
             name="test_repo_1",
             owner="iuc",
@@ -23,10 +23,10 @@ def test_find_repository_id():
 
 
 def test_find_repository_id_missing():
-    with mock_shed_client() as tsi:
+    with mock_shed_context() as shed_context:
         repo_id = shed.find_repository_id(
             ctx=None,
-            tsi=tsi,
+            shed_context=shed_context,
             path=".",
             name="test_repo_absent",
             owner="iuc",
@@ -36,12 +36,12 @@ def test_find_repository_id_missing():
 
 
 def test_find_repository_id_missing_exception():
-    with mock_shed_client() as tsi:
+    with mock_shed_context() as shed_context:
         exception = None
         try:
             shed.find_repository_id(
                 ctx=None,
-                tsi=tsi,
+                shed_context=shed_context,
                 path=".",
                 name="test_repo_absent",
                 owner="iuc"
@@ -52,28 +52,28 @@ def test_find_repository_id_missing_exception():
 
 
 def test_find_category_ids():
-    with mock_shed_client() as tsi:
+    with mock_shed_context() as shed_context:
         category_ids = shed.find_category_ids(
-            tsi,
+            shed_context.tsi,
             ["Text Manipulation"]
         )
         assert category_ids == ["c1"]
 
 
 def test_create_simple():
-    with mock_shed_client() as tsi:
+    with mock_shed_context() as shed_context:
         path = os.path.join(TEST_REPOS_DIR, "single_tool")
         repo_config = shed.shed_repo_config(path)
         create_response = shed.create_repository_for(
             None,
-            tsi,
+            shed_context.tsi,
             "single_tool",
             repo_config,
         )
         assert "id" in create_response
         repo_id = shed.find_repository_id(
             ctx=None,
-            tsi=tsi,
+            shed_context=shed_context,
             path=".",
             name="single_tool",
             owner="iuc"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,9 +142,9 @@ class CliShedTestCase(CliTestCase):
 
 
 @contextlib.contextmanager
-def mock_shed_client():
+def mock_shed_context():
     with mock_shed() as mock_shed_obj:
-        yield shed.tool_shed_client(shed_target=mock_shed_obj.url)
+        yield shed.get_shed_context(shed_target=mock_shed_obj.url)
 
 
 class TempDirectoryTestCase(TestCase):


### PR DESCRIPTION
Each shed section can now have a ``username`` which will be used in lieu of the top-level ``shed_username`` in that config. Each ``sheds`` keys can now specify a URL - existing sections (``toolshed``, ``testtoolshed``, and ``local``) will be assigned URLs automatically if they are specified and are somewhat special in that respect.

But new profiles can be created with arbitrary names and used in conjunction with ``--shed_target`` as described by @erasche here https://github.com/galaxyproject/planemo/pull/224#issuecomment-106058005.

All of planemo's unit tests pass - but I was hoping since many people have complained about this problem someone would volunteer to test this for me and report bugs.