### PR TITLE
A bunch of fixes for shed_update.

### DIFF
--- a/tests/test_shed_upload.py
+++ b/tests/test_shed_upload.py
@@ -32,7 +32,13 @@ class ShedUploadTestCase(CliShedTestCase):
             upload_command.extend(self._shed_args())
             self._check_exit_code(upload_command, exit_code=2)
 
-    def test_upload_with_check_diff(self):
+    def test_update_not_exists_update_only(self):
+        with self._isolate_repo("single_tool"):
+            upload_command = ["shed_update", "--skip_upload"]
+            upload_command.extend(self._shed_args())
+            self._check_exit_code(upload_command, exit_code=2)
+
+    def test_update_with_check_diff(self):
         with self._isolate_repo("single_tool") as f:
             upload_command = [
                 "shed_update", "--force_repository_creation", "--check_diff"
@@ -53,7 +59,13 @@ class ShedUploadTestCase(CliShedTestCase):
             r = self._check_exit_code(upload_command)
             assert "not different, skipping upload." not in r.output
 
-    def test_upload_with_force_create(self):
+    def test_update_metadata_only(self):
+        with self._isolate_repo("single_tool"):
+            upload_command = ["shed_update", "--force_repository_creation", "--skip_upload"]
+            upload_command.extend(self._shed_args())
+            self._check_exit_code(upload_command)
+
+    def test_update_with_force_create(self):
         with self._isolate_repo("single_tool") as f:
             upload_command = ["shed_update", "--force_repository_creation"]
             upload_command.extend(self._shed_args())


### PR DESCRIPTION
 - bd9b9f5 fixed #416 
 - Add test for #416.
 - Previously ``--skip_upload`` and ``--force_repository_creation`` would not work together.
 - Ensure absent repository yields a consistent exit code of 2.
 - Message such as "Repo updated but metadata was not." would be printed if upload was skipped and metadata failed.