### PR TITLE
Project Governance

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,34 +1,99 @@
-Contributor Code of Conduct
-===========================
+Planemo Project Code of Conduct
+===============================
 
-As contributors and maintainers of this project, we pledge to respect
-all people who contribute through reporting issues, posting feature
-requests, updating documentation, submitting pull requests or patches,
-and other activities.
+This code of conduct outlines our expectations for participants within the
+Planemo community, as well as steps to reporting unacceptable behavior. We are
+committed to providing a welcoming and inspiring community for all and expect
+our code of conduct to be honored. Anyone who violates this code of conduct may
+be banned from the community.
 
-We are committed to making participation in this project a
-harassment-free experience for everyone, regardless of level of
-experience, gender, gender identity and expression, sexual orientation,
-disability, personal appearance, body size, race, age, or religion.
+Our open source community strives to:
 
-Examples of unacceptable behavior by participants include the use of
-sexual language or imagery, derogatory comments or personal attacks,
-trolling, public or private harassment, insults, or other unprofessional
-conduct.
+* **Be friendly and patient.**
 
-Project maintainers have the right and responsibility to remove, edit,
-or reject comments, commits, code, wiki edits, issues, and other
-contributions that are not aligned to this Code of Conduct. Project
-maintainers or contributors who do not follow the Code of Conduct may be
-removed from the project team.
+* **Be welcoming**: We strive to be a community that welcomes and
+  supports people of all backgrounds and identities. This includes, but is not
+  limited to members of any race, ethnicity, culture, national origin, colour,
+  immigration status, social and economic class, educational level, sex, sexual
+  orientation, gender identity and expression, age, size, family status,
+  political belief, religion, and mental and physical ability.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by emailing `John Chilton <jmchilton@gmail.com>`__. To
-report an issue involving John Chilton please email both `Dave Clements 
-<mailto:clements@galaxyproject.org>`__ (the Outreach Coordinator for
-the Galaxy project) and `Anton Nekrutenko <mailto:anton@bx.psu.edu>`__
-(John Chilton's supervisor and a principle investigator for the Galaxy
-project).
+* **Be considerate**: Your work will be used by other people, and you in turn
+  will depend on the work of others. Any decision you take will affect users
+  and colleagues, and you should take those consequences into account when
+  making decisions. Remember that we're a world-wide community, so you might
+  not be communicating in someone else's primary language.
 
-This Code of Conduct is adapted from the `khmer Contributor Code of Conduct
-<https://github.com/ged-lab/khmer/blob/master/CODE_OF_CONDUCT.rst>`__.
+* **Be respectful**: Not all of us will agree all the time, but disagreement is
+  no excuse for poor behavior and poor manners. We might all experience some
+  frustration now and then, but we cannot allow that frustration to turn into a
+  personal attack. It’s important to remember that a community where people
+  feel uncomfortable or threatened is not a productive one.
+
+* **Be careful in the words that we choose**: We are a community of
+  professionals, and we conduct ourselves professionally. Be kind to others. Do
+  not insult or put down other participants. Harassment and other exclusionary
+  behavior aren't acceptable. This includes, but is not limited to: Violent
+  threats or language directed against another person, Discriminatory jokes and
+  language, Posting sexually explicit or violent material, Posting (or
+  threatening to post) other people’s personally identifying information
+  (“doxing”), Personal insults, especially those using racist or sexist terms,
+  Unwelcome sexual attention, Advocating for, or encouraging, any of the above
+  behavior, Repeated harassment of others. In general, if someone asks you to
+  stop, then stop.
+
+* **Try to understand why we disagree**: Disagreements, both social and
+  technical, happen all the time. It is important that we resolve disagreements
+  and differing views constructively. Remember that we’re different. Diversity
+  contributes to the strength of our community, which is composed of people
+  from a wide range of backgrounds. Different people have different
+  perspectives on issues. Being unable to understand why someone holds a
+  viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to
+  err and blaming each other doesn’t get us anywhere. Instead, focus on helping
+  to resolve issues and learning from mistakes.
+
+### Diversity Statement
+
+We encourage everyone to participate and are committed to building a community
+for all. Although we will fail at times, we seek to treat everyone both as
+fairly and equally as possible. Whenever a participant has made a mistake, we
+expect them to take responsibility for it. If someone has been harmed or
+offended, it is our responsibility to listen carefully and respectfully, and do
+our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age,
+gender, gender identity or expression, culture, ethnicity, language, national
+origin, political beliefs, profession, race, religion, sexual orientation,
+socioeconomic status, and technical ability. We will not tolerate
+discrimination based on any of the protected characteristics above, including
+participants with disabilities.
+
+### Reporting Issues
+
+If you experience or witness unacceptable behavior, or have any other concerns,
+please report it by contacting Dave Clements (clementsgalaxy@gmail.com). To
+report an issue involving Dave Clements please email James Taylor
+(james@taylorlab.org). All reports will be handled with discretion. In your
+report please include:
+
+- Your contact information.
+
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If there
+  are additional witnesses, please include them as well. Your account of what
+  occurred, and if you believe the incident is ongoing. If there is a publicly
+  available record (e.g. a mailing list archive or a public IRC logger), please
+  include a link.
+
+- Any additional information that may be helpful.
+
+After filing a report, a representative will contact you personally, review the
+incident, follow up with any additional questions, and make a decision as to
+how to respond. If the person who is harassing you is part of the response
+team, they will recuse themselves from handling your incident. If the complaint
+originates from a member of the response team, it will be handled by a
+different member of the response team. We will respect confidentiality requests
+for the purpose of protecting victims of abuse.
+
+### Attribution & Acknowledgements
+
+This code of conduct is based on the Open Code of Conduct from the TODOGroup.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Contents:
    commands
    conduct
    contributing
+   organization
    developing
    history
 

--- a/docs/organization.rst
+++ b/docs/organization.rst
@@ -1,0 +1,53 @@
+==================================
+Project Governance
+==================================
+
+This document informally outlines the organizational structure governing the
+Planemo code base hosted at https://github.com/galaxyproject/planemo. This
+governance extends to code-related activities of this repository such as
+releases and packaging and related Planemo projects such planemo-machine. This
+governance does not include any other Galaxy-related projects belonging to the
+``galaxyproject`` organization on GitHub.
+
+Benevolent Dictator for Now (BDFN)
+===================================
+
+John Chilton (@jmchilton) is the benevolent dictator for now (BDFN) and is solely
+responsible for setting project policy. The BDFN is responsible for maintaining
+the trust of the developer community and so should be consistent and
+transparent in decision making processes and request comment and build
+consensus whenever possible.
+
+The BDFN position only exists because the developers of the project believe it
+is currently too small to support full and open governance at this time. In
+order to keep things evolving quickly, it is better to keep procedures and
+process to a minimum and centralize important decisions with a trusted
+developer. The BDFN is explicitly meant to be replaced with a more formal and
+democratice process if the project grows to a sufficient size or importance.
+
+The *committers* group is the group of trusted developers and advocates who
+manage the Planemo code base. They assume many roles required to achieve
+the project's goals, especially those that require a high level of trust.
+
+The BDFN will add committers as he or she see fits, usually after a few
+successful pull requests. Committers may commit directly or merge pull
+requests at their discretion, but everyone (including the BDFN) should open
+pull requests for larger changes.
+
+In order to encourage a shared sense of ownership and openness, any committer
+may decide at any time to request a open governance model for the project be
+established and the BDFN must replace this informal policy with a more formal
+one and work with the project committers to establish a consensus on these
+procedures.
+
+Committers
+==============================
+
+- Dannon Baker (@dannon)
+- Martin Cech (@martenson)
+- John Chilton (@jmchilton)
+- Peter Cock (@peterjc)
+- Björn Grüning (@bgruening)
+- Eric Rasche (@erasche)
+- James Taylor (@jxtx)
+- Marius van den Beek (@mvdbeek)


### PR DESCRIPTION
 - Replace Planemo Code of Conducts with Galaxy's for consistency and because @tnabtaf is a better point person than me.
 - Add a [project governance](https://github.com/jmchilton/planemo/blob/coc/docs/organization.rst) document (tl;dr @jmchilton can do whatever he wants until someone cool asks him to stop).
