### PR TITLE
Shorten command one line descriptions for main help

### DIFF
--- a/planemo/commands/cmd_brew_env.py
+++ b/planemo/commands/cmd_brew_env.py
@@ -24,7 +24,9 @@ from galaxy.util import bunch
 )
 @command_function
 def cli(ctx, path, brew=None, skip_install=False, shell=None):
-    """Display commands used to modify environment to inject tool's brew
+    """List commands to inject brew dependencies.
+
+    Display commands used to modify environment to inject tool's brew
     dependencies.::
 
         % . <(planemo brew_env bowtie2.xml)

--- a/planemo/commands/cmd_brew_init.py
+++ b/planemo/commands/cmd_brew_init.py
@@ -14,8 +14,9 @@ INSTALL_SCRIPT = "https://raw.github.com/Homebrew/linuxbrew/go/install"
 @click.command('brew_init')
 @command_function
 def cli(ctx):
-    """Download linuxbrew install and run it with ruby. Linuxbrew is a fork
-    of Homebrew (http://brew.sh/linuxbrew/).
+    """Download linuxbrew install & run it in ruby.
+
+    Linuxbrew is a fork of Homebrew (http://brew.sh/linuxbrew/).
 
     For more information on installing linuxbrew and pre-requisites see
     https://github.com/Homebrew/linuxbrew#installation.

--- a/planemo/commands/cmd_conda_env.py
+++ b/planemo/commands/cmd_conda_env.py
@@ -36,7 +36,9 @@ alias conda_env_deactivate="source %s; %s"
 # @options.skip_install_option()  # TODO
 @command_function
 def cli(ctx, path, **kwds):
-    """Source output to activate a conda environment for this tool.
+    """How to activate conda environment for tool.
+
+    Source output to activate a conda environment for this tool.
 
         % . <(planemo conda_env bowtie2.xml)
         % which bowtie2

--- a/planemo/commands/cmd_config_init.py
+++ b/planemo/commands/cmd_config_init.py
@@ -47,7 +47,9 @@ SUCCESS_MESSAGE = (
 )
 @command_function
 def cli(ctx, path, template=None, **kwds):
-    """Help initialize global configuration (in home directory) for Planemo.
+    """Initialise global configuration for Planemo.
+
+    Helps initialize global configuration (in home directory) for Planemo.
     """
     # TODO: prompt for values someday.
     config_path = config.global_config_path()

--- a/planemo/commands/cmd_create_gist.py
+++ b/planemo/commands/cmd_create_gist.py
@@ -26,9 +26,7 @@ target_path = click.Path(
 )
 @command_function
 def cli(ctx, path, **kwds):
-    """Download a tool repository as a tarball from the tool shed and extract
-    to the specified directory.
-    """
+    """Upload file to GitHub as a sharable gist."""
     file_url = github_util.publish_as_gist_file(ctx, path)
     if kwds.get("link_type") == "raw":
         share_url = file_url

--- a/planemo/commands/cmd_cwl_script.py
+++ b/planemo/commands/cmd_cwl_script.py
@@ -16,7 +16,9 @@ from planemo.cwl import to_script
 @click.option('basedir', '--base_dir', type=click.Path(), default=".")
 @command_function
 def cli(ctx, path, job_path, **kwds):
-    """This compiles simple common workflow language workflows to a shell
+    """Compile simple CWL workflows to shell script.
+
+    Compiles simple common workflow language (CWL) workflows to a shell
     script.
     """
     to_script(ctx, path, job_path, **kwds)

--- a/planemo/commands/cmd_dependency_script.py
+++ b/planemo/commands/cmd_dependency_script.py
@@ -163,7 +163,7 @@ def process_tool_dependencies_xml(tool_dep, install_handle, env_sh_handle):
 @options.dependencies_script_options()
 @command_function
 def cli(ctx, paths, recursive=False, fail_fast=True, download_cache=None):
-    """Prepare a bash shell script to install tool requirements (**Experimental**)
+    """Compile tool_dependencies.xml to bash script.
 
     An experimental approach parsing tool_dependencies.xml files into
     bash shell scripts, intended initially for use within Continuous

--- a/planemo/commands/cmd_docker_build.py
+++ b/planemo/commands/cmd_docker_build.py
@@ -17,7 +17,7 @@ from galaxy.tools.deps import dockerfiles
 @options.docker_host_option()
 @command_function
 def cli(ctx, path=".", dockerfile=None, **kwds):
-    """Build (and optionally cache Docker images) for tool Dockerfiles.
+    """Build (and optionally cache) Docker images.
 
     Loads the tool or tools referenced by ``TOOL_PATH`` (by default all tools
     in current directory), and ensures they all reference the same Docker image
@@ -31,6 +31,8 @@ def cli(ctx, path=".", dockerfile=None, **kwds):
 
         % planemo docker_build bowtie2.xml # asssumes Dockerfile in same dir
         % planemo docker_shell --from_tag bowtie2.xml
+
+    This can optionally also cache the images.
     """
     dockerfiles.dockerfile_build(
         path=path,

--- a/planemo/commands/cmd_docker_shell.py
+++ b/planemo/commands/cmd_docker_shell.py
@@ -42,7 +42,9 @@ from galaxy.tools.deps.requirements import parse_requirements_from_xml
 @options.docker_host_option()
 @command_function
 def cli(ctx, path, **kwds):
-    """Launch a shell in the Docker container referenced by the specified
+    """Launch shell in Docker container for a tool.
+
+    Will launch a shell in the Docker container referenced by the specified
     tool. Prints a command to do this the way Galaxy would in job files it
     generates - so be sure to wrap this in $(...) to launch the subshell.::
 

--- a/planemo/commands/cmd_docs.py
+++ b/planemo/commands/cmd_docs.py
@@ -9,5 +9,5 @@ SYNTAX_URL = "http://planemo.readthedocs.org/en/latest/"
 @click.command("syntax")
 @command_function
 def cli(ctx, **kwds):
-    """Open the Planemo documentation in a web browser."""
+    """Open Planemo documentation in web browser."""
     click.launch(SYNTAX_URL)

--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -36,7 +36,7 @@ from planemo.tool_lint import lint_tools_on_path
 # )
 @command_function
 def cli(ctx, paths, **kwds):
-    """Check tools for common errors and adherence to best practices."""
+    """Check for common errors and best practices."""
     lint_args = build_lint_args(ctx, **kwds)
     exit_code = lint_tools_on_path(
         ctx,

--- a/planemo/commands/cmd_normalize.py
+++ b/planemo/commands/cmd_normalize.py
@@ -37,7 +37,7 @@ from galaxy.tools.linters.xml_order import TAG_ORDER
 )
 @command_function
 def cli(ctx, path, expand_macros=False, **kwds):
-    """Generate normalized tool XML from input (breaks formatting).
+    """Generate normalized tool XML from input.
 
     This will break the formatting of your tool and is currently only intended
     for viewing macro expansions for for use with XSD validation (see

--- a/planemo/commands/cmd_project_init.py
+++ b/planemo/commands/cmd_project_init.py
@@ -27,7 +27,9 @@ UNTAR_ARGS = " -C %s -zxf - " + UNTAR_FILTER
 )
 @command_function
 def cli(ctx, path, template=None, **kwds):
-    """Initialize a new tool project (demo only right now).
+    """(Experimental) Initialize a new tool project.
+
+    This is only a proof-of-concept demo right now.
     """
     if template is None:
         warn("Creating empty project, this function doesn't do much yet.")

--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -14,7 +14,7 @@ from planemo import options
 @options.galaxy_cwl_root_option()
 @command_function
 def cli(ctx, paths, **kwds):
-    """Launch a Galaxy instance with the specified tool in the tool panel.
+    """Launch Galaxy instance with specified tools.
 
     The Galaxy tool panel will include just the referenced tool or tools (by
     default all the tools in the current working directory) and the upload

--- a/planemo/commands/cmd_share_test.py
+++ b/planemo/commands/cmd_share_test.py
@@ -16,12 +16,16 @@ PLANEMO_TEST_VIEWER_URL_TEMPLATE = (
 @options.tool_test_json()
 @command_function
 def cli(ctx, path, **kwds):
-    """Publish JSON test results to Github Gist and produce sharable URL.
+    """Publish JSON test results as sharable Gist.
 
-    Sharable URL  can be used to share an HTML version of the report that
-    can be easily embedded in pull requests or commit messages. Requires
-    a ~/.planemo.yml with Github 'username' and 'password' defined in a
-    'github' section of that configuration file.
+    This will upload the JSON test results to Github as a Gist and
+    produce sharable URL.
+
+    The sharable URL can be used to share an HTML version of the report
+    that can be easily embedded in pull requests or commit messages.
+
+    Requires a ~/.planemo.yml with Github 'username' and 'password'
+    defined in a 'github' section of that configuration file.
     """
     file_url = github_util.publish_as_gist_file(ctx, path)
     share_url = PLANEMO_TEST_VIEWER_URL_TEMPLATE % file_url

--- a/planemo/commands/cmd_shed_build.py
+++ b/planemo/commands/cmd_shed_build.py
@@ -13,7 +13,10 @@ from planemo import shed
 @options.optional_tools_arg(multiple=False)
 @command_function
 def cli(ctx, path, **kwds):
-    """Create a Galaxy tool tarball from a ``.shed.yml`` file.
+    """Create a Galaxy tool tarball.
+
+    This will use the .shed.yml file to prepare a tarball
+    (which you could upload to the Tool Shed manually).
     """
 
     def build(realized_repository):

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -15,7 +15,9 @@ from planemo.io import info
 @options.shed_skip_upload()
 @command_function
 def cli(ctx, paths, **kwds):
-    """Create a repository in a Galaxy Tool Shed from a ``.shed.yml`` file.
+    """Create a repository in a Galaxy Tool Shed.
+
+    This will read the settings from the ``.shed.yml`` file.
     """
     shed_context = shed.get_shed_context(ctx, **kwds)
 

--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -37,7 +37,7 @@ from planemo.io import captured_io_for_xunit
 @options.report_xunit()
 @command_function
 def cli(ctx, paths, **kwds):
-    """Produce diff between local repository and Tool Shed contents.
+    """diff between local repository and Tool Shed.
 
     By default, this will produce a diff between this repository and what
     would be uploaded to the Tool Shed with the `shed_upload` command - but

--- a/planemo/commands/cmd_shed_download.py
+++ b/planemo/commands/cmd_shed_download.py
@@ -29,7 +29,9 @@ target_path = click.Path(
 )
 @command_function
 def cli(ctx, paths, **kwds):
-    """Download a tool repository as a tarball from the tool shed and extract
+    """Download tool from Tool Shed into directory.
+
+    Download a tool repository as a tarball from the tool shed and extract
     to the specified directory.
     """
     shed_context = shed.get_shed_context(ctx, read_only=True, **kwds)

--- a/planemo/commands/cmd_shed_init.py
+++ b/planemo/commands/cmd_shed_init.py
@@ -42,11 +42,11 @@ from planemo import shed
 @options.force_option()
 @command_function
 def cli(ctx, path, **kwds):
-    """Bootstrap a new Tool Shed configuration (.shed.yml) file.
+    """Bootstrap new Tool Shed .shed.yml file.
 
-    This file is used by other ``planemo`` commands such as ``shed_lint``,
-    ``shed_create``, ``shed_upload``, and ``shed_diff`` to manage repositories
-    in a Galaxy Tool Shed.
+    This Tool Shed configuration file is used by other ``planemo`` commands
+    such as ``shed_lint``, ``shed_create``, ``shed_upload``, and ``shed_diff``
+    to manage repositories in a Galaxy Tool Shed.
     """
     exit_code = shed.shed_init(ctx, path, **kwds)
     sys.exit(exit_code)

--- a/planemo/commands/cmd_shed_lint.py
+++ b/planemo/commands/cmd_shed_lint.py
@@ -39,7 +39,7 @@ from planemo import shed_lint
 # )
 @command_function
 def cli(ctx, paths, **kwds):
-    """Check a Tool Shed repository for common problems.
+    """Check Tool Shed repository for common issues.
 
     With the ``--tools`` flag, this command lints actual Galaxy tools
     in addition to tool shed artifacts.

--- a/planemo/commands/cmd_shed_serve.py
+++ b/planemo/commands/cmd_shed_serve.py
@@ -21,7 +21,7 @@ from planemo import io
 )
 @command_function
 def cli(ctx, paths, **kwds):
-    """ Serve a transient Galaxy with published repositories installed.
+    """Launch Galaxy with Tool Shed dependencies.
 
     This command will start a Galaxy instance configured to target the
     specified shed, find published artifacts (tools and dependencies)

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -19,7 +19,7 @@ from planemo.io import captured_io_for_xunit
 @options.shed_skip_metadata()
 @command_function
 def cli(ctx, paths, **kwds):
-    """Update repository in shed from a ``.shed.yml`` file.
+    """Update Tool Shed repository.
 
     By default this command will update both repository metadata
     from ``.shed.yml`` and upload new contents from the repository

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -33,7 +33,7 @@ tar_path = click.Path(
 )
 @command_function
 def cli(ctx, paths, **kwds):
-    """Low-level command for uploading tar balls to a shed.
+    """Low-level command to upload tarballs.
 
     Generally, ``shed_update`` should be used instead since it also updates
     both tool shed contents (via tar ball generation and upload) as well as

--- a/planemo/commands/cmd_syntax.py
+++ b/planemo/commands/cmd_syntax.py
@@ -9,5 +9,5 @@ SYNTAX_URL = "https://wiki.galaxyproject.org/Admin/Tools/ToolConfigSyntax"
 @click.command("syntax")
 @command_function
 def cli(ctx, **kwds):
-    """Open tool config syntax wiki page in a web browser."""
+    """Open tool config syntax page in web browser."""
     click.launch(SYNTAX_URL)

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -37,7 +37,7 @@ from planemo.galaxy.test import (
 @options.engine_options()
 @command_function
 def cli(ctx, paths, **kwds):
-    """Run the tests in the specified tool tests in a Galaxy instance.
+    """Run specified tool's tests within Galaxy.
 
     All referenced tools (by default all the tools in the current working
     directory) will be tested and the results quickly summarized.

--- a/planemo/commands/cmd_test_reports.py
+++ b/planemo/commands/cmd_test_reports.py
@@ -14,8 +14,10 @@ from planemo.galaxy.test import StructuredData, handle_reports
 @options.test_report_options()
 @command_function
 def cli(ctx, path, **kwds):
-    """Generate various tool test reports (HTML, text, markdown) from
-    structure output from tests (tool_test_output.json).
+    """Generate human readable tool test reports.
+
+    Creates reports in various formats  (HTML, text, markdown)
+    from the structured test output (tool_test_output.json).
     """
     if not os.path.exists(path):
         io.error("Failed to tool test json file at %s" % path)

--- a/planemo/commands/cmd_tool_factory.py
+++ b/planemo/commands/cmd_tool_factory.py
@@ -12,7 +12,7 @@ from planemo.galaxy import serve
 @options.galaxy_serve_options()
 @command_function
 def cli(ctx, **kwds):
-    """(Experimental) Launch Galaxy with the Tool Factory 2 available.
+    """(Experimental) Launch Galaxy with Tool Factory 2.
 
     For more information about the Galaxy Tool Factory see the publication
     Creating reusable tools from scripts: the Galaxy Tool Factory by Lazarus

--- a/planemo/commands/cmd_tool_init.py
+++ b/planemo/commands/cmd_tool_init.py
@@ -192,7 +192,7 @@ REUSING_MACROS_MESSAGE = ("Macros file macros.xml already exists, assuming "
 @options.build_cwl_option()
 @command_function
 def cli(ctx, **kwds):
-    """Generate a tool outline from supplied arguments."""
+    """Generate tool outline from given arguments."""
     invalid = _validate_kwds(kwds)
     tool_id = kwds.get("id")
     if invalid:

--- a/planemo/commands/cmd_travis_before_install.py
+++ b/planemo/commands/cmd_travis_before_install.py
@@ -28,7 +28,9 @@ export PATH=$PATH:${BUILD_BIN_DIR}
 @click.command('travis_before_install')
 @command_function
 def cli(ctx):
-    """This command is used internally by planemo to assist in contineous testing
+    """Internal command for GitHub/TravisCI testing.
+
+    This command is used internally by planemo to assist in contineous testing
     of tools with Travis CI (https://travis-ci.org/).
     """
     build_dir = os.environ.get("TRAVIS_BUILD_DIR", None)

--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -11,7 +11,7 @@ from galaxy.tools.deps.commands import shell
 
 PREPARE_MESSAGE = (
     "Place commands to prepare an Ubuntu VM for use with your tool(s) "
-    "in the .travis/setup_custom_dependencies.bash shell script. Be sure to"
+    "in the .travis/setup_custom_dependencies.bash shell script. Be sure to "
     "add these new files to your git repository with 'git add .travis "
     ".travis.yml' and then commit. You will also need to register your github "
     "tool project with Travi CI by visiting https://travis-ci.org/."

--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -41,7 +41,9 @@ script:
 @options.optional_project_arg()
 @command_function
 def cli(ctx, path):
-    """Setup files in a github tool repository to enable continuous
+    """Create files to use GitHub/TravisCI testing.
+
+    Setup files in a github tool repository to enable continuous
     integration testing.::
 
         % planemo travis_init .


### PR DESCRIPTION
This would close #183 by using pithy one-line help summaries for each command to avoid truncation in ``planemo --help``, which now gives:

```
$ planemo --help
Usage: planemo [OPTIONS] COMMAND [ARGS]...

  A command-line toolkit for building tools and workflows for Galaxy.

  Check out the full documentation for Planemo online
  http://planemo.readthedocs.org or open with ``planemo docs``.

Options:
  --version         Show the version and exit.
  -v, --verbose     Enables verbose mode.
  --config TEXT     Planemo configuration YAML file.
  --directory TEXT  Workspace for planemo.
  --help            Show this message and exit.

Commands:
  brew                   Install tool requirements using brew.
  brew_env               List commands to inject brew dependencies.
  brew_init              Download linuxbrew install & run it in ruby.
  conda_env              How to activate conda environment for tool.
  conda_init             Download and install conda.
  conda_install          Install conda packages for tool requirements.
  config_init            Initialise global configuration for Planemo.
  create_gist            Upload file to GitHub as a sharable gist.
  cwl_script             Compile simple CWL workflows to shell script.
  database_create        Create a *development* database.
  database_delete        Delete a *development* database.
  database_list          List databases in configured database source.
  dependency_script      Compile tool_dependencies.xml to bash script.
  docker_build           Build (and optionally cache) Docker images.
  docker_shell           Launch shell in Docker container for a tool.
  docs                   Open Planemo documentation in web browser.
  lint                   Check for common errors and best practices.
  normalize              Generate normalized tool XML from input.
  profile_create         Create a profile.
  profile_delete         Delete a profile.
  profile_list           List configured profile names.
  project_init           (Experimental) Initialize a new tool project.
  run                    Planemo command for running tools and jobs.
  serve                  Launch Galaxy instance with specified tools.
  share_test             Publish JSON test results as sharable Gist.
  shed_build             Create a Galaxy tool tarball.
  shed_create            Create a repository in a Galaxy Tool Shed.
  shed_diff              diff between local repository and Tool Shed.
  shed_download          Download tool from Tool Shed into directory.
  shed_init              Bootstrap new Tool Shed .shed.yml file.
  shed_lint              Check Tool Shed repository for common issues.
  shed_serve             Launch Galaxy with Tool Shed dependencies.
  shed_test              Run tests of published shed artifacts.
  shed_update            Update Tool Shed repository.
  shed_upload            Low-level command to upload tarballs.
  syntax                 Open tool config syntax page in web browser.
  test                   Run specified tool's tests within Galaxy.
  test_reports           Generate human readable tool test reports.
  tool_factory           (Experimental) Launch Galaxy with Tool...
  tool_init              Generate tool outline from given arguments.
  travis_before_install  Internal command for GitHub/TravisCI testing.
  travis_init            Create files to use GitHub/TravisCI testing.
  virtualenv             Create a virtualenv.
```

Also corrected the ``create_gist`` help string which was copied from another command.