### PR TITLE
Review command-line handling framework toward consistency and extension.

### DIFF
--- a/planemo/commands/cmd_brew.py
+++ b/planemo/commands/cmd_brew.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``brew`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 
 from galaxy.tools.loader_directory import load_tool_elements_from_path
@@ -15,7 +15,7 @@ from galaxy.util import bunch
 @click.command('brew')
 @options.optional_tools_arg()
 @options.brew_option()
-@pass_context
+@command_function
 def cli(ctx, path, brew=None):
     """Install tool requirements using brew. (**Experimental**)
 

--- a/planemo/commands/cmd_brew_env.py
+++ b/planemo/commands/cmd_brew_env.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import click
 import os
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.io import ps1_for_path
 
@@ -22,7 +22,7 @@ from galaxy.util import bunch
     "--shell",
     is_flag=True
 )
-@pass_context
+@command_function
 def cli(ctx, path, brew=None, skip_install=False, shell=None):
     """Display commands used to modify environment to inject tool's brew
     dependencies.::

--- a/planemo/commands/cmd_brew_init.py
+++ b/planemo/commands/cmd_brew_init.py
@@ -4,7 +4,7 @@ import click
 import urllib
 from tempfile import mkstemp
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo.io import shell
 
 
@@ -12,7 +12,7 @@ INSTALL_SCRIPT = "https://raw.github.com/Homebrew/linuxbrew/go/install"
 
 
 @click.command('brew_init')
-@pass_context
+@command_function
 def cli(ctx):
     """Download linuxbrew install and run it with ruby. Linuxbrew is a fork
     of Homebrew (http://brew.sh/linuxbrew/).

--- a/planemo/commands/cmd_conda_env.py
+++ b/planemo/commands/cmd_conda_env.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 
 from planemo.io import ps1_for_path
@@ -34,7 +34,7 @@ alias conda_env_deactivate="source %s; %s"
 @options.optional_tools_arg()
 @options.conda_target_options()
 # @options.skip_install_option()  # TODO
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Source output to activate a conda environment for this tool.
 

--- a/planemo/commands/cmd_conda_init.py
+++ b/planemo/commands/cmd_conda_init.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``conda_init`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.conda import build_conda_context
 
@@ -10,7 +10,7 @@ from galaxy.tools.deps import conda_util
 
 @click.command('conda_init')
 @options.conda_target_options()
-@pass_context
+@command_function
 def cli(ctx, **kwds):
     """Download and install conda.
 

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``conda_install`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo.io import coalesce_return_codes
 from planemo import options
 
@@ -13,10 +13,9 @@ from galaxy.tools.deps import conda_util
 @click.command('conda_install')
 @options.optional_tools_arg()
 @options.conda_target_options()
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
-    """Install conda packages for tool requirements.
-    """
+    """Install conda packages for tool requirements."""
     conda_context = build_conda_context(**kwds)
     return_codes = []
     for conda_target in collect_conda_targets(path):

--- a/planemo/commands/cmd_create_gist.py
+++ b/planemo/commands/cmd_create_gist.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``create_gist`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo.io import info
 from planemo import github_util
 
@@ -24,7 +24,7 @@ target_path = click.Path(
     default="raw",
     help=("Link type to generate for the file.")
 )
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Download a tool repository as a tarball from the tool shed and extract
     to the specified directory.

--- a/planemo/commands/cmd_cwl_run.py
+++ b/planemo/commands/cmd_cwl_run.py
@@ -1,6 +1,6 @@
 """Module describing the planemo ``cwl_run`` command."""
 import click
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import cwl
 
@@ -19,7 +19,7 @@ from planemo import cwl
           "but the CWL reference implementation cwltool and be selected "
           "also.")
 )
-@pass_context
+@command_function
 def cli(ctx, path, job_path, **kwds):
     """Planemo command for running CWL tools and jobs.
 

--- a/planemo/commands/cmd_dependency_script.py
+++ b/planemo/commands/cmd_dependency_script.py
@@ -7,7 +7,7 @@ import click
 from xml.etree import ElementTree as ET
 
 from planemo.io import info, error
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 
 from planemo.shed2tap.base import BasePackage, Dependency
@@ -161,7 +161,7 @@ def process_tool_dependencies_xml(tool_dep, install_handle, env_sh_handle):
 @click.command('dependency_script')
 @options.shed_realization_options()
 @options.dependencies_script_options()
-@pass_context
+@command_function
 def cli(ctx, paths, recursive=False, fail_fast=True, download_cache=None):
     """Prepare a bash shell script to install tool requirements (**Experimental**)
 

--- a/planemo/commands/cmd_docker_build.py
+++ b/planemo/commands/cmd_docker_build.py
@@ -1,6 +1,6 @@
 """Module describing the planemo ``docker_build`` command."""
 import click
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.io import error
 
@@ -15,9 +15,9 @@ from galaxy.tools.deps import dockerfiles
 @options.docker_sudo_option()
 @options.docker_sudo_cmd_option()
 @options.docker_host_option()
-@pass_context
+@command_function
 def cli(ctx, path=".", dockerfile=None, **kwds):
-    """Builds (and optionally caches Docker images) for tool Dockerfiles.
+    """Build (and optionally cache Docker images) for tool Dockerfiles.
 
     Loads the tool or tools referenced by ``TOOL_PATH`` (by default all tools
     in current directory), and ensures they all reference the same Docker image

--- a/planemo/commands/cmd_docker_shell.py
+++ b/planemo/commands/cmd_docker_shell.py
@@ -13,7 +13,7 @@ such a tag from a Dockerfile located in the tool's directory.
 from __future__ import print_function
 import click
 import os
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 
 from galaxy.tools.loader import load_tool
@@ -40,7 +40,7 @@ from galaxy.tools.deps.requirements import parse_requirements_from_xml
 @options.docker_sudo_option()
 @options.docker_sudo_cmd_option()
 @options.docker_host_option()
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Launch a shell in the Docker container referenced by the specified
     tool. Prints a command to do this the way Galaxy would in job files it

--- a/planemo/commands/cmd_docs.py
+++ b/planemo/commands/cmd_docs.py
@@ -1,13 +1,13 @@
 """Module describing the planemo ``docs`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 
 SYNTAX_URL = "http://planemo.readthedocs.org/en/latest/"
 
 
 @click.command("syntax")
-@pass_context
+@command_function
 def cli(ctx, **kwds):
     """Open the Planemo documentation in a web browser."""
     click.launch(SYNTAX_URL)

--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 
 from planemo.tool_lint import build_lint_args
@@ -30,7 +30,7 @@ from planemo.tool_lint import lint_tools_on_path
 # help="If an sha256sum is available, download the entire file AND validate it.",
 # default=False,
 # )
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Check specified tool(s) for common errors and adherence to best
     practices.

--- a/planemo/commands/cmd_normalize.py
+++ b/planemo/commands/cmd_normalize.py
@@ -3,7 +3,7 @@ from xml.etree import ElementTree
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 
 from galaxy.tools.loader import (
@@ -35,7 +35,7 @@ from galaxy.tools.linters.xml_order import TAG_ORDER
           "best practices as part of this command, this flag will disable "
           "that behavior.")
 )
-@pass_context
+@command_function
 def cli(ctx, path, expand_macros=False, **kwds):
     """Generate normalized tool XML from input (breaks formatting).
 

--- a/planemo/commands/cmd_project_init.py
+++ b/planemo/commands/cmd_project_init.py
@@ -5,7 +5,7 @@ import shutil
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.io import (
     warn,
@@ -25,7 +25,7 @@ UNTAR_ARGS = " -C %s -zxf - " + UNTAR_FILTER
     '--template',
     default=None
 )
-@pass_context
+@command_function
 def cli(ctx, path, template=None, **kwds):
     """Initialize a new tool project (demo only right now).
     """

--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``serve`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo.galaxy import galaxy_serve
 from planemo import options
 
@@ -11,7 +11,7 @@ from planemo import options
 @options.galaxy_serve_options()
 @options.enable_cwl_option()
 @options.galaxy_cwl_root_option()
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Launch a Galaxy instance with the specified tool in the tool panel.
 

--- a/planemo/commands/cmd_share_test.py
+++ b/planemo/commands/cmd_share_test.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``share_test`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.io import info
 from planemo import github_util
@@ -14,7 +14,7 @@ PLANEMO_TEST_VIEWER_URL_TEMPLATE = (
 
 @click.command("share_test")
 @options.tool_test_json()
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Publish JSON test results to Github Gist and produce sharable URL.
 

--- a/planemo/commands/cmd_shed_build.py
+++ b/planemo/commands/cmd_shed_build.py
@@ -4,14 +4,14 @@ import sys
 import click
 import shutil
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 
 
 @click.command("shed_build")
 @options.optional_tools_arg(multiple=False)
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Create a Galaxy tool tarball from a ``.shed.yml`` file.
     """

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 from planemo.io import info
@@ -13,7 +13,7 @@ from planemo.io import info
 @options.shed_publish_options()
 @options.shed_message_option()
 @options.shed_skip_upload()
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Create a repository in a Galaxy Tool Shed from a ``.shed.yml`` file.
     """

--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -6,7 +6,7 @@ from xml.sax.saxutils import escape
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 from planemo.reports import build_report
@@ -35,7 +35,7 @@ from planemo.io import captured_io_for_xunit
          "populated by the Tool Shed.",
 )
 @options.report_xunit()
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Produce diff between local repository and Tool Shed contents.
 

--- a/planemo/commands/cmd_shed_download.py
+++ b/planemo/commands/cmd_shed_download.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 
@@ -27,7 +27,7 @@ target_path = click.Path(
          "created as shed_download_<name>.tar.gz by default for instance, "
          "simpler repositories will just be downloaded to the specified file."
 )
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Download a tool repository as a tarball from the tool shed and extract
     to the specified directory.

--- a/planemo/commands/cmd_shed_init.py
+++ b/planemo/commands/cmd_shed_init.py
@@ -2,7 +2,7 @@
 import click
 import sys
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 
 from planemo import options
 from planemo import shed
@@ -40,7 +40,7 @@ from planemo import shed
 )
 @options.shed_repo_options()
 @options.force_option()
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Bootstrap a new Tool Shed configuration (.shed.yml) file.
 

--- a/planemo/commands/cmd_shed_lint.py
+++ b/planemo/commands/cmd_shed_lint.py
@@ -2,7 +2,7 @@
 import click
 import sys
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 from planemo import shed_lint
@@ -38,7 +38,7 @@ from planemo import shed_lint
 #     help="If an sha256sum is available, download the entire file AND validate it.",
 #     default=False,
 # )
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Check a Tool Shed repository for common problems.
 

--- a/planemo/commands/cmd_shed_serve.py
+++ b/planemo/commands/cmd_shed_serve.py
@@ -2,7 +2,7 @@
 import time
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.galaxy import shed_serve
 from planemo import shed
@@ -17,7 +17,7 @@ from planemo import io
     is_flag=True,
     help="Do not install shed dependencies as part of repository installation."
 )
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """ Serve a transient Galaxy with published repositories installed.
 

--- a/planemo/commands/cmd_shed_test.py
+++ b/planemo/commands/cmd_shed_test.py
@@ -4,7 +4,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.galaxy.serve import shed_serve
 from planemo import shed
@@ -20,7 +20,7 @@ from planemo.galaxy.test import run_in_config
     is_flag=True,
     help="Do not install shed dependencies as part of repository installation."
 )
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """ Run tests of published shed artifacts.
 

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 from planemo.io import info, error
@@ -17,7 +17,7 @@ from planemo.io import captured_io_for_xunit
 @options.shed_upload_options()
 @options.shed_skip_upload()
 @options.shed_skip_metadata()
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Update repository in shed from a ``.shed.yml`` file.
 

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 
@@ -31,7 +31,7 @@ tar_path = click.Path(
     type=tar_path,
     default=None,
 )
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Low-level command for uploading tar balls to a shed.
 

--- a/planemo/commands/cmd_syntax.py
+++ b/planemo/commands/cmd_syntax.py
@@ -1,13 +1,13 @@
 """Module describing the planemo ``syntax`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 
 SYNTAX_URL = "https://wiki.galaxyproject.org/Admin/Tools/ToolConfigSyntax"
 
 
 @click.command("syntax")
-@pass_context
+@command_function
 def cli(ctx, **kwds):
     """Open tool config syntax wiki page in a web browser."""
     click.launch(SYNTAX_URL)

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.galaxy import galaxy_config
 
@@ -26,7 +26,7 @@ from planemo.galaxy.test import (
 @options.galaxy_target_options()
 @options.galaxy_config_options()
 @options.test_options()
-@pass_context
+@command_function
 def cli(ctx, paths, **kwds):
     """Run the tests in the specified tool tests in a Galaxy instance.
 

--- a/planemo/commands/cmd_test_reports.py
+++ b/planemo/commands/cmd_test_reports.py
@@ -3,7 +3,7 @@ import os
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import io
 from planemo import options
 from planemo.galaxy.test import StructuredData, handle_reports
@@ -12,7 +12,7 @@ from planemo.galaxy.test import StructuredData, handle_reports
 @click.command('test_reports')
 @options.tool_test_json()
 @options.test_report_options()
-@pass_context
+@command_function
 def cli(ctx, path, **kwds):
     """Generate various tool test reports (HTML, text, markdown) from
     structure output from tests (tool_test_output.json).

--- a/planemo/commands/cmd_tool_factory.py
+++ b/planemo/commands/cmd_tool_factory.py
@@ -2,14 +2,14 @@
 import os
 
 import click
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo.galaxy import serve
 
 
 @click.command('tool_factory')
 @options.galaxy_serve_options()
-@pass_context
+@command_function
 def cli(ctx, **kwds):
     """(Experimental) Launch Galaxy with the Tool Factory 2 available.
 

--- a/planemo/commands/cmd_tool_init.py
+++ b/planemo/commands/cmd_tool_init.py
@@ -4,7 +4,7 @@ import sys
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import options
 from planemo import io
 from planemo import tool_builder
@@ -190,7 +190,7 @@ REUSING_MACROS_MESSAGE = ("Macros file macros.xml already exists, assuming "
     help="Generate a macros.xml for reuse across many tools.",
 )
 @click.command("tool_init")
-@pass_context
+@command_function
 def cli(ctx, **kwds):
     """Generate a tool outline from supplied arguments.
     """

--- a/planemo/commands/cmd_travis_before_install.py
+++ b/planemo/commands/cmd_travis_before_install.py
@@ -4,7 +4,7 @@ import string
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo.io import shell
 
 SETUP_FILE_NAME = "setup_custom_dependencies.bash"
@@ -26,7 +26,7 @@ export PATH=$PATH:${BUILD_BIN_DIR}
 
 
 @click.command('travis_before_install')
-@pass_context
+@command_function
 def cli(ctx):
     """This command is used internally by planemo to assist in contineous testing
     of tools with Travis CI (https://travis-ci.org/).

--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -3,7 +3,7 @@ import os
 
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo.io import warn, info
 from planemo import options
 from planemo import RAW_CONTENT_URL
@@ -39,7 +39,7 @@ script:
 
 @click.command('travis_init')
 @options.optional_project_arg()
-@pass_context
+@command_function
 def cli(ctx, path):
     """Setup files in a github tool repository to enable continuous
     integration testing.::

--- a/planemo/commands/cmd_virtualenv.py
+++ b/planemo/commands/cmd_virtualenv.py
@@ -1,7 +1,7 @@
 """Module describing the planemo ``virtualenv`` command."""
 import click
 
-from planemo.cli import pass_context
+from planemo.cli import command_function
 from planemo import virtualenv
 
 VIRTUALENV_PATH_TYPE = click.Path(
@@ -17,7 +17,7 @@ VIRTUALENV_PATH_TYPE = click.Path(
 @click.argument("virtualenv_path",
                 metavar="VIRTUALENV_PATH",
                 type=VIRTUALENV_PATH_TYPE)
-@pass_context
+@command_function
 def cli(ctx, virtualenv_path, **kwds):
     """Create a virtualenv.
 

--- a/planemo/config.py
+++ b/planemo/config.py
@@ -1,41 +1,98 @@
+"""Module defines abstractions for configuring Planemo."""
 import os
 import yaml
+
+import aenum
+import click
 
 PLANEMO_CONFIG_ENV_PROP = "PLANEMO_GLOBAL_CONFIG_PATH"
 DEFAULT_CONFIG = {
 }
 
+VALUE_UNSET = object()
 
-def get_default_callback(default, name=None, resolve_path=False):
+
+OptionSource = aenum.Enum(
+    "OptionSource", 'cli global_config default'
+)
+
+
+def _default_callback(
+    default, use_global_config=False, resolve_path=False,
+):
 
     def callback(ctx, param, value):
         planemo_ctx = ctx.obj
-        config_name = name
-        if config_name is None:
-            config_name = param.name
+        param_name = param.name
+        if value is not None:
+            result = value
+            option_source = OptionSource.cli
+        else:
+            result, option_source = _find_default(
+                planemo_ctx,
+                param,
+                use_global_config=use_global_config,
+            )
 
-        result = _default_option(planemo_ctx, config_name, value, default)
-        if resolve_path and result:
+        if result is VALUE_UNSET:
+            result = default
+            option_source = OptionSource.default
+
+        assert option_source is not None
+        assert result is not VALUE_UNSET
+
+        if resolve_path and result is not None:
             result = os.path.abspath(result)
+
+        planemo_ctx.set_option_source(param_name, option_source)
         return result
 
     return callback
 
 
-def _default_option(ctx, kwd_key, kwd_value, default):
-    value = kwd_value
-
-    if value is None:
+def _find_default(ctx, param, use_global_config):
+    if use_global_config:
         global_config = ctx.global_config
-        global_config_key = "default_%s" % kwd_key
+        global_config_key = "default_%s" % param.name
         if global_config_key in global_config:
             default_value = global_config[global_config_key]
-        else:
-            default_value = default
+            return default_value, OptionSource.global_config
 
-        value = default_value
+    return VALUE_UNSET, None
 
-    return value
+
+def planemo_option(*args, **kwargs):
+    """Extend ``click.option`` with planemo-config aware configuration.
+
+    This extends click.option to use a callback when assigning default
+    values, add ``use_global_config`` keyword argument to allow reading
+    defaults from ~/.planemo.yml, and tracks how parameters are specified
+    using the Planemo Context object.
+    """
+    option_type = kwargs.get("type", None)
+    use_global_config = kwargs.pop("use_global_config", False)
+
+    if "default" in kwargs:
+        default = kwargs.pop("default")
+        outer_callback = kwargs.pop("callback", None)
+
+        def callback(ctx, param, value):
+            resolve_path = option_type and getattr(option_type, "resolve_path", False)
+            result = _default_callback(
+                default,
+                use_global_config=use_global_config,
+                resolve_path=resolve_path,
+            )(ctx, param, value)
+
+            if outer_callback is not None:
+                result = outer_callback(ctx, param, result)
+
+            return result
+
+        kwargs["callback"] = callback
+        kwargs["default"] = None
+
+    return click.option(*args, **kwargs)
 
 
 def global_config_path(config_path=None):
@@ -60,5 +117,5 @@ def read_global_config(config_path):
 __all__ = [
     "global_config_path",
     "read_global_config",
-    "get_default_callback",
+    "planemo_option",
 ]

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -8,11 +8,11 @@ import os
 
 import click
 from galaxy.tools.deps import docker_util
-from .config import get_default_callback
+from .config import planemo_option
 
 
 def force_option(what="files"):
-    return click.option(
+    return planemo_option(
         "-f",
         "--force",
         is_flag=True,
@@ -21,7 +21,7 @@ def force_option(what="files"):
 
 
 def skip_venv_option():
-    return click.option(
+    return planemo_option(
         "--skip_venv",
         is_flag=True,
         help=("Do not create or source a virtualenv environment for Galaxy, "
@@ -31,7 +31,7 @@ def skip_venv_option():
 
 
 def test_data_option():
-    return click.option(
+    return planemo_option(
         "--test_data",
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
         help="test-data directory to for specified tool(s).",
@@ -39,7 +39,7 @@ def test_data_option():
 
 
 def tool_data_table_option():
-    return click.option(
+    return planemo_option(
         "--tool_data_table",
         type=click.Path(exists=True, file_okay=True, resolve_path=True),
         help="tool_data_table_conf.xml file to for specified tool(s).",
@@ -47,7 +47,7 @@ def tool_data_table_option():
 
 
 def galaxy_root_option():
-    return click.option(
+    return planemo_option(
         "--galaxy_root",
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
         help="Root of development galaxy directory to execute command with.",
@@ -55,17 +55,19 @@ def galaxy_root_option():
 
 
 def galaxy_sqlite_database_option():
-    return click.option(
+    return planemo_option(
         "--galaxy_sqlite_database",
-        callback=get_default_callback(None, resolve_path=True),
+        default=None,
+        use_global_config=True,
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
         help="Preseeded Galaxy sqlite database to target.",
     )
 
 
 def galaxy_cwl_root_option():
-    return click.option(
+    return planemo_option(
         "--cwl_galaxy_root",
+        use_global_config=True,
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
         help=("Root of development galaxy directory to execute command with"
               " (must be branch of Galaxy with CWL support, this option"
@@ -75,21 +77,21 @@ def galaxy_cwl_root_option():
 
 
 def galaxy_port_option():
-    return click.option(
+    return planemo_option(
         "--port",
         type=int,
-        default=None,
-        callback=get_default_callback("9090"),
+        default="9090",
+        use_global_config=True,
         help="Port to serve Galaxy on (default is 9090).",
     )
 
 
 def galaxy_host_option():
-    return click.option(
+    return planemo_option(
         "--host",
         type=str,
-        default=None,
-        callback=get_default_callback("127.0.0.1"),
+        default="127.0.0.1",
+        use_global_config=True,
         help=("Host to bind Galaxy to. Default is 127.0.0.1 that is "
               "restricted to localhost connections for security reasons "
               "set to 0.0.0.0 to bind Galaxy to all ports including "
@@ -98,7 +100,7 @@ def galaxy_host_option():
 
 
 def dependency_resolvers_option():
-    return click.option(
+    return planemo_option(
         "--dependency_resolvers_config_file",
         type=click.Path(
             exists=True,
@@ -106,12 +108,13 @@ def dependency_resolvers_option():
             dir_okay=False,
             resolve_path=True
         ),
+        use_global_config=True,
         help="Dependency resolver configuration for Galaxy to target.",
     )
 
 
 def enable_cwl_option():
-    return click.option(
+    return planemo_option(
         "--cwl",
         is_flag=True,
         help=("Configure Galaxy for use with CWL tool."
@@ -121,7 +124,7 @@ def enable_cwl_option():
 
 
 def cwl_conformance_test():
-    return click.option(
+    return planemo_option(
         "--conformance-test",
         is_flag=True,
         help=("Generate CWL conformance test object describing job. "
@@ -131,7 +134,7 @@ def cwl_conformance_test():
 
 
 def brew_dependency_resolution():
-    return click.option(
+    return planemo_option(
         "--brew_dependency_resolution",
         is_flag=True,
         help="Configure Galaxy to use plain brew dependency resolution.",
@@ -139,7 +142,7 @@ def brew_dependency_resolution():
 
 
 def conda_dependency_resolution():
-    return click.option(
+    return planemo_option(
         "--conda_dependency_resolution",
         is_flag=True,
         help="Configure Galaxy to use only conda for dependency resolution.",
@@ -147,7 +150,7 @@ def conda_dependency_resolution():
 
 
 def shed_dependency_resolution():
-    return click.option(
+    return planemo_option(
         "--shed_dependency_resolution",
         is_flag=True,
         help=("Configure Galaxy to use brewed Tool Shed dependency"
@@ -156,7 +159,7 @@ def shed_dependency_resolution():
 
 
 def job_config_option():
-    return click.option(
+    return planemo_option(
         "--job_config_file",
         type=click.Path(
             exists=True,
@@ -165,12 +168,13 @@ def job_config_option():
             resolve_path=True
         ),
         help="Job configuration file for Galaxy to target.",
-        callback=get_default_callback(None),
+        default=None,
+        use_global_config=True,
     )
 
 
 def tool_dependency_dir_option():
-    return click.option(
+    return planemo_option(
         "--tool_dependency_dir",
         type=click.Path(
             exists=True,
@@ -178,12 +182,13 @@ def tool_dependency_dir_option():
             dir_okay=True,
             resolve_path=True
         ),
+        use_global_config=True,
         help="Tool dependency dir for Galaxy to target.",
     )
 
 
 def install_galaxy_option():
-    return click.option(
+    return planemo_option(
         "--install_galaxy",
         is_flag=True,
         help="Download and configure a disposable copy of Galaxy from github."
@@ -191,7 +196,7 @@ def install_galaxy_option():
 
 
 def no_cache_galaxy_option():
-    return click.option(
+    return planemo_option(
         "--no_cache_galaxy",
         is_flag=True,
         help=("Skip caching of Galaxy source and dependencies obtained with "
@@ -202,18 +207,20 @@ def no_cache_galaxy_option():
 
 
 def galaxy_branch_option():
-    return click.option(
+    return planemo_option(
         "--galaxy_branch",
-        callback=get_default_callback(None),
+        default=None,
+        use_global_config=True,
         help=("Branch of Galaxy to target (defaults to master) if a Galaxy "
               "root isn't specified.")
     )
 
 
 def galaxy_source_option():
-    return click.option(
+    return planemo_option(
         "--galaxy_source",
-        callback=get_default_callback(None),
+        default=None,
+        use_global_config=True,
         help=("Git source of Galaxy to target (defaults to the official "
               "galaxyproject github source if a Galaxy root isn't "
               "specified.")
@@ -221,7 +228,7 @@ def galaxy_source_option():
 
 
 def skip_install_option():
-    return click.option(
+    return planemo_option(
         "--skip_install",
         is_flag=True,
         help="Skip installation - only source requirements already available."
@@ -229,31 +236,34 @@ def skip_install_option():
 
 
 def brew_option():
-    return click.option(
+    return planemo_option(
         "--brew",
+        use_global_config=True,
         type=click.Path(exists=True, file_okay=True, dir_okay=False),
         help="Homebrew 'brew' executable to use."
     )
 
 
 def conda_prefix_option():
-    return click.option(
+    return planemo_option(
         "--conda_prefix",
+        use_global_config=True,
         type=click.Path(file_okay=False, dir_okay=True),
         help="Conda prefix to use for conda dependency commands."
     )
 
 
 def conda_exec_option():
-    return click.option(
+    return planemo_option(
         "--conda_exec",
+        use_global_config=True,
         type=click.Path(exists=True, file_okay=True, dir_okay=False),
         help="Location of conda executable."
     )
 
 
 def conda_debug_option():
-    return click.option(
+    return planemo_option(
         "--conda_debug",
         is_flag=True,
         help="Enable more verbose conda logging."
@@ -261,9 +271,10 @@ def conda_debug_option():
 
 
 def conda_ensure_channels_option():
-    return click.option(
+    return planemo_option(
         "--conda_ensure_channels",
         type=str,
+        use_global_config=True,
         help=("Ensure conda is configured with specified comma separated "
               "list of channels."),
         default="r,bioconda"
@@ -271,7 +282,7 @@ def conda_ensure_channels_option():
 
 
 def conda_copy_dependencies_option():
-    return click.option(
+    return planemo_option(
         "--conda_copy_dependencies",
         is_flag=True,
         help=("Conda dependency resolution for Galaxy will copy dependencies "
@@ -280,7 +291,7 @@ def conda_copy_dependencies_option():
 
 
 def conda_auto_install_option():
-    return click.option(
+    return planemo_option(
         "--conda_auto_install",
         is_flag=True,
         help=("Conda dependency resolution for Galaxy will auto install "
@@ -289,7 +300,7 @@ def conda_auto_install_option():
 
 
 def conda_auto_init_option():
-    return click.option(
+    return planemo_option(
         "--conda_auto_init",
         is_flag=True,
         help=("Conda dependency resolution for Galaxy will auto install "
@@ -401,7 +412,7 @@ def optional_project_arg(exists=True):
 
 
 def no_cleanup_option():
-    return click.option(
+    return planemo_option(
         "--no_cleanup",
         is_flag=True,
         help=("Do not cleanup temp files created for and by Galaxy.")
@@ -409,7 +420,7 @@ def no_cleanup_option():
 
 
 def docker_cmd_option():
-    return click.option(
+    return planemo_option(
         "--docker_cmd",
         default=docker_util.DEFAULT_DOCKER_COMMAND,
         help="Command used to launch docker (defaults to docker)."
@@ -417,7 +428,7 @@ def docker_cmd_option():
 
 
 def docker_sudo_option():
-    return click.option(
+    return planemo_option(
         "--docker_sudo",
         is_flag=True,
         help="Flag to use sudo when running docker."
@@ -425,34 +436,34 @@ def docker_sudo_option():
 
 
 def docker_sudo_cmd_option():
-    return click.option(
+    return planemo_option(
         "--docker_sudo_cmd",
-        default=None,
         help="sudo command to use when --docker_sudo is enabled " +
              "(defaults to sudo).",
-        callback=get_default_callback(docker_util.DEFAULT_SUDO_COMMAND),
+        default=docker_util.DEFAULT_SUDO_COMMAND,
+        use_global_config=True,
     )
 
 
 def docker_host_option():
-    return click.option(
+    return planemo_option(
         "--docker_host",
-        default=None,
         help="Docker host to target when executing docker commands " +
              "(defaults to localhost).",
-        callback=get_default_callback(docker_util.DEFAULT_HOST),
+        use_global_config=True,
+        default=docker_util.DEFAULT_HOST,
     )
 
 
 def shed_owner_option():
-    return click.option(
+    return planemo_option(
         "--owner",
         help="Tool Shed repository owner (username)."
     )
 
 
 def shed_name_option():
-    return click.option(
+    return planemo_option(
         "--name",
         help="Tool Shed repository name (defaults to the inferred "
              "tool directory name)."
@@ -460,27 +471,27 @@ def shed_name_option():
 
 
 def validate_shed_target_callback(ctx, param, value):
-    target = get_default_callback("toolshed")(ctx, param, value)
-    if target is None:
+    if value is None:
         ctx.fail("default_shed_target set to None, must specify a value for "
                  "--shed_target to run this command.")
-    return target
+    return value
 
 
 def shed_target_option():
-    return click.option(
+    return planemo_option(
         "-t",
         "--shed_target",
         help="Tool Shed to target (this can be 'toolshed', 'testtoolshed', "
              "'local' (alias for http://localhost:9009/), an arbitrary url "
              "or mappings defined ~/.planemo.yml.",
         default=None,
+        use_global_config=True,
         callback=validate_shed_target_callback,
     )
 
 
 def shed_key_option():
-    return click.option(
+    return planemo_option(
         "--shed_key",
         help=("API key for Tool Shed access. An API key is required unless "
               "e-mail and password is specified. This key can be specified "
@@ -489,14 +500,14 @@ def shed_key_option():
 
 
 def shed_key_from_env_option():
-    return click.option(
+    return planemo_option(
         "--shed_key_from_env",
         help="Environment variable to read API key for Tool Shed access from."
     )
 
 
 def shed_email_option():
-    return click.option(
+    return planemo_option(
         "--shed_email",
         help="E-mail for Tool Shed auth (required unless shed_key is "
              "specified)."
@@ -504,7 +515,7 @@ def shed_email_option():
 
 
 def shed_password_option():
-    return click.option(
+    return planemo_option(
         "--shed_password",
         help="Password for Tool Shed auth (required unless shed_key is "
              "specified)."
@@ -512,7 +523,7 @@ def shed_password_option():
 
 
 def shed_skip_upload():
-    return click.option(
+    return planemo_option(
         "--skip_upload",
         is_flag=True,
         help=("Skip upload contents as part of operation, only update "
@@ -521,7 +532,7 @@ def shed_skip_upload():
 
 
 def shed_skip_metadata():
-    return click.option(
+    return planemo_option(
         "--skip_metadata",
         is_flag=True,
         help=("Skip metadata update as part of operation, only upload "
@@ -530,7 +541,7 @@ def shed_skip_metadata():
 
 
 def shed_message_option():
-    return click.option(
+    return planemo_option(
         "-m",
         "--message",
         help="Commit message for tool shed upload."
@@ -538,7 +549,7 @@ def shed_message_option():
 
 
 def shed_force_create_option():
-    return click.option(
+    return planemo_option(
         "--force_repository_creation",
         help=("If a repository cannot be found for the specified user/repo "
               "name pair, then automatically create the repository in the "
@@ -549,7 +560,7 @@ def shed_force_create_option():
 
 
 def shed_check_diff_option():
-    return click.option(
+    return planemo_option(
         "--check_diff",
         is_flag=True,
         help=("Skip uploading if the shed_diff detects there would be no "
@@ -671,7 +682,7 @@ def galaxy_serve_options():
 
 
 def shed_fail_fast_option():
-    return click.option(
+    return planemo_option(
         "--fail_fast",
         is_flag=True,
         default=False,
@@ -681,7 +692,7 @@ def shed_fail_fast_option():
 
 
 def lint_xsd_option():
-    return click.option(
+    return planemo_option(
         "--xsd",
         is_flag=True,
         default=False,
@@ -691,7 +702,7 @@ def lint_xsd_option():
 
 
 def report_level_option():
-    return click.option(
+    return planemo_option(
         "--report_level",
         type=click.Choice(["all", "warn", "error"]),
         default="all",
@@ -699,7 +710,7 @@ def report_level_option():
 
 
 def report_xunit():
-    return click.option(
+    return planemo_option(
         "--report_xunit",
         type=click.Path(file_okay=True, resolve_path=True),
         help="Output an XUnit report, useful for CI testing",
@@ -708,7 +719,7 @@ def report_xunit():
 
 
 def skip_option():
-    return click.option(
+    return planemo_option(
         "-s",
         "--skip",
         default=None,
@@ -719,7 +730,7 @@ def skip_option():
 
 
 def fail_level_option():
-    return click.option(
+    return planemo_option(
         "--fail_level",
         type=click.Choice(['warn', 'error']),
         default="warn"
@@ -733,7 +744,7 @@ def recursive_shed_option():
 
 
 def recursive_option(help="Recursively perform command for subdirectories."):
-    return click.option(
+    return planemo_option(
         "-r",
         "--recursive",
         is_flag=True,
@@ -757,26 +768,25 @@ def tool_test_json():
 
 def test_report_options():
     return _compose(
-        click.option(
+        planemo_option(
             "--test_output",
             type=click.Path(file_okay=True, resolve_path=True),
-            callback=get_default_callback("tool_test_output.html",
-                                          resolve_path=True),
+            use_global_config=True,
+            default="tool_test_output.html",
             help=("Output test report (HTML - for humans) defaults to "
                   "tool_test_output.html."),
-            default=None,
         ),
-        click.option(
+        planemo_option(
             "--test_output_text",
             type=click.Path(file_okay=True, resolve_path=True),
-            callback=get_default_callback(None, resolve_path=True),
+            use_global_config=True,
             help=("Output test report (Basic text - for display in CI)"),
             default=None,
         ),
-        click.option(
+        planemo_option(
             "--test_output_markdown",
             type=click.Path(file_okay=True, resolve_path=True),
-            callback=get_default_callback(None, resolve_path=True),
+            use_global_config=True,
             help=("Output test report (Markdown style - for humans & "
                   "computers)"),
             default=None,
@@ -786,36 +796,34 @@ def test_report_options():
 
 def test_options():
     return _compose(
-        click.option(
+        planemo_option(
             "--update_test_data",
             is_flag=True,
             help="Update test-data directory with job outputs (normally"
                  " written to directory --job_output_files if specified.)"
         ),
         test_report_options(),
-        click.option(
+        planemo_option(
             "--test_output_xunit",
             type=click.Path(file_okay=True, resolve_path=True),
-            callback=get_default_callback(None, resolve_path=True),
+            use_global_config=True,
             help="Output test report (xUnit style - for computers).",
-            default=None,
         ),
-        click.option(
+        planemo_option(
             "--test_output_json",
             type=click.Path(file_okay=True, resolve_path=True),
-            callback=get_default_callback("tool_test_output.json",
-                                          resolve_path=True),
+            use_global_config=True,
             help=("Output test report (planemo json) defaults to "
                   "tool_test_output.json."),
-            default=None,
+            default="tool_test_output.json",
         ),
-        click.option(
+        planemo_option(
             "--job_output_files",
             type=click.Path(file_okay=False, resolve_path=True),
             help="Write job outputs to specified directory.",
             default=None,
         ),
-        click.option(
+        planemo_option(
             "--summary",
             type=click.Choice(["none", "minimal", "compact"]),
             default="minimal",
@@ -834,10 +842,10 @@ def _compose(*functions):
 
 def dependencies_script_options():
     return _compose(
-        click.option(
+        planemo_option(
             "--download_cache",
             type=click.Path(file_okay=False, resolve_path=True),
-            callback=get_default_callback(None),
+            use_global_config=True,
             help=("Directory to cache downloaded files, default is $DOWNLOAD_CACHE"),
             default=None,
         ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aenum
 Click
 six>=1.7.0
 pyyaml


### PR DESCRIPTION
 - Implement a wrapper around ``click.option`` that handles global config consistently without having to deal with callbacks directly in ``planemo.options``.
 - Implement tracking of how options are set (command-line, global config, or default).
 - Replace command decorator ``pass_context`` with a new decorator that performs the context pass but provides an entry point for more sophisticated command-line hanlding in the future (will use for Galaxy profiles).
 - Improvements to docstrings.
 - Allow new options to be globally configured with defaults in ~/.planemo.yml including afew conda options.
 - Add aenum as a project dependency for tracking option sources.