### PR TITLE
If virtualenv not on PATH, have Planemo create one for Galaxy.

### DIFF
--- a/planemo/commands/cmd_virtualenv.py
+++ b/planemo/commands/cmd_virtualenv.py
@@ -1,0 +1,24 @@
+import click
+
+from planemo.cli import pass_context
+from planemo import virtualenv
+
+VIRTUALENV_PATH_TYPE = click.Path(
+    exists=False,
+    writable=True,
+    resolve_path=True,
+)
+
+
+@click.command("virtualenv")
+@click.argument("virtualenv_path",
+                metavar="VIRTUALENV_PATH",
+                type=VIRTUALENV_PATH_TYPE)
+@pass_context
+def cli(ctx, virtualenv_path):
+    """Create a virtualenv.
+
+    Use virtualenv as library to create a virtualenv for Galaxy if virtualenv
+    is not available on the PATH.
+    """
+    virtualenv.create_and_exit(virtualenv_path)

--- a/planemo/virtualenv.py
+++ b/planemo/virtualenv.py
@@ -1,0 +1,26 @@
+""" Utilities for using virtualenv as library and planemo command.
+"""
+from __future__ import absolute_import
+
+import os
+import sys
+
+import virtualenv
+from galaxy.tools.deps.commands import which
+
+
+def create_and_exit(virtualenv_path):
+    sys.argv = ["virtualenv", virtualenv_path]
+    return virtualenv.main()
+
+
+def create_command(virtualenv_path):
+    """ If virtualenv is on Planemo's path use it, otherwise use the planemo
+    subcommand virtualenv to create the virtualenv.
+    """
+    planemo_path = os.path.abspath(sys.argv[0])
+    virtualenv_on_path = which("virtualenv")
+    if virtualenv_on_path:
+        return " ".join([os.path.abspath(virtualenv_on_path), virtualenv_path])
+    else:
+        return " ".join([planemo_path, "virtualenv", virtualenv_path])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ docutils
 jinja2
 glob2
 cwltool
+virtualenv

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ requirements = [
     'PyGithub',
     'bioblend',
     'glob2',
+    'virtualenv',
 ]
 
 # Only import cwltool for Python 2.7.


### PR DESCRIPTION
http://dev.list.galaxyproject.org/Planemo-0-20-0-and-xunit-td4668334.html

Ping @natefoo, this seem like a reasonable approach?

$ cd project_templates/demo
$ which virtualenv
virtualenv not found
$ ../../.venv/bin/planemo s cat.xml
git --git-dir /home/john/.planemo/gx_repo fetch >/dev/null 2>&1
cd /tmp/tmpfBhxgp; git clone  --branch 'dev' '/home/john/.planemo/gx_repo' 'galaxy-dev'; cd galaxy-dev; if [ -d .venv ] || [ -f dist-eggs.ini ]; then GALAXY_VIRTUAL_ENV=.venv;  else GALAXY_VIRTUAL_ENV=/home/john/.planemo/gx_venv; fi; export GALAXY_VIRTUAL_ENV; if [ ! -e $GALAXY_VIRTUAL_ENV ]; then /home/john/workspace/planemo/.venv/bin/planemo virtualenv $GALAXY_VIRTUAL_ENV; fi; [ -e $GALAXY_VIRTUAL_ENV ] && . $GALAXY_VIRTUAL_ENV/bin/activate; COMMON_STARTUP_ARGS=; $(grep -q 'skip-venv' run_tests.sh) && COMMON_STARTUP_ARGS="--skip-venv --dev-wheels"; export COMMON_STARTUP_ARGS; echo "Set COMMON_STARTUP_ARGS to ${COMMON_STARTUP_ARGS}"; ./scripts/common_startup.sh ${COMMON_STARTUP_ARGS}
Cloning into 'galaxy-dev'...
done.
Using real prefix '/usr'
New python executable in /home/john/.planemo/gx_venv/bin/python
Installing setuptools, pip, wheel...done.
Set COMMON_STARTUP_ARGS to --skip-venv --dev-wheels
....