### PR TITLE
fix duplicated attributes

### DIFF
--- a/planemo/galaxy_config.py
+++ b/planemo/galaxy_config.py
@@ -693,7 +693,7 @@ def _handle_dependency_resolution(config_directory, kwds):
             attribute_key = "_".join(key.split("_")[1:])
             add_attribute(attribute_key, value)
 
-    if "prefix" not in attributes:
+    if not [attribute for attribute in attributes if "prefix" in attribute]:
         conda_context = build_conda_context(**kwds)
         add_attribute("prefix", conda_context.conda_prefix)
 


### PR DESCRIPTION
Remove one of the two prefix="" attributes from the `resolvers_conf.xml` which results in this error:
 
```
  File "/home/bag/projects/code/galaxy-test/lib/galaxy/tools/deps/__init__.py", line 44, in build_dependency_manager
    dependency_manager = DependencyManager( **dependency_manager_kwds )
  File "/home/bag/projects/code/galaxy-test/lib/galaxy/tools/deps/__init__.py", line 87, in __init__
    self.dependency_resolvers = self.__build_dependency_resolvers( conf_file )
  File "/home/bag/projects/code/galaxy-test/lib/galaxy/tools/deps/__init__.py", line 132, in __build_dependency_resolvers
    plugin_source = plugin_config.plugin_source_from_path( conf_file )
  File "/home/bag/projects/code/galaxy-test/lib/galaxy/util/plugin_config.py", line 74, in plugin_source_from_path
    return ('xml', ElementTree.parse( path ).getroot())
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1182, in parse
    tree.parse(source, parser)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 656, in parse
    parser.feed(data)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1642, in feed
    self._raiseerror(v)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1506, in _raiseerror
    raise err
xml.etree.ElementTree.ParseError: duplicate attribute: line 2, column 66
```