### PR TITLE
Update pip and setuptools on TravisCI; fix travis_init

### DIFF
--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -46,6 +46,7 @@ TRAVIS_SETUP = """#!/bin/bash
 # TODO: Add your instructions here:
 """
 
+
 @click.command('travis_init')
 @options.optional_project_arg()
 @command_function
@@ -78,5 +79,5 @@ def cli(ctx, path):
     if not os.path.exists(setup_sh):
         open(setup_sh, "w").write(TRAVIS_SETUP)
     else:
-        warning(".travis/setup_custom_dependencies.bash already exists, not overwriting.")
+        warn(".travis/setup_custom_dependencies.bash already exists, not overwriting.")
     info(PREPARE_MESSAGE)

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -2,6 +2,7 @@
 sudo apt-get install -y python-virtualenv
 virtualenv planemo-venv
 . planemo-venv/bin/activate
+pip install --upgrade pip setuptools
 pip install planemo
 planemo travis_before_install # runs .travis/setup_custom_dependencies.bash
 . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source environment created by planemo


### PR DESCRIPTION
Fixes #520 by explicitly updating pip and setuptools before installing planemo.

Also fixes a regression I introduced recently in 364fec2a3b5458e49ce3f96b76413627243c049c (typo in function name)