### PR TITLE
Use planemo test --no_cache_galaxy under TravisCI

### DIFF
--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -3,6 +3,6 @@ sudo apt-get install -y python-virtualenv
 virtualenv planemo-venv
 . planemo-venv/bin/activate
 pip install planemo
-planemo travis_before_install
+planemo travis_before_install # runs .travis/setup_custom_dependencies.bash
 . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source environment created by planemo
 planemo test --install_galaxy --no_cache_galaxy ${TRAVIS_BUILD_DIR}

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -4,7 +4,5 @@ virtualenv planemo-venv
 . planemo-venv/bin/activate
 pip install planemo
 planemo travis_before_install
- . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source environment created by planemo
-# TODO: Add --no_cache_galaxy once planemo 0.7.0 is available
-# on PyPI.
-planemo test --install_galaxy ${TRAVIS_BUILD_DIR}
+. ${TRAVIS_BUILD_DIR}/.travis/env.sh # source environment created by planemo
+planemo test --install_galaxy --no_cache_galaxy ${TRAVIS_BUILD_DIR}


### PR DESCRIPTION
As per the TODO comment this replaces, it requires planemo 0.7.0 or later to be installed from PyPI, but that has been true for a long time now.

Note I have NOT tested this yet (still working on transitioning my own Galaxy tools to use ``planemo test``).