### PR TITLE
Remove shell_exec

### DIFF
--- a/planemo/commands/cmd_conda_init.py
+++ b/planemo/commands/cmd_conda_init.py
@@ -22,5 +22,4 @@ def cli(ctx, **kwds):
     http://docs.continuum.io/anaconda/eula.
     """
     conda_context = build_conda_context(**kwds)
-    return conda_util.install_conda(conda_context=conda_context,
-                                    shell_exec=shell)
+    return conda_util.install_conda(conda_context=conda_contex)


### PR DESCRIPTION
Install conda do not have any `shell_exec` parameter anymore: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tools/deps/conda_util.py#L261