### PR TITLE
Capture stdout/stderr for shed_diff and shed_update XUnit reports

### DIFF
--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -132,8 +132,8 @@ def cli(ctx, paths, **kwds):
         xunit_case = {
             'classname': realized_repository.name,
             'time': (time2 - time1),
-            'stdout': [m['data'] for m in captured_std if m['logger'] == 'stdout'],
-            'stderr': [m['data'] for m in captured_std if m['logger'] == 'stderr'],
+            'stdout': [escape(m['data']) for m in captured_std if m['logger'] == 'stdout'],
+            'stderr': [escape(m['data']) for m in captured_std if m['logger'] == 'stderr'],
         }
         if result >= 200:
             collected_data['results']['errors'] += 1

--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -130,6 +130,7 @@ def cli(ctx, paths, **kwds):
         # Collect data about what happened
         collected_data['results']['total'] += 1
         xunit_case = {
+            'name': 'shed-diff',
             'classname': realized_repository.name,
             'time': (time2 - time1),
             'stdout': [escape(m['data']) for m in captured_std if m['logger'] == 'stdout'],
@@ -142,7 +143,6 @@ def cli(ctx, paths, **kwds):
                 'errorMessage': 'Error diffing repositories',
                 'errorContent': escape(diff_output_contents),
                 'time': (time2 - time1),
-                'name': 'shed-diff',
             })
         elif result > 2:
             collected_data['results']['failures'] += 1

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -79,11 +79,12 @@ def cli(ctx, paths, **kwds):
         upload_ok = True
 
         captured_io = {}
-        with captured_io_for_xunit(kwds, captured_io):
-            upload_ret_code = shed.upload_repository(
-                ctx, realized_repository, **kwds
-            )
-            upload_ok = not upload_ret_code
+        if not kwds["skip_upload"]:
+            with captured_io_for_xunit(kwds, captured_io):
+                upload_ret_code = shed.upload_repository(
+                    ctx, realized_repository, **kwds
+                )
+                upload_ok = not upload_ret_code
 
         # Now that we've uploaded (or skipped appropriately), collect results.
         if upload_ret_code == 2:

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -1,8 +1,6 @@
 """
 """
 import sys
-import time
-from xml.sax.saxutils import escape
 
 import click
 
@@ -11,7 +9,7 @@ from planemo import options
 from planemo import shed
 from planemo.io import info, error
 from planemo.reports import build_report
-from planemo.io import Capturing, tee_captured_output
+from planemo.io import captured_io_for_xunit
 
 
 @click.command("shed_update")
@@ -80,32 +78,12 @@ def cli(ctx, paths, **kwds):
         upload_ret_code = 0
         upload_ok = True
 
-        # Are they using XUnit reports
-        with_xunit = kwds.get('report_xunit', False)
-        # Set up in case they're using XUnit reports and we've captured all
-        # stdout/err
-        captured_std = []
-
-        # Start the time
-        time1 = time.time()
-        if not kwds["skip_upload"]:
-            if with_xunit:
-                # If the user is requesting an XUnit report they can live with
-                # boring/non-pretty stdout/err
-                with Capturing() as captured_std:
-                    upload_ret_code = shed.upload_repository(
-                        ctx, realized_repository, **kwds
-                    )
-                    tee_captured_output(captured_std)
-            else:
-                upload_ret_code = shed.upload_repository(
-                    ctx, realized_repository, **kwds
-                )
+        captured_io = {}
+        with captured_io_for_xunit(kwds, captured_io):
+            upload_ret_code = shed.upload_repository(
+                ctx, realized_repository, **kwds
+            )
             upload_ok = not upload_ret_code
-        time2 = time.time()
-
-        stdout = [escape(m['data']) for m in captured_std if m['logger'] == 'stdout']
-        stderr = [escape(m['data']) for m in captured_std if m['logger'] == 'stderr']
 
         # Now that we've uploaded (or skipped appropriately), collect results.
         if upload_ret_code == 2:
@@ -114,10 +92,10 @@ def cli(ctx, paths, **kwds):
                 'classname': realized_repository.name,
                 'errorType': 'FailedUpdate',
                 'errorMessage': 'Failed to update repository as it does not exist in target ToolShed',
-                'time': (time2 - time1),
+                'time': captured_io["time"],
                 'name': 'shed-update',
-                'stdout': stdout,
-                'stderr': stderr,
+                'stdout': captured_io["stdout"],
+                'stderr': captured_io["stderr"],
             })
             error("Failed to update repository it does not exist "
                   "in target ToolShed.")
@@ -134,10 +112,10 @@ def cli(ctx, paths, **kwds):
         if metadata_ok and upload_ok:
             collected_data['tests'].append({
                 'classname': realized_repository.name,
-                'time': (time2 - time1),
+                'time': captured_io["time"],
                 'name': 'shed-update',
-                'stdout': stdout,
-                'stderr': stderr,
+                'stdout': captured_io["stdout"],
+                'stderr': captured_io["stderr"],
             })
             return 0
         elif upload_ok:
@@ -146,10 +124,10 @@ def cli(ctx, paths, **kwds):
                 'classname': realized_repository.name,
                 'errorType': 'FailedMetadata',
                 'errorMessage': 'Failed to update repository metadata',
-                'time': (time2 - time1),
+                'time': captured_io["time"],
                 'name': 'shed-update',
-                'stdout': stdout,
-                'stderr': stderr,
+                'stdout': captured_io["stdout"],
+                'stderr': captured_io["stderr"],
             })
             error("Repo updated but metadata was not.")
             return 1
@@ -159,10 +137,10 @@ def cli(ctx, paths, **kwds):
                 'classname': realized_repository.name,
                 'errorType': 'FailedUpdate',
                 'errorMessage': 'Failed to update repository',
-                'time': (time2 - time1),
+                'time': captured_io["time"],
                 'name': 'shed-update',
-                'stdout': stdout,
-                'stderr': stderr,
+                'stdout': captured_io["stdout"],
+                'stderr': captured_io["stderr"],
             })
             error("Failed to update a repository.")
             return 1

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -2,6 +2,7 @@
 """
 import sys
 import time
+from xml.sax.saxutils import escape
 
 import click
 
@@ -103,8 +104,8 @@ def cli(ctx, paths, **kwds):
             upload_ok = not upload_ret_code
         time2 = time.time()
 
-        stdout = [m['data'] for m in captured_std if m['logger'] == 'stdout']
-        stderr = [m['data'] for m in captured_std if m['logger'] == 'stderr']
+        stdout = [escape(m['data']) for m in captured_std if m['logger'] == 'stdout']
+        stderr = [escape(m['data']) for m in captured_std if m['logger'] == 'stderr']
 
         # Now that we've uploaded (or skipped appropriately), collect results.
         if upload_ret_code == 2:

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -143,6 +143,10 @@ def captured_io_for_xunit(kwds, captured_io):
         captured_io["stdout"] = stdout
         captured_io["stderr"] = stderr
         captured_io["time"] = (time2 - time1)
+    else:
+        captured_io["stdout"] = None
+        captured_io["stderr"] = None
+        captured_io["time"] = None
 
 
 class Capturing(list):

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from __future__ import absolute_import
+
 import contextlib
 import os
 import shutil

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import tempfile
 import time
+from cStringIO import StringIO
 
 import click
 from galaxy.tools.deps import commands
@@ -114,3 +115,45 @@ def kill_posix(pid):
             time.sleep(1)
             if not _check_pid():
                 return
+
+
+class Capturing(list):
+    """Function context which captures stdout/stderr
+
+    This keeps planemo's codebase clean without requiring planemo to hold onto
+    messages, or pass user-facing messages back at all. This could probably be
+    solved by swapping planemo entirely to a logger and reading from/writing
+    to that, but this is easier.
+
+    This swaps sys.std{out,err} with StringIOs and then makes that output
+    available.
+    """
+    # http://stackoverflow.com/a/16571630
+
+    def __enter__(self):
+        self._stdout = sys.stdout
+        self._stderr = sys.stderr
+        sys.stdout = self._stringio_stdout = StringIO()
+        sys.stderr = self._stringio_stderr = StringIO()
+        return self
+
+    def __exit__(self, *args):
+        self.extend([{'logger': 'stdout', 'data': x} for x in
+                     self._stringio_stdout.getvalue().splitlines()])
+        self.extend([{'logger': 'stderr', 'data': x} for x in
+                     self._stringio_stderr.getvalue().splitlines()])
+
+        sys.stdout = self._stdout
+        sys.stderr = self._stderr
+
+
+def tee_captured_output(output):
+    """For messages captured with Capturing, send them to their correct
+    locations so as to not interfere with normal user experience.
+    """
+    for message in output:
+        # Append '\n' due to `splitlines()` above
+        if message['logger'] == 'stdout':
+            sys.stdout.write(message['data'] + '\n')
+        if message['logger'] == 'stderr':
+            sys.stderr.write(message['data'] + '\n')

--- a/planemo/reports/xunit.tpl
+++ b/planemo/reports/xunit.tpl
@@ -8,9 +8,17 @@
     <testcase classname="{{ testcase.classname }}" name="{{ testcase.name }}" time="{{ testcase.time }}">
         {% if 'errorType' in testcase %}
             <error type="planemo.{{ testcase.errorType }}" message="{{ testcase.errorMessage }}">
-            {{ testcase.errorContent }}
+                {{ testcase.errorContent }}
             </error>
         {% endif %}
+        <system-out>
+        {% for out in testcase.stdout %}{{ out }}
+        {% endfor %}
+        </system-out>
+        <system-err>
+        {% for err in testcase.stderr %}{{ err }}
+        {% endfor %}
+        </system-err>
     </testcase>
     {% endfor %}
 </testsuite>

--- a/tests/data/repos/multi_repos_nested.xunit-bad.xml
+++ b/tests/data/repos/multi_repos_nested.xunit-bad.xml
@@ -9,7 +9,11 @@
         Only in _local_: related_file
 
         </error>
+        <system-out />
+        <system-err />
     </testcase>
     <testcase classname="cat2" name="shed-diff" time="">
+        <system-out />
+        <system-err />
     </testcase>
 </testsuite>

--- a/tests/data/repos/multi_repos_nested.xunit.xml
+++ b/tests/data/repos/multi_repos_nested.xunit.xml
@@ -4,6 +4,26 @@
            errors="0"
            failures="0"
            skip="0">
-    <testcase classname="cat1" name="shed-diff" time=""/>
-    <testcase classname="cat2" name="shed-diff" time=""/>
+    <testcase classname="cat1" name="shed-diff" time="">
+        <system-out>
+        <!-- This will be stripped for reproducible tests -->
+            Diffing repository cat1
+            wget -q --recursive -O - 'http://localhost:57094/repository/download?repository_id=a7e8db1b-3713-419e-a848-366418a3a092&amp;changeset_revision=default&amp;file_type=gz' | tar -xzf - -C /tmp/tool_shed_diff_aB6CUR/_custom_shed_ --strip-components 1
+            mkdir "/tmp/tool_shed_diff_aB6CUR/_local_"; tar -xzf "/tmp/tmpIoaK5w" -C "/tmp/tool_shed_diff_aB6CUR/_local_"; rm -rf /tmp/tmpIoaK5w
+            cd "/tmp/tool_shed_diff_aB6CUR"; diff -r _local_ _custom_shed_ &gt;&gt; '/tmp/tmp0LSO1f'
+        </system-out>
+        <system-err>
+        </system-err>
+    </testcase>
+    <testcase classname="cat2" name="shed-diff" time="">
+        <system-out>
+        <!-- This will be stripped for reproducible tests -->
+            Diffing repository cat2
+            wget -q --recursive -O - 'http://localhost:59544/repository/download?repository_id=13be3240-154f-4b3d-bc18-55d7f9f04348&amp;changeset_revision=default&amp;file_type=gz' | tar -xzf - -C /tmp/tool_shed_diff_8uFMKd/_custom_shed_ --strip-components 1
+            mkdir "/tmp/tool_shed_diff_8uFMKd/_local_"; tar -xzf "/tmp/tmpr0_p32" -C "/tmp/tool_shed_diff_8uFMKd/_local_"; rm -rf /tmp/tmpr0_p32
+            cd "/tmp/tool_shed_diff_8uFMKd"; diff -r _local_ _custom_shed_ &gt;&gt; '/tmp/tmpHR6AlP'
+        </system-out>
+        <system-err>
+        </system-err>
+    </testcase>
 </testsuite>

--- a/tests/test_shed_diff.py
+++ b/tests/test_shed_diff.py
@@ -145,4 +145,10 @@ class ShedDiffTestCase(CliShedTestCase):
             if 'time' in x.attrib:
                 del x.attrib['time']
 
+            # Remove contents of stdout/stderr blocks
+            for y in x.findall('system-out'):
+                y.text = ""
+            for y in x.findall('system-err'):
+                y.text = ""
+
         return node


### PR DESCRIPTION
@jmchilton would you mind putting eyes to this if you have time? @martenson you might be interested in this as well.

# The Good

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="planemo-update"
           tests="1"
           errors="0"
           failures="1"
           skip="0">
    <testcase classname="seqtk" name="" time="6.95435190201">
            <error type="planemo.FailedUpdate" message="Failed to update repository">
            </error>
        <system-out>
        cd '/home/hxr/work/tools-iuc/tools/seqtk' &amp;&amp; git rev-parse HEAD
        cd '/home/hxr/work/tools-iuc/tools/seqtk' &amp;&amp; git diff --quiet
        </system-out>
        <system-err>
        Could not update seqtk
        Unexpected response from galaxy: 400: {"content_alert": "", "err_msg": "No changes to repository."}
        </system-err>
    </testcase>
</testsuite>
```

XUnit reports for shed_update and shed_diff will now contain stdout/stderr, and make those available to browse in Jenkins

# The Bad

Logs under `--report_xunit` are no longer pretty colours. They're boring black and white. Seems like an acceptable loss since you gain awesome XUnit reports.

If `--report_xunit` is not specified, tests are still colourful.

# The Ugly

This PR provides a small class called `planemo.io.Capturing` which lets you capture stdout/stderr for any function calls, and then process that data at your convenience. You don't have to rearchitect any of the existing infrastructure for logging user facing messages, you can just capture it and deal with it as you please. This code smells and it's pretty stinky. Instead of some way to handle message propagation properly and dispatching messages to handlers which care about them, we monkey patch `sys.std*`. I am not proud of this, but it solves the problem simply and quickly with very few changes.

The whole of `cmd_shed_update` and `cmd_shed_diff` are probably in dire need of a refactoring 