### PR TITLE
Target galaxyproject/galaxy master by default.

### DIFF
--- a/planemo/options.py
+++ b/planemo/options.py
@@ -180,6 +180,25 @@ def no_cache_galaxy_option():
     )
 
 
+def galaxy_branch_option():
+    return click.option(
+        "--galaxy_branch",
+        callback=get_default_callback(None),
+        help=("Branch of Galaxy to target (defaults to master) if a Galaxy "
+              "root isn't specified.")
+    )
+
+
+def galaxy_source_option():
+    return click.option(
+        "--galaxy_source",
+        callback=get_default_callback(None),
+        help=("Git source of Galaxy to target (defaults to the official "
+              "galaxyproject github source if a Galaxy root isn't "
+              "specified.")
+    )
+
+
 def brew_option():
     return click.option(
         "--brew",
@@ -532,6 +551,8 @@ def galaxy_target_options():
         galaxy_root_option(),
         galaxy_sqlite_database_option(),
         install_galaxy_option(),
+        galaxy_branch_option(),
+        galaxy_source_option(),
         no_cache_galaxy_option(),
         no_cleanup_option(),
         job_config_option(),


### PR DESCRIPTION
Planemo is growing up and needs to become more stable, fixes #383.

Make the Galaxy source and branch configurable for any option that may result in planemo intalling Galaxy. The branch can be specified with the --galaxy_branch CLI option or by specified default_galaxy_branch in ~/.planemo.yml. Likewise the github source can be specified with the --galaxy_source option or by specifing default_galaxy_source in ~/.planemo.yml file.