### PR TITLE
Try and handle UTF-8

### DIFF
--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -163,6 +163,7 @@ def cli(ctx, paths, **kwds):
     if kwds.get('report_xunit', False):
         with open(kwds['report_xunit'], 'w') as handle:
             handle.write(build_report.template_data(
-                collected_data, template_name='xunit.tpl'))
+                collected_data, template_name='xunit.tpl')
+                .encode('ascii', 'xmlcharrefreplace'))
 
     sys.exit(exit_code)

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -151,6 +151,7 @@ def cli(ctx, paths, **kwds):
     if kwds.get('report_xunit', False):
         with open(kwds['report_xunit'], 'w') as handle:
             handle.write(build_report.template_data(
-                collected_data, template_name='xunit.tpl'))
+                collected_data, template_name='xunit.tpl')
+                .encode('ascii', 'xmlcharrefreplace'))
 
     sys.exit(exit_code)


### PR DESCRIPTION
Planemo crashes at the very last step trying to output data. Here we encode to xml-safe ascii instead.