### PR TITLE
More complete I/O capturing.

### DIFF
--- a/planemo/commands/cmd_brew_init.py
+++ b/planemo/commands/cmd_brew_init.py
@@ -4,7 +4,7 @@ import urllib
 from tempfile import mkstemp
 
 from planemo.cli import pass_context
-from galaxy.tools.deps import commands
+from planemo.io import shell
 
 
 INSTALL_SCRIPT = "https://raw.github.com/Homebrew/linuxbrew/go/install"
@@ -24,4 +24,4 @@ def cli(ctx):
     """
     fname = mkstemp('install_brew')
     urllib.urlretrieve(INSTALL_SCRIPT, fname)
-    commands.execute(["ruby", fname])
+    shell(["ruby", fname])

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -18,12 +18,16 @@ from galaxy.tools.deps.commands import which
 def communicate(cmds, **kwds):
     info(cmds)
     p = commands.shell_process(cmds, **kwds)
-    ret_val = p.communicate()
+    if kwds.get("stdout", None) is None and commands.redirecting_io(sys=sys):
+        output = commands.redirect_aware_commmunicate(p)
+    else:
+        output = p.communicate()
+
     if p.returncode != 0:
         template = "Problem executing commands {0} - ({1}, {2})"
-        msg = template.format(cmds, ret_val[0], ret_val[1])
+        msg = template.format(cmds, output[0], output[1])
         raise RuntimeError(msg)
-    return ret_val
+    return output
 
 
 def shell(cmds, **kwds):

--- a/planemo_ext/galaxy/tools/deps/commands.py
+++ b/planemo_ext/galaxy/tools/deps/commands.py
@@ -1,16 +1,49 @@
 import os
 import subprocess
+import sys as _sys
+
+
+def redirecting_io(sys=_sys):
+    assert sys is not None
+    # We are redirecting standard out and standard error.
+    return not hasattr(sys.stdout, "fileno")
+
+
+def redirect_aware_commmunicate(p, sys=_sys):
+    assert sys is not None
+    out, err = p.communicate()
+    if redirecting_io(sys=sys):
+        if out:
+            sys.stdout.write(out)
+            out = None
+        if err:
+            sys.stderr.write(err)
+            err = None
+    return out, err
 
 
 def shell(cmds, env=None, **kwds):
+    sys = kwds.get("sys", _sys)
+    assert sys is not None
     p = shell_process(cmds, env, **kwds)
-    return p.wait()
+    if redirecting_io(sys=sys):
+        redirect_aware_commmunicate(p, sys=sys)
+        exit = p.returncode
+        return exit
+    else:
+        return p.wait()
 
 
 def shell_process(cmds, env=None, **kwds):
+    sys = kwds.get("sys", _sys)
     popen_kwds = dict(
         shell=True,
     )
+    if kwds.get("stdout", None) is None and redirecting_io(sys=sys):
+        popen_kwds["stdout"] = subprocess.PIPE
+    if kwds.get("stderr", None) is None and redirecting_io(sys=sys):
+        popen_kwds["stderr"] = subprocess.PIPE
+
     popen_kwds.update(**kwds)
     if env:
         new_env = os.environ.copy()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,22 @@
+from .test_utils import io
+
+
+def test_io_capture():
+    with io.conditionally_captured_io(True, tee=False) as capture:
+        io.warn("Problem...")
+    assert capture[0]["data"] == "Problem..."
+
+    with io.conditionally_captured_io(True, tee=False) as capture:
+        io.shell("echo 'Problem...'")
+    assert capture[0]["data"] == "echo 'Problem...'"
+    assert capture[1]["data"] == "Problem..."
+
+    with io.conditionally_captured_io(True, tee=False) as capture:
+        io.communicate("echo 'Problem...'")
+    assert capture[0]["data"] == "echo 'Problem...'"
+    assert capture[1]["data"] == "Problem..."
+
+    with io.conditionally_captured_io(False, tee=False) as capture:
+        io.communicate("echo 'Test...'")
+
+    assert capture is None


### PR DESCRIPTION
 - If I/O is captured, redirect I/O from subprocesses created with planemo.io.
 - Update Galaxy's commands.py to allow overriding sys object for I/O.
 - Eliminate one planemo call to Galaxy's commands.execute.

Ping @erasche ... just for a second set of eyes.