### PR TITLE
Verify sha256sum checksums in planemo dependency_script

### DIFF
--- a/planemo/commands/cmd_dependency_script.py
+++ b/planemo/commands/cmd_dependency_script.py
@@ -24,11 +24,13 @@ then
 fi
 # Set full strict mode now, side stepping case $INSTALL_DIR not setup.
 set -euo pipefail
-export DOWNLOAD_CACHE=`(cd "$DOWNLOAD_CACHE"; pwd)`
+export DOWNLOAD_CACHE="${DOWNLOAD_CACHE:-./download_cache}"
 if [[ ! -d $DOWNLOAD_CACHE ]]
 then
     mkdir -p $DOWNLOAD_CACHE
 fi
+# Make this into an absolute path
+export DOWNLOAD_CACHE=`(cd "$DOWNLOAD_CACHE"; pwd)`
 echo "Using $DOWNLOAD_CACHE for cached downloads."
 export INSTALL_DIR=`(cd "$INSTALL_DIR"; pwd)`
 echo "Using $INSTALL_DIR for the installed files."
@@ -203,7 +205,7 @@ def cli(ctx, paths, recursive=False, fail_fast=True, download_cache=None):
         # Effectively using this as a global variable, refactor this
         # once using a visitor pattern instead of action.to_bash()
         os.environ["DOWNLOAD_CACHE"] = os.path.abspath(download_cache)
-    print("Using $DOWNLOAD_CACHE=%r" % os.environ["DOWNLOAD_CACHE"])
+        print("Using $DOWNLOAD_CACHE=%r" % os.environ["DOWNLOAD_CACHE"])
     failed = False
     with open("env.sh", "w") as env_sh_handle:
         with open("dep_install.sh", "w") as install_handle:

--- a/planemo/shed2tap/base.py
+++ b/planemo/shed2tap/base.py
@@ -403,6 +403,9 @@ def _cache_download(url, filename, sha256sum=None):
         # TODO - expose this as a command line option
         raise ValueError("Dependencies cache location $DOWNLOAD_CACHE not set.")
 
+    if not os.path.isdir(cache):
+        os.mkdir(cache)
+
     local = os.path.join(cache, filename)
 
     if not os.path.isfile(local):

--- a/planemo/shed2tap/base.py
+++ b/planemo/shed2tap/base.py
@@ -9,6 +9,8 @@ from six import string_types
 from six import iteritems
 
 import os
+import sys
+import subprocess
 import tarfile
 import zipfile
 from ftplib import all_errors as FTPErrors  # tuple of exceptions
@@ -411,8 +413,8 @@ def _cache_download(url, filename, sha256sum=None):
     if not os.path.isfile(local):
         # Must download it...
         try:
-            import sys  # TODO - log this nicely...
-            sys.stderr.write("Downloading %s\n" % url)
+            # TODO - log this nicely...
+            sys.stderr.write("Downloading %s to %r\n" % (url, local))
             urlretrieve(url, local)
         except URLError:
             # Most likely server is down, could be bad URL in XML action:
@@ -422,8 +424,11 @@ def _cache_download(url, filename, sha256sum=None):
             raise RuntimeError("Unable to download %s" % url)
 
     if sha256sum:
-        # TODO - check local copy
-        pass
+        # TODO - log this nicely...
+        sys.stderr.write("Verifying checksum for %s\n" % filename)
+        filehash = subprocess.check_output(['shasum', '-a', '256', local])[0:64].strip()
+        if filehash != sha256sum:
+            raise RuntimeError("Checksum failure for %s, got %r but wanted %r" % (local, filehash, sha256sum))
 
     return local
 


### PR DESCRIPTION
In addition this fixes a problem trying to run the script without setting ``$DOWNLOAD_CACHE`` (documented as defaulting to ``./download_cache``) or if the local cache folder did not exist.