### PR TITLE
Try to shorten config_directory path

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -143,6 +143,16 @@ def galaxy_config(ctx, tool_paths, for_tests=False, **kwds):
     if not config_directory:
         created_config_directory = True
         config_directory = mkdtemp()
+        # the following makes sure the transient config_dir path is short
+        # enough for conda linking (https://github.com/conda/conda-build/pull/877)
+        if len(config_directory) > 20:
+            try:
+                short_config_directory = mkdtemp(dir="/tmp")
+                os.rmdir(config_directory)
+                config_directory = short_config_directory
+            except OSError:
+                # path doesn't exist or permission denied, keep the long config_dir
+                pass
     try:
         latest_galaxy = False
         install_env = {}


### PR DESCRIPTION
This circumvents 
```
Error: ERROR: placeholder '/Users/aaronmeurer/anaconda/envs/_build_placehold_placehold_placehold_placehold_' too short in: ncurses-5.9-1
```  
for me.

Conda has limitations in the length of the placeholder path. This can be easily used up on OSX, since OSX provides a long tmpdir path (/var/folders/56/g35vb5h14_v0d6chwtfxvdfr0000gn/T/). If that is the 
case, we can try to use mkdtemp with the /tmp directory.
May also be a workaround for #433.