### PR TITLE
cast repo_id as string for shed compat

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -258,7 +258,7 @@ def upload_repository(ctx, realized_repository, **kwds):
     # TODO: support updating repo information if it changes in the config file
     try:
         shed_context.tsi.repositories.update_repository(
-            repo_id, tar_path, **update_kwds
+            str(repo_id), tar_path, **update_kwds
         )
     except Exception as e:
         message = api_exception_to_message(e)


### PR DESCRIPTION
Seriously the only thing :) Since repo_ids are now returned as `int`s rather thans `str`s, we cast them as a string and we're done.