### PR TITLE
Return to working directory after shell_command action

### DIFF
--- a/planemo/shed2tap/base.py
+++ b/planemo/shed2tap/base.py
@@ -556,7 +556,10 @@ class ShellCommandAction(BaseAction):
         self.command = elem.text
 
     def to_bash(self):
-        return [self.command], []
+        # Galaxy would run each action from the same temp
+        # working directory - possible that tool_dependencies.xml
+        # shell_command could change $PWD so reset this:
+        return ["pushd .", self.command, "popd"], []
 
 
 class TemplateShellCommandAction(BaseAction):


### PR DESCRIPTION
Closes issue #404 with the verbose approach of wrapping the ``shell_command`` with ``pushd .`` and ``popd``.