### PR TITLE
Refactor toward support for running Galaxy in docker-galaxy-stable.

### DIFF
--- a/planemo/options.py
+++ b/planemo/options.py
@@ -550,6 +550,14 @@ def no_cleanup_option():
     )
 
 
+def docker_enable_option():
+    return planemo_option(
+        "--docker/--no_docker",
+        default=False,
+        help=("Run Galaxy tools in Docker if enabled.")
+    )
+
+
 def docker_cmd_option():
     return planemo_option(
         "--docker_cmd",
@@ -583,6 +591,22 @@ def docker_host_option():
              "(defaults to localhost).",
         use_global_config=True,
         default=docker_util.DEFAULT_HOST,
+    )
+
+
+def docker_config_options():
+    return _compose(
+        docker_cmd_option(),
+        docker_sudo_option(),
+        docker_host_option(),
+        docker_sudo_cmd_option(),
+    )
+
+
+def galaxy_docker_options():
+    return _compose(
+        docker_enable_option(),
+        docker_config_options(),
     )
 
 
@@ -808,6 +832,7 @@ def galaxy_target_options():
         no_cache_galaxy_option(),
         no_cleanup_option(),
         galaxy_email_option(),
+        galaxy_docker_options(),
         # Profile options...
         job_config_option(),
         tool_dependency_dir_option(),


### PR DESCRIPTION
 - General cleanup of planemo.galaxy.config docstrings and such.
 - Refactor the configured Galaxy properties into ones relevant for Docker and not.
 - Create an interface for the GalaxyConfig object to be very explicit about what the rest of planemo expects from it.
 - Reduce this interface - mainly involves refactoring startup command generation so pid_file doesn't need to be used outside the config module.
 - Implement a BaseGalaxyConfig for GalaxyConfig object functionality that will be shared with a future Docker impementation - and put the local instance specific stuff in a LocalGalaxyConfig object.

xref #15 