### PR TITLE
fix --no_cache_galaxy

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -587,7 +587,9 @@ def _install_galaxy(ctx, config_directory, env, kwds):
 def _install_galaxy_via_download(ctx, config_directory, env, kwds):
     branch = _galaxy_branch(kwds)
     tar_cmd = "tar -zxvf %s" % branch
-    command = DOWNLOAD_GALAXY + "; %s | tail" % tar_cmd
+    command = DOWNLOAD_GALAXY + "%s; %s | tail" % (branch, tar_cmd)
+    if branch != "dev":
+        command = command + "; ln -s galaxy-%s galaxy-dev" % (branch)
     _install_with_command(ctx, config_directory, command, env, kwds)
 
 

--- a/planemo/galaxy/run.py
+++ b/planemo/galaxy/run.py
@@ -23,7 +23,7 @@ PRINT_VENV_COMMAND = shell_join(
 
 # TODO: Mac-y curl variant of this.
 DOWNLOAD_GALAXY = (
-    "wget https://codeload.github.com/galaxyproject/galaxy/tar.gz/dev"
+    "wget https://codeload.github.com/galaxyproject/galaxy/tar.gz/"
 )
 
 CACHED_VIRTUAL_ENV_COMMAND = ("if [ -d .venv ] || [ -f dist-eggs.ini ];"


### PR DESCRIPTION
I was integrating planemo in some travis test. And I observed an issue when I used the --no_cache_galaxy: https://github.com/workflow4metabolomics/anova/blob/master/.travis.yml

```
planemo test --install_galaxy --no_cache_galaxy
cd /tmp/tmphuaDkk; wget https://codeload.github.com/galaxyproject/galaxy/tar.gz/dev; tar -zxvf master | tail; cd galaxy-dev;
[...]
tar (child): master: Cannot open: No such file or directory
```
planemo download the dev archive (hard code) but try to in a folder named master (kind of argument).


```
planemo test --install_galaxy --no_cache_galaxy --galaxy_branch "dev"
```

In this case, it works

So I integrated the branch name in the DOWNLOAD_GALAXY URL.
But because the galaxy-dev folder is everywhere I propose an ugly-quick&durty symlink :/