### PR TITLE
Infrastructure and docs for building and linting CWL tools

### DIFF
--- a/docs/_writing_cwl_intro.rst
+++ b/docs/_writing_cwl_intro.rst
@@ -1,0 +1,102 @@
+The Basics
+====================================================
+
+.. include:: _writing_using_seqtk.rst
+
+Common Workflow Language tool files are just simple YAML_ files, so at this point
+one could just open a text editor and start implementing the tool. Planemo has a
+command ``tool_init`` to quickly generate a skeleton to work from, so let's
+start by doing that.
+
+::
+
+    $ planemo tool_init --cwl --id 'seqtk_seq' --name 'Convert to FASTA (seqtk)'
+
+The ``tool_init`` command can take various complex arguments - but three two
+most basic ones are shown above ``--cwl``, ``--id`` and ``--name``. The ``--cwl``
+flag simply tells Planemo to generate a Common Workflow Language tool. ``--id`` is
+a short identifier for this tool and it should be unique across all tools.
+``--name`` is a short, human-readable name for the the tool - it corresponds
+to the ``label`` attribute in the CWL tool document.
+
+The above command will generate the file ``seqtk_seq.cwl`` - which should look
+like this.
+
+.. literalinclude:: writing/seqtk_seq_v1.cwl
+   :language: yaml
+
+This tool file has the common fields required for a CWL tool with TODO notes,
+but you will still need to open up the editor and fill out the command, describe
+input parameters, tool outputs, writeup a help section, etc....
+
+The ``tool_init`` command can do a little bit better than this as well. We can
+use the test command we tried above ``seqtk seq -a 2.fastq > 2.fasta`` as
+an example to generate a command block by specifing the inputs and the outputs
+as follows.
+
+::
+
+    $ planemo tool_init --force \
+                        --cwl \
+                        --id 'seqtk_seq' \
+                        --name 'Convert to FASTA (seqtk)' \
+                        --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                        --example_input 2.fastq \
+                        --example_output 2.fasta
+
+This will generate the following CWL tool definition - which now has correct
+definitions for the input, output, and command specified. These represent a best
+guess by planemo, and in most cases will need to be tweaked manually after the
+tool is generated.
+
+.. literalinclude:: writing/seqtk_seq_v2.cwl
+   :language: yaml
+
+.. include:: _writing_from_help_command.rst
+
+::
+
+    $ planemo tool_init --force \
+                        --cwl \
+                        --id 'seqtk_seq' \
+                        --name 'Convert to FASTA (seqtk)' \
+                        --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                        --example_input 2.fastq \
+                        --example_output 2.fasta
+                        --help_from_command 'seqtk seq'
+
+This command generates the following CWL YAML file.
+
+.. literalinclude:: writing/seqtk_seq_v3.cwl
+   :language: yaml
+
+.. include:: _writing_lint_intro.rst
+
+::
+
+    $ planemo l seqtk_seq.cwl
+    Linting tool /home/john/workspace/planemo/docs/writing/seqtk_seq.cwl
+    Applying linter general... CHECK
+    .. CHECK: Tool defines a version [0.0.1].
+    .. CHECK: Tool defines a name [Convert to FASTA (seqtk)].
+    .. CHECK: Tool defines an id [seqtk_seq_v3].
+    Applying linter cwl_validation... CHECK
+    .. INFO: CWL appears to be valid.
+    Applying linter docker_image... WARNING
+    .. WARNING: Tool does not specify a DockerPull source.
+    Applying linter new_draft... CHECK
+    .. INFO: Modern CWL version [cwl:draft-3]
+    Failed linting
+
+Here the linting failed because we have not yet defined a Docker image for the
+the tool. A later revision of this document will cover specifying a Docker image
+for this tool with the ``--container`` argument and discuss defining more
+parameters for this tool.
+
+For more information on the Common Workflow Language check out the Draft 3
+`User Guide`_ and Specification_.
+
+.. _YAML: http://yaml.org/
+.. _User Guide: http://www.commonwl.org/draft-3/UserGuide.html
+.. _Specification: http://www.commonwl.org/draft-3/CommandLineTool.html
+

--- a/docs/_writing_from_help_command.rst
+++ b/docs/_writing_from_help_command.rst
@@ -1,0 +1,10 @@
+As shown at the beginning of this section, the command ``seqtk seq`` generates
+a help message for the ``seq`` command. ``tool_init`` can take that help message and 
+stick it right in the generated tool file using the ``help_from_command`` option. 
+
+Generally command help messages aren't exactly appropriate for tools
+since they mention argument names and simillar details that are abstracted
+away by the tool - but they can be an excellent place to start.
+
+The following planemo ``tool_init`` call has been enhanced to use ``--help_from_command``.
+

--- a/docs/_writing_intro.rst
+++ b/docs/_writing_intro.rst
@@ -1,56 +1,11 @@
 The Basics
 ====================================================
 
-This guide is going to demonstrate building up Galaxy tools wrappers for
-commands from Heng Li's Seqtk_ package - a package for processing sequence
-data in FASTA and FASTQ files. For fully worked through Seqtk wrappers -
-checkout Eric Rasche's `wrappers <https://github.com/galaxyproject/tools-
-iuc/tree/master/tools/seqtk>`_ on Github.
+.. include:: _writing_using_seqtk.rst
 
-To get started let's install Seqtk, download an example FASTQ file, and test
-out the a simple Seqtk command - ``seq`` which converts FASTQ files into
-FASTA. Here we are going to use ``brew`` to install seqtk - but however you
-obtain it should be fine.
-
-::
-
-    $ brew tap homebrew/science
-    $ brew install seqtk
-    ==> Installing seqtk from homebrew/homebrew-science
-    ==> Downloading https://github.com/lh3/seqtk/archive/73866e7.tar.gz
-    ######################################################################## 100.0%
-    ==> make
-    /home/john/.linuxbrew/Cellar/seqtk/1.0-r68: 3 files, 208K, built in 2 seconds
-    $ wget https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/2.fastq
-    $ seqtk seq
-
-        Usage:   seqtk seq [options] <in.fq>|<in.fa>
-
-        Options: -q INT    mask bases with quality lower than INT [0]
-                 -X INT    mask bases with quality higher than INT [255]
-                 -n CHAR   masked bases converted to CHAR; 0 for lowercase [0]
-                 -l INT    number of residues per line; 0 for 2^32-1 [0]
-                 -Q INT    quality shift: ASCII-INT gives base quality [33]
-                 -s INT    random seed (effective with -f) [11]
-                 -f FLOAT  sample FLOAT fraction of sequences [1]
-                 -M FILE   mask regions in BED or name list FILE [null]
-                 -L INT    drop sequences with length shorter than INT [0]
-                 -c        mask complement region (effective with -M)
-                 -r        reverse complement
-                 -A        force FASTA output (discard quality)
-                 -C        drop comments at the header lines
-                 -N        drop sequences containing ambiguous bases
-                 -1        output the 2n-1 reads only
-                 -2        output the 2n reads only
-                 -V        shift quality by '(-Q) - 33'
-    $ seqtk seq -a 2.fastq > 2.fasta
-    $ cat 2.fasta
-    >EAS54_6_R1_2_1_413_324
-    CCCTTCTTGTCTTCAGCGTTTCTCC
-    >EAS54_6_R1_2_1_540_792
-    TTGGCAGGCCAAGGCCGATGGATCA
-    >EAS54_6_R1_2_1_443_348
-    GTTGCTTCTGGCGTGGGTGGGGGGG
+For fully worked through Seqtk wrappers - checkout Eric Rasche's
+`wrappers <https://github.com/galaxyproject/tools-iuc/tree/master/tools/seqtk>`__
+on Github.
 
 Galaxy tool files are just simple XML files, so at this point one could just
 open a text editor and start implementing the tool. Planemo has a command
@@ -74,7 +29,7 @@ like this.
 .. literalinclude:: writing/seqtk_seq_v1.xml
    :language: xml
 
-This tool file has the common sections required for Galaxy tool but you will
+This tool file has the common sections required for a Galaxy tool but you will
 still need to open up the editor and fill out the command template, describe
 input parameters, tool outputs, writeup a help section, etc....
 
@@ -100,12 +55,7 @@ definitions for the input and output as well as an actual command template.
    :language: xml
    :emphasize-lines: 8-16
 
-As shown above the command ``seqtk seq`` generates a help message for the
-``seq`` command. ``tool_init`` can take that help message and stick it right
-in the generated tool file using the ``help_from_command`` option. Generally
-command help messages aren't exactly appropriate for Galaxy tool wrappers
-since they mention argument names and simillar details that are abstracted
-away by the tool - but they can be a good place to start.
+.. include:: _writing_from_help_command.rst
 
 ::
 
@@ -120,18 +70,15 @@ away by the tool - but they can be a good place to start.
                         --cite_url 'https://github.com/lh3/seqtk' \
                         --help_from_command 'seqtk seq'
 
+In addition to demonstrating ``--help_from_command``, this demonstrates generating
+a test case from our example with ``--test_case`` and additing a citation for the
+underlying tool. The resulting tool XML file is:
+
 .. literalinclude:: writing/seqtk_seq_v3.xml
    :language: xml
    :emphasize-lines: 17-58
 
-At this point we have a fairly a functional tool with test and help. This was
-a pretty simple example - usually you will need to put more work into the tool
-XML to get to this point - ``tool_init`` is really just designed to get you
-started.
-
-Now lets lint and test the tool we have developed. The planemo ``lint`` (or
-just ``l``) command will reviews tools for obvious mistakes and compliance
-with best practices.
+.. include:: _writing_lint_intro.rst
 
 ::
 
@@ -164,4 +111,3 @@ command. This will print a lot of output but should ultimately reveal our one
 test passed.
 
 .. _DOI: http://www.doi.org/
-.. _Seqtk: https://github.com/lh3/seqtk

--- a/docs/_writing_lint_intro.rst
+++ b/docs/_writing_lint_intro.rst
@@ -1,0 +1,8 @@
+At this point we have a fairly a functional tool with test and help. This was
+a pretty simple example - usually you will need to put more work into the tool
+to get to this point - ``tool_init`` is really just designed to get you
+started.
+
+Now lets lint and test the tool we have developed. The planemo ``lint`` (or
+just ``l``) command will reviews tools for obvious mistakes and compliance
+with best practices.

--- a/docs/_writing_using_seqtk.rst
+++ b/docs/_writing_using_seqtk.rst
@@ -1,0 +1,52 @@
+This guide is going to demonstrate building up tools for commands from Heng
+Li's Seqtk_ package - a package for processing sequence data in FASTA_ and
+FASTQ_ files.
+
+To get started let's install Seqtk, download an example FASTQ file, and test
+out the a simple Seqtk command - ``seq`` which converts FASTQ files into
+FASTA. Here we are going to use ``brew`` to install Seqtk - but however you
+obtain it should be fine.
+
+::
+
+    $ brew tap homebrew/science
+    $ brew install seqtk
+    ==> Installing seqtk from homebrew/homebrew-science
+    ==> Downloading https://github.com/lh3/seqtk/archive/73866e7.tar.gz
+    ######################################################################## 100.0%
+    ==> make
+    /home/john/.linuxbrew/Cellar/seqtk/1.0-r68: 3 files, 208K, built in 2 seconds
+    $ wget https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/2.fastq
+    $ seqtk seq
+
+        Usage:   seqtk seq [options] <in.fq>|<in.fa>
+
+        Options: -q INT    mask bases with quality lower than INT [0]
+                 -X INT    mask bases with quality higher than INT [255]
+                 -n CHAR   masked bases converted to CHAR; 0 for lowercase [0]
+                 -l INT    number of residues per line; 0 for 2^32-1 [0]
+                 -Q INT    quality shift: ASCII-INT gives base quality [33]
+                 -s INT    random seed (effective with -f) [11]
+                 -f FLOAT  sample FLOAT fraction of sequences [1]
+                 -M FILE   mask regions in BED or name list FILE [null]
+                 -L INT    drop sequences with length shorter than INT [0]
+                 -c        mask complement region (effective with -M)
+                 -r        reverse complement
+                 -A        force FASTA output (discard quality)
+                 -C        drop comments at the header lines
+                 -N        drop sequences containing ambiguous bases
+                 -1        output the 2n-1 reads only
+                 -2        output the 2n reads only
+                 -V        shift quality by '(-Q) - 33'
+    $ seqtk seq -a 2.fastq > 2.fasta
+    $ cat 2.fasta
+    >EAS54_6_R1_2_1_413_324
+    CCCTTCTTGTCTTCAGCGTTTCTCC
+    >EAS54_6_R1_2_1_540_792
+    TTGGCAGGCCAAGGCCGATGGATCA
+    >EAS54_6_R1_2_1_443_348
+    GTTGCTTCTGGCGTGGGTGGGGGGG
+
+.. _Seqtk: https://github.com/lh3/seqtk
+.. _FASTA: https://en.wikipedia.org/wiki/FASTA_format
+.. _FASTQ: https://en.wikipedia.org/wiki/FASTQ_format

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents:
    configuration
    appliance
    writing
+   writing_cwl
    publishing
    commands
    standards/docs/best_practices

--- a/docs/writing/gen.sh
+++ b/docs/writing/gen.sh
@@ -18,5 +18,29 @@ planemo tool_init --force \
                   --example_input 2.fastq \
                   --example_output 2.fasta \
                   --test_case \
+                  --cite_url 'https://github.com/lh3/seqtk' \
                   --help_from_command 'seqtk seq'
 mv seqtk_seq.xml seqtk_seq_v3.xml
+
+
+planemo tool_init --cwl --id 'seqtk_seq' --name 'Convert to FASTA (seqtk)'
+mv seqtk_seq.cwl seqtk_seq_v1.cwl
+
+planemo tool_init --force \
+                  --cwl \
+                  --id 'seqtk_seq' \
+                  --name 'Convert to FASTA (seqtk)' \
+                  --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                  --example_input 2.fastq \
+                  --example_output 2.fasta
+mv seqtk_seq.cwl seqtk_seq_v2.cwl
+
+planemo tool_init --force \
+                  --cwl \
+                  --id 'seqtk_seq' \
+                  --name 'Convert to FASTA (seqtk)' \
+                  --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                  --example_input 2.fastq \
+                  --example_output 2.fasta \
+                  --help_from_command 'seqtk seq'                  
+mv seqtk_seq.cwl seqtk_seq_v3.cwl

--- a/docs/writing/seqtk_seq_v1.cwl
+++ b/docs/writing/seqtk_seq_v1.cwl
@@ -1,0 +1,11 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: 'cwl:draft-3'
+class: CommandLineTool
+id: "seqtk_seq"
+label: "Convert to FASTA (seqtk)"
+inputs: [] # TODO
+outputs: [] # TODO
+baseCommand: []
+arguments: []
+description: |
+   TODO: Fill in description.

--- a/docs/writing/seqtk_seq_v2.cwl
+++ b/docs/writing/seqtk_seq_v2.cwl
@@ -1,0 +1,25 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: 'cwl:draft-3'
+class: CommandLineTool
+id: "seqtk_seq"
+label: "Convert to FASTA (seqtk)"
+inputs:
+  - id: input1
+    type: File
+    description: |
+      TODO
+    inputBinding:
+      position: 1
+      prefix: "-a"
+outputs:
+  - id: output1
+    type: File
+    outputBinding:
+      glob: out
+baseCommand:
+  - "seqtk"
+  - "seq"
+arguments: []
+stdout: out
+description: |
+   TODO: Fill in description.

--- a/docs/writing/seqtk_seq_v3.cwl
+++ b/docs/writing/seqtk_seq_v3.cwl
@@ -1,0 +1,46 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: 'cwl:draft-3'
+class: CommandLineTool
+id: "seqtk_seq"
+label: "Convert to FASTA (seqtk)"
+inputs:
+  - id: input1
+    type: File
+    description: |
+      TODO
+    inputBinding:
+      position: 1
+      prefix: "-a"
+outputs:
+  - id: output1
+    type: File
+    outputBinding:
+      glob: out
+baseCommand:
+  - "seqtk"
+  - "seq"
+arguments: []
+stdout: out
+description: |
+  
+  Usage:   seqtk seq [options] <in.fq>|<in.fa>
+  
+  Options: -q INT    mask bases with quality lower than INT [0]
+           -X INT    mask bases with quality higher than INT [255]
+           -n CHAR   masked bases converted to CHAR; 0 for lowercase [0]
+           -l INT    number of residues per line; 0 for 2^32-1 [0]
+           -Q INT    quality shift: ASCII-INT gives base quality [33]
+           -s INT    random seed (effective with -f) [11]
+           -f FLOAT  sample FLOAT fraction of sequences [1]
+           -M FILE   mask regions in BED or name list FILE [null]
+           -L INT    drop sequences with length shorter than INT [0]
+           -c        mask complement region (effective with -M)
+           -r        reverse complement
+           -A        force FASTA output (discard quality)
+           -C        drop comments at the header lines
+           -N        drop sequences containing ambiguous bases
+           -1        output the 2n-1 reads only
+           -2        output the 2n reads only
+           -V        shift quality by '(-Q) - 33'
+           -U        convert all bases to uppercases
+  

--- a/docs/writing_appliance.rst
+++ b/docs/writing_appliance.rst
@@ -15,7 +15,7 @@ for obtaining the virtual appliance if you have not done so already.
 .. include:: _writing_suites.rst
 .. include:: _writing_conclusion.rst
 
-.. _Galaxy: (http://galaxyproject.org/)
+.. _Galaxy: http://galaxyproject.org/
 .. _GitHub: https://github.com/
 .. _Docker: https://www.docker.com/
 .. _Homebrew: http://brew.sh/

--- a/docs/writing_cwl.rst
+++ b/docs/writing_cwl.rst
@@ -1,0 +1,20 @@
+=======================================
+Building Common Workflow Language Tools
+=======================================
+
+The following links are for the same tutorial describing the basics of how to
+build `Common Workflow Language`_ tools. The first variant is tailored to local
+development environments (e.g. if Planemo has been installed with ``brew`` or ``pip``) and
+the second is for developers using a dedicated Planemo `virtual appliance
+<https://planemo.readthedocs.org/en/latest/appliance.html>`_ (available for
+Docker_, Vagrant_, etc...).
+
+.. toctree::
+
+   ...using Planemo <writing_cwl_standalone>
+   ...using a Planemo Virtual Appliance <writing_cwl_appliance>
+
+.. _Common Workflow Language: http://www.commonwl.org/
+.. _Galaxy: http://galaxyproject.org/
+.. _Docker: https://www.docker.com/
+.. _Vagrant: https://www.vagrantup.com/

--- a/docs/writing_cwl_appliance.rst
+++ b/docs/writing_cwl_appliance.rst
@@ -1,0 +1,17 @@
+======================================================================
+Building Common Workflow Language Tools (Using the Planemo Appliance)
+======================================================================
+
+This tutorial is a gentle introduction to writing `Common Workflow Language`_
+tools using the Planemo virtual appliance  (available for Docker_ and Vagrant_).
+Check out ` these instructions <https://planemo.readthedocs.org/en/latest/appliance.html>`__
+for obtaining the virtual appliance if you have not done so already.
+
+.. include:: _writing_cwl_intro.rst
+
+.. _Common Workflow Language: http://www.commonwl.org/
+.. _GitHub: https://github.com/
+.. _Docker: https://www.docker.com/
+.. _Homebrew: http://brew.sh/
+.. _linuxbrew: https://github.com/Homebrew/linuxbrew
+.. _Vagrant: https://www.vagrantup.com/

--- a/docs/writing_cwl_standalone.rst
+++ b/docs/writing_cwl_standalone.rst
@@ -1,0 +1,17 @@
+=====================================================
+Building Common Workflow Language Tools Using Planemo
+=====================================================
+
+This tutorial is a gentle introduction to writing `Common Workflow Language`_ tools using Planemo_. Please read the `installation instructions
+<http://planemo.readthedocs.org/en/latest/installation.html>`__ for Planemo_
+if you have not already installed it.
+
+.. include:: _writing_cwl_intro.rst
+
+.. _Common Workflow Language: http://www.commonwl.org/
+.. _GitHub: https://github.com/
+.. _Docker: https://www.docker.com/
+.. _Homebrew: http://brew.sh/
+.. _linuxbrew: https://github.com/Homebrew/linuxbrew
+.. _Vagrant: https://www.vagrantup.com/
+.. _Planemo: http://planemo.readthedocs.org/

--- a/docs/writing_standalone.rst
+++ b/docs/writing_standalone.rst
@@ -14,7 +14,7 @@ if you have not already installed it.
 .. include:: _writing_suites.rst
 .. include:: _writing_conclusion.rst
 
-.. _Galaxy: (http://galaxyproject.org/)
+.. _Galaxy: http://galaxyproject.org/
 .. _GitHub: https://github.com/
 .. _Docker: https://www.docker.com/
 .. _Homebrew: http://brew.sh/

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -147,6 +147,14 @@ def enable_cwl_option():
     )
 
 
+def build_cwl_option():
+    return planemo_option(
+        "--cwl",
+        is_flag=True,
+        help="Build a CWL tool instead of a Galaxy tool.",
+    )
+
+
 def cwl_conformance_test():
     return planemo_option(
         "--conformance-test",

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -1,5 +1,9 @@
+from collections import namedtuple
+import shlex
 import subprocess
+
 from planemo import templates
+from planemo import io
 
 
 TOOL_TEMPLATE = """<tool id="{{id}}" name="{{name}}" version="{{version}}">
@@ -123,12 +127,135 @@ MACROS_TEMPLATE = """<macros>
 """
 
 
+CWL_TEMPLATE = """#!/usr/bin/env cwl-runner
+cwlVersion: '{{cwl_version}}'
+class: CommandLineTool
+id: "{{id}}"
+label: "{{label}}"
+{%- if containers %}
+requirements:
+{%- for container in containers %}
+  - class: DockerRequirement
+    dockerPull: {{ container.image_id }}
+{%- endfor %}
+{%- endif %}
+{%- if inputs or outputs %}
+inputs:
+{%- for input in inputs %}
+  - id: {{ input.id }}
+    type: File
+    description: |
+      TODO
+    inputBinding:
+      position: {{ input.position }}
+{%- if input.prefix %}
+      prefix: "{{input.prefix.prefix}}"
+{%- if not input.prefix.separated %}
+      separate: false
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+{%- for output in outputs %}
+{%- if output.require_filename %}
+  - id: {{ output.id }}
+    type: string
+    description: |
+      Filename for output {{ output.id }}
+    inputBinding:
+      position: {{ output.position }}
+{%- if output.prefix %}
+      prefix: "{{output.prefix.prefix}}"
+{%- if not output.prefix.separated %}
+      separate: false
+{%- endif %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+{%- else %}
+inputs: [] # TODO
+{%- endif %}
+{%- if outputs %}
+outputs:
+{%- for output in outputs %}
+  - id: {{ output.id }}
+    type: File
+    outputBinding:
+      glob: {{ output.glob }}
+{%- endfor %}
+{%- else %}
+outputs: [] # TODO
+{%- endif %}
+{%- if base_command %}
+baseCommand:
+{%- for base_command_part in base_command %}
+  - "{{ base_command_part}}"
+{%- endfor %}
+{%- else %}
+baseCommand: []
+{%- endif %}
+{%- if arguments %}
+arguments:
+{%- for argument in arguments %}
+  - valueFrom: "{{ argument.value }}"
+    position: {{ argument.position }}
+{%- if argument.prefix %}
+      prefix: "{{argument.prefix.prefix}}"
+{%- if not argument.prefix.separated %}
+      separate: false
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+{%- else %}
+arguments: []
+{%- endif %}
+{%- if stdout %}
+stdout: {{ stdout }}
+{%- endif %}
+description: |
+{%- if help %}
+  {{ help|indent(2) }}
+{%- else %}
+   TODO: Fill in description.
+{%- endif %}
+"""
+
+
 def build(**kwds):
+    """Build up a :func:`ToolDescription` from supplid arguments."""
+    if kwds.get("cwl"):
+        builder = _build_cwl
+    else:
+        builder = _build_galaxy
+    return builder(**kwds)
+
+
+def _build_cwl(**kwds):
+    _handle_help(kwds)
+    _handle_requirements(kwds)
+
+    command_io = CommandIO(**kwds)
+    render_kwds = {
+        "cwl_version": "cwl:draft-3",
+        "help": kwds.get("help", ""),
+        "containers": kwds.get("containers", []),
+        "id": kwds.get("id"),
+        "label": kwds.get("name"),
+    }
+    render_kwds.update(command_io.cwl_properties())
+
+    contents = _render(render_kwds, template_str=CWL_TEMPLATE)
+    macro_contents = None
+    test_files = []
+    return ToolDescription(
+        contents,
+        macro_contents,
+        test_files
+    )
+
+
+def _build_galaxy(**kwds):
     # Test case to build up from supplied inputs and outputs, ultimately
     # ignored unless kwds["test_case"] is truthy.
-    test_case = TestCase()
-
-    command = _find_command(kwds)
 
     _handle_help(kwds)
 
@@ -138,54 +265,15 @@ def build(**kwds):
     citations = map(UrlCitation, cite_urls)
     kwds["bibtex_citations"] = citations
 
-    # process raw inputs
-    inputs = kwds.get("input", [])
-    del kwds["input"]
-    inputs = list(map(Input, inputs or []))
-
-    # alternatively process example inputs
-    example_inputs = kwds["example_input"]
-    del kwds["example_input"]
-    for i, input_file in enumerate(example_inputs or []):
-        name = "input%d" % (i + 1)
-        inputs.append(Input(input_file, name=name))
-        test_case.params.append((name, input_file))
-        command = _replace_file_in_command(command, input_file, name)
-
-    # handle raw outputs (from_work_dir ones) as well as named_outputs
-    outputs = kwds.get("output", [])
-    del kwds["output"]
-    outputs = list(map(Output, outputs or []))
-
-    named_outputs = kwds.get("named_output", [])
-    del kwds["named_output"]
-    for named_output in (named_outputs or []):
-        outputs.append(Output(name=named_output))
-
-    # handle example outputs
-    example_outputs = kwds["example_output"]
-    del kwds["example_output"]
-    for i, output_file in enumerate(example_outputs or []):
-        name = "output%d" % (i + 1)
-        from_path = output_file
-        use_from_path = True
-        if output_file in command:
-            # Actually found the file in the command, assume it can
-            # be specified directly and skip from_work_dir.
-            use_from_path = False
-        output = Output(name=name, from_path=from_path,
-                        use_from_path=use_from_path)
-        outputs.append(output)
-        test_case.outputs.append((name, output_file))
-        command = _replace_file_in_command(command, output_file, output.name)
-
-    kwds["inputs"] = inputs
-    kwds["outputs"] = outputs
-
     # handle requirements and containers
     _handle_requirements(kwds)
 
-    kwds["command"] = command
+    command_io = CommandIO(**kwds)
+    kwds["inputs"] = command_io.inputs
+    kwds["outputs"] = command_io.outputs
+    kwds["command"] = command_io.cheetah_template
+
+    test_case = command_io.test_case()
 
     # finally wrap up tests
     tests, test_files = _handle_tests(kwds, test_case)
@@ -199,6 +287,223 @@ def build(**kwds):
         macro_contents = _render(kwds, MACROS_TEMPLATE)
 
     return ToolDescription(contents, macro_contents, test_files)
+
+
+class CommandIO(object):
+
+    def __init__(self, **kwds):
+        command = _find_command(kwds)
+        cheetah_template = command
+
+        # process raw inputs
+        inputs = kwds.pop("input", [])
+        inputs = list(map(Input, inputs or []))
+
+        # alternatively process example inputs
+        example_inputs = kwds.pop("example_input", [])
+        for i, input_file in enumerate(example_inputs or []):
+            name = "input%d" % (i + 1)
+            inputs.append(Input(input_file, name=name, example=True))
+            cheetah_template = _replace_file_in_command(cheetah_template, input_file, name)
+
+        # handle raw outputs (from_work_dir ones) as well as named_outputs
+        outputs = kwds.pop("output", [])
+        outputs = list(map(Output, outputs or []))
+
+        named_outputs = kwds.pop("named_output", [])
+        for named_output in (named_outputs or []):
+            outputs.append(Output(name=named_output, example=False))
+
+        # handle example outputs
+        example_outputs = kwds.pop("example_output", [])
+        for i, output_file in enumerate(example_outputs or []):
+            name = "output%d" % (i + 1)
+            from_path = output_file
+            use_from_path = True
+            if output_file in cheetah_template:
+                # Actually found the file in the command, assume it can
+                # be specified directly and skip from_work_dir.
+                use_from_path = False
+            output = Output(name=name, from_path=from_path,
+                            use_from_path=use_from_path, example=True)
+            outputs.append(output)
+            cheetah_template = _replace_file_in_command(cheetah_template, output_file, output.name)
+
+        self.inputs = inputs
+        self.outputs = outputs
+        self.command = command
+        self.cheetah_template = cheetah_template
+
+    def example_input_names(self):
+        for input in self.inputs:
+            if input.example:
+                yield input.input_description
+
+    def example_output_names(self):
+        for output in self.outputs:
+            if output.example:
+                yield output.example_path
+
+    def cwl_lex_list(self):
+        if not self.command:
+            return []
+
+        command_parts = shlex.split(self.command)
+        parse_list = []
+
+        input_count = 0
+        output_count = 0
+
+        index = 0
+
+        prefixed_parts = []
+        while index < len(command_parts):
+            value = command_parts[index]
+            eq_split = value.split("=")
+
+            prefix = None
+            if not _looks_like_start_of_prefix(index, command_parts):
+                index += 1
+            elif len(eq_split) == 2:
+                prefix = Prefix(eq_split[0] + "=", False)
+                value = eq_split[1]
+                index += 1
+            else:
+                prefix = Prefix(value, True)
+                value = command_parts[index + 1]
+                index += 2
+            prefixed_parts.append((prefix, value))
+
+        for position, (prefix, value) in enumerate(prefixed_parts):
+            if value in self.example_input_names():
+                input_count += 1
+                input = CwlInput("input%d" % input_count, position, prefix)
+                parse_list.append(input)
+            elif value in self.example_output_names():
+                output_count += 1
+                output = CwlOutput("output%d" % output_count, position, prefix)
+                parse_list.append(output)
+            else:
+                part = CwlCommandPart(value, position, prefix)
+                parse_list.append(part)
+        return parse_list
+
+    def cwl_properties(self):
+        base_command = []
+        arguments = []
+        inputs = []
+        outputs = []
+
+        lex_list = self.cwl_lex_list()
+
+        index = 0
+        while index < len(lex_list):
+            token = lex_list[index]
+            if isinstance(token, CwlCommandPart):
+                base_command.append(token.value)
+            else:
+                break
+            index += 1
+
+        while index < len(lex_list):
+            token = lex_list[index]
+            if token.is_token(">"):
+                break
+            token.position = index - len(base_command) + 1
+            if isinstance(token, CwlCommandPart):
+                arguments.append(token)
+            elif isinstance(token, CwlInput):
+                inputs.append(token)
+            elif isinstance(token, CwlOutput):
+                token.glob = "$(inputs.%s)" % token.id
+                outputs.append(token)
+
+            index += 1
+
+        stdout = None
+        if index < len(lex_list):
+            token = lex_list[index]
+            if token.is_token(">") and (index + 1) < len(lex_list):
+                output_token = lex_list[index + 1]
+                if not isinstance(output_token, CwlOutput):
+                    output_token = CwlOutput("std_out", None)
+
+                output_token.glob = "out"
+                output_token.require_filename = False
+                outputs.append(output_token)
+                stdout = "out"
+                index += 2
+            else:
+                io.warn("Example command too complex, you will need to build it up manually.")
+
+        return {
+            "inputs": inputs,
+            "outputs": outputs,
+            "arguments": arguments,
+            "base_command": base_command,
+            "stdout": stdout,
+        }
+
+    def test_case(self):
+        test_case = TestCase()
+        for input in self.inputs:
+            if input.example:
+                test_case.params.append((input.name, input.input_description))
+
+        for output in self.outputs:
+            if output.example:
+                test_case.outputs.append((output.name, output.from_path))
+
+        return test_case
+
+
+def _looks_like_start_of_prefix(index, parts):
+    value = parts[index]
+    if len(value.split("=")) == 2:
+        return True
+    if index + 1 == len(parts):
+        return False
+    next_value = parts[index + 1]
+    next_value_is_not_start = (len(value.split("=")) != 2) and next_value[0] not in ["-", ">", "<", "|"]
+    return value.startswith("-") and next_value_is_not_start
+
+
+Prefix = namedtuple("Prefix", ["prefix", "separated"])
+
+
+class CwlCommandPart(object):
+
+    def __init__(self, value, position, prefix):
+        self.value = value
+        self.position = position
+        self.prefix = prefix
+
+    def is_token(self, value):
+        return self.value == value
+
+
+class CwlInput(object):
+
+    def __init__(self, id, position, prefix):
+        self.id = id
+        self.position = position
+        self.prefix = prefix
+
+    def is_token(self, value):
+        return False
+
+
+class CwlOutput(object):
+
+    def __init__(self, id, position, prefix):
+        self.id = id
+        self.position = position
+        self.prefix = prefix
+        self.glob = None
+        self.require_filename = True
+
+    def is_token(self, value):
+        return False
 
 
 def _render(kwds, template_str=TOOL_TEMPLATE):
@@ -216,9 +521,11 @@ def _replace_file_in_command(command, specified_file, name):
     if '"%s"' % specified_file in command:
         # Sample command already wrapped filename in double quotes
         command = command.replace(specified_file, '$%s' % name)
-    else:
+    elif (" %s " % specified_file) in (" " + command + " "):
         # In case of spaces, best to wrap filename in double quotes
         command = command.replace(specified_file, '"$%s"' % name)
+    else:
+        command = command.replace(specified_file, '$%s' % name)
     return command
 
 
@@ -276,9 +583,10 @@ def _handle_requirements(kwds):
 
 
 def _find_command(kwds):
-    """ Find base command from supplied arguments or just return None if no
-    such command was supplied (template will just replace this with TODO
-    item).
+    """Find base command from supplied arguments or just return None.
+
+    If no such command was supplied (template will just replace this
+    with a TODO item).
     """
     command = kwds.get("command")
     if not command:
@@ -325,7 +633,7 @@ class UrlCitation(object):
 
 class ToolDescription(object):
 
-    def __init__(self, contents, macro_contents, test_files):
+    def __init__(self, contents, macro_contents=None, test_files=[]):
         self.contents = contents
         self.macro_contents = macro_contents
         self.test_files = test_files
@@ -333,7 +641,7 @@ class ToolDescription(object):
 
 class Input(object):
 
-    def __init__(self, input_description, name=None):
+    def __init__(self, input_description, name=None, example=False):
         parts = input_description.split(".")
         name = name or parts[0]
         if len(parts) > 0:
@@ -341,6 +649,8 @@ class Input(object):
         else:
             datatype = "data"
 
+        self.input_description = input_description
+        self.example = example
         self.name = name
         self.datatype = datatype
 
@@ -351,7 +661,7 @@ class Input(object):
 
 class Output(object):
 
-    def __init__(self, from_path=None, name=None, use_from_path=False):
+    def __init__(self, from_path=None, name=None, use_from_path=False, example=False):
         if from_path:
             parts = from_path.split(".")
             name = name or parts[0]
@@ -369,6 +679,9 @@ class Output(object):
             self.from_path = from_path
         else:
             self.from_path = None
+        self.example = example
+        if example:
+            self.example_path = from_path
 
     def __str__(self):
         if self.from_path:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ docutils
 jinja2
 glob2
 virtualenv
-galaxy-lib>=16.7.1
+galaxy-lib>=16.7.2
 cwltool ; python_version == '2.7'

--- a/tests/data/tools/ok-cat1-tool.cwl
+++ b/tests/data/tools/ok-cat1-tool.cwl
@@ -1,0 +1,1 @@
+../../../project_templates/cwl_draft3_spec/cat1-tool.cwl

--- a/tests/test_build_and_lint.py
+++ b/tests/test_build_and_lint.py
@@ -1,4 +1,7 @@
 import os
+
+import yaml
+
 from .test_utils import CliTestCase
 
 
@@ -31,9 +34,57 @@ class BuildAndLintTestCase(CliTestCase):
             self._check_exit_code(_init_command(doi=False))
             self._check_lint(exit_code=1)
 
-    def _check_lint(self, exit_code=0):
-        lint_cmd = ["lint", "--fail_level", "warn", "seqtk_seq.xml"]
+    def test_cwl(self):
+        with self._isolate() as f:
+            self._check_exit_code(_cwl_init_command())
+            self._check_lint(filename="seqtk_seq.cwl", exit_code=0)
+
+            with open(os.path.join(f, "seqtk_seq.cwl")) as f:
+                process_dict = yaml.load(f)
+            assert process_dict["id"] == "seqtk_seq"
+            assert process_dict["label"] == "Convert to FASTA (seqtk)"
+            assert process_dict["baseCommand"] == ["seqtk", "seq"]
+            input0 = process_dict["inputs"][0]
+            assert input0["inputBinding"]["position"] == 1
+            assert input0["inputBinding"]["prefix"] == "-a"
+            assert input0["type"] == "File"
+            output = process_dict["outputs"][0]
+            assert output["type"] == "File"
+            assert output["outputBinding"]["glob"] == "out"
+            assert process_dict["stdout"] == "out"
+
+    def test_cwl_fail_on_empty_help(self):
+        with self._isolate():
+            self._check_exit_code(_cwl_init_command(help_text=False))
+            self._check_lint(filename="seqtk_seq.cwl", exit_code=1)
+
+    def test_cwl_fail_on_no_docker(self):
+        with self._isolate():
+            self._check_exit_code(_cwl_init_command(help_text=False))
+            self._check_lint(filename="seqtk_seq.cwl", exit_code=1)
+
+    def _check_lint(self, filename="seqtk_seq.xml", exit_code=0):
+        lint_cmd = ["lint", "--fail_level", "warn", filename]
         self._check_exit_code(lint_cmd, exit_code=exit_code)
+
+
+def _cwl_init_command(help_text=True, container=True):
+    command = [
+        "tool_init", "--force", "--cwl",
+        "--id", "seqtk_seq",
+        "--name", "Convert to FASTA (seqtk)",
+        "--container", "jmchilton/seqtk:v1",
+        "--name", "Convert to FASTA (seqtk)",
+        "--example_command", "seqtk seq -a 2.fastq > 2.fasta",
+        "--example_input", "2.fastq",
+        "--example_output", "2.fasta"
+    ]
+    if container:
+        command.extend(["--container", "jmchilton/seqtk:v1"])
+    if help_text:
+        command.extend(["--help_text", "The help text."])
+
+    return command
 
 
 def _init_command(test_case=True, help_text=True, doi=True, macros=False):

--- a/tests/test_command_io.py
+++ b/tests/test_command_io.py
@@ -1,0 +1,104 @@
+"""Test cases for the CommandIO abstraction in tool_builder."""
+
+from planemo.tool_builder import CommandIO
+
+
+def test_simplest_command():
+    """Test very simple command."""
+    command_io = _example("random_fastq")
+    _assert_eq(command_io.cheetah_template, "random_fastq")
+
+
+def test_example_and_quotes():
+    """Test example input/output transition."""
+    command_io = _example("convert 1.bed 1.bam", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    _assert_eq(command_io.cheetah_template, 'convert "$input1" "$output1"')
+    _assert_eq(len(command_io.outputs), 1)
+    _assert_eq(len(command_io.inputs), 1)
+
+
+def test_example_already_quoted():
+    """Test example input/output transition."""
+    command_io = _example('convert "1.bed" "1.bam"', example_outputs=["1.bam"], example_inputs=["1.bed"])
+    _assert_eq(command_io.cheetah_template, 'convert "$input1" "$output1"')
+
+
+def test_example_already_quoted_single():
+    """Test example input/output transition."""
+    command_io = _example("convert '1.bed' '1.bam'", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    _assert_eq(command_io.cheetah_template, "convert '$input1' '$output1'")
+
+
+def test_example_cwl_simplest():
+    command_io = _example("convert '1.bed' '1.bam'", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    cwl_properties = command_io.cwl_properties()
+
+    _assert_eq(cwl_properties["base_command"], ["convert"])
+    _assert_eq(cwl_properties["inputs"][0].position, 1)
+    _assert_eq(cwl_properties["outputs"][0].position, 2)
+
+
+def test_example_cwl_argument():
+    command_io = _example("seqtk convert '1.bed' moo '1.bam'", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    cwl_properties = command_io.cwl_properties()
+
+    _assert_eq(cwl_properties["base_command"], ["seqtk", "convert"])
+    _assert_eq(cwl_properties["inputs"][0].position, 1)
+    _assert_eq(cwl_properties["inputs"][0].prefix, None)
+    _assert_eq(cwl_properties["outputs"][0].position, 3)
+    _assert_eq(cwl_properties["outputs"][0].prefix, None)
+    _assert_eq(cwl_properties["outputs"][0].glob, "$(inputs.output1)")
+    _assert_eq(len(cwl_properties["arguments"]), 1)
+    _assert_eq(cwl_properties["arguments"][0].position, 2)
+    _assert_eq(cwl_properties["arguments"][0].value, "moo")
+
+
+def test_example_cwl_simple_redirect():
+    command_io = _example("seqtk convert '1.bed' > '1.bam'", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    cwl_properties = command_io.cwl_properties()
+
+    _assert_eq(cwl_properties["base_command"], ["seqtk", "convert"])
+    _assert_eq(cwl_properties["inputs"][0].position, 1)
+    _assert_eq(cwl_properties["outputs"][0].glob, "out")
+    _assert_eq(cwl_properties["stdout"], "out")
+
+
+def test_prefixes_separated():
+    command_io = _example("seqtk convert -i '1.bed' --output '1.bam'", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    cwl_properties = command_io.cwl_properties()
+    _assert_eq(cwl_properties["base_command"], ["seqtk", "convert"])
+    _assert_eq(cwl_properties["inputs"][0].position, 1)
+    _assert_eq(cwl_properties["inputs"][0].prefix.prefix, "-i")
+    _assert_eq(cwl_properties["inputs"][0].prefix.separated, True)
+
+    _assert_eq(cwl_properties["outputs"][0].glob, "$(inputs.output1)")
+    _assert_eq(cwl_properties["outputs"][0].prefix.prefix, "--output")
+    _assert_eq(cwl_properties["outputs"][0].prefix.separated, True)
+    _assert_eq(cwl_properties["stdout"], None)
+
+
+def test_prefixes_joined():
+    command_io = _example("seqtk convert INPUT=1.bed OUTPUT=1.bam", example_outputs=["1.bam"], example_inputs=["1.bed"])
+    cwl_properties = command_io.cwl_properties()
+    _assert_eq(cwl_properties["base_command"], ["seqtk", "convert"])
+    _assert_eq(cwl_properties["inputs"][0].position, 1)
+    _assert_eq(cwl_properties["inputs"][0].prefix.prefix, "INPUT=")
+    _assert_eq(cwl_properties["inputs"][0].prefix.separated, False)
+
+    _assert_eq(cwl_properties["outputs"][0].glob, "$(inputs.output1)")
+    _assert_eq(cwl_properties["outputs"][0].prefix.prefix, "OUTPUT=")
+    _assert_eq(cwl_properties["outputs"][0].prefix.separated, False)
+    _assert_eq(cwl_properties["stdout"], None)
+
+
+def _example(example_command, example_outputs=[], example_inputs=[]):
+    """Build a CommandIO object for test cases."""
+    kwds = {}
+    kwds["example_command"] = example_command
+    kwds["example_output"] = example_outputs
+    kwds["example_input"] = example_inputs
+    return CommandIO(**kwds)
+
+
+def _assert_eq(a, b):
+    assert a == b, "%s != %s" % (a, b)


### PR DESCRIPTION
- Through galaxy-lib updates, lint will now lint CWL tools.
  - Checks for a validation, description, Docker image, and cwlVersion.
- Update ``tool_init`` to take in a ``--cwl`` parameter and generate CWL tools.
- Add a section to the documentation on building CWL tools - replicate the
  first three ``planemo tool_init`` commands for the seqtk_seq example.
- Tests and docstring improvements.

Requires galaxy-lib improvements in 16.7.2.

Fixes #450, xref #408.
