### PR TITLE
Fix an issue when you run shed_diff --shed_target local

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -290,7 +290,7 @@ def _diff_in(ctx, working, realized_repository, **kwds):
     path = realized_repository.path
     shed_target_source = kwds.get("shed_target_source", None)
 
-    label_a = "_%s_" % (shed_target_source if shed_target_source else "local")
+    label_a = "_%s_" % (shed_target_source if shed_target_source else "workingdir")
     shed_target = kwds.get("shed_target", "B")
     if "/" in shed_target:
         shed_target = "custom_shed"


### PR DESCRIPTION
Hi,

We are a developer team in Roscoff in France.

We have detected a bug when you run planemo shed_diff --shed_target local.
The directories, which are compared, have the same name _local_ for both files from the localtoolshed and files from the working tested directory.

BEFORE
```
$ planemo shed_diff -t local
Diffing repository package_fastme_1_0_0 
wget -q --recursive -O - 'http://localhost:9009/repository/download?repository_id=d9abeb98649a6a7e&changeset_revision=default&file_type=gz' | tar -xzf - -C /tmp/tool_shed_diff_bQBFCC/_local_ --strip-components 1
mkdir "/tmp/tool_shed_diff_bQBFCC/_local_"; tar -xzf "/tmp/tmpLl2Gh5" -C "/tmp/tool_shed_diff_bQBFCC/_local_"; rm -rf /tmp/tmpLl2Gh5
mkdir: cannot create directory `/tmp/tool_shed_diff_bQBFCC/_local_': File exists
[...]
  File "/usr/local/galaxy/galaxy/.venv/lib/python2.7/site-packages/planemo/shed/diff.py", line 11, in diff_and_remove
    assert label_a != label_b
```

We propose a fix changing the working tested directory name: _workingdir_ instead of _local_ 

AFTER
```
$ planemo shed_diff -t local
Diffing repository package_fastme_1_0_0 
wget -q --recursive -O - 'http://localhost:9009/repository/download?repository_id=d9abeb98649a6a7e&changeset_revision=default&file_type=gz' | tar -xzf - -C /tmp/tool_shed_diff_Jh4HoN/_local_ --strip-components 1
mkdir "/tmp/tool_shed_diff_Jh4HoN/_workingdir_"; tar -xzf "/tmp/tmpGHqMci" -C "/tmp/tool_shed_diff_Jh4HoN/_workingdir_"; rm -rf /tmp/tmpGHqMci
cd "/tmp/tool_shed_diff_Jh4HoN"; diff -r _workingdir_ _local_ >> '/tmp/tmpiX8fW2'
```

If you have any questions about this fix don't hesitate to contact us.

Cheers

Gwendoline Andres and Gildas Le Corguillé - ABiMS Roscoff - CNRS/UPMC - France

