### PR TITLE
Include shed_lint in script run by travis_init

### DIFF
--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -6,4 +6,5 @@ pip install --upgrade pip setuptools
 pip install planemo
 planemo travis_before_install # runs .travis/setup_custom_dependencies.bash
 . ${TRAVIS_BUILD_DIR}/.travis/env.sh # source environment created by planemo
+planemo shed_lint --fail_level error --tools --ensure_metadata --urls -r ${TRAVIS_BUILD_DIR}
 planemo test --install_galaxy --no_cache_galaxy ${TRAVIS_BUILD_DIR}


### PR DESCRIPTION
Untested (since currently my Galaxy GitHub repositories are not setup via ``planemo travis_init``), but intended to resolve #514 