### PR TITLE
Look for sha256sum checksums during shed_lint

### DIFF
--- a/tests/data/repos/package_1/tool_dependencies.xml
+++ b/tests/data/repos/package_1/tool_dependencies.xml
@@ -4,35 +4,35 @@
     <install version="1.0">
       <actions_group>
         <actions os="linux" architecture="i386">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/linux/i386/samtools/samtools-0.1.16-linux-i386.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="7090bd62142df0ed3a2b4000292fc0edc917e773d0269c2f3f5b0d36b7888c22">http://depot.galaxyproject.org/package/linux/i386/samtools/samtools-0.1.16-linux-i386.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions os="linux" architecture="x86_64">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/linux/x86_64/samtools/samtools-0.1.16-linux-x86_64.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="1d050e70fb6570117f282e3ab827f1f37fd453a0558c55ea565092ec3b2b9db2">http://depot.galaxyproject.org/package/linux/x86_64/samtools/samtools-0.1.16-linux-x86_64.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions os="darwin" architecture="i386">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/darwin/i386/samtools/samtools-0.1.16-Darwin-i386.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="4b89dd5542809098269939f6eb913abcf0011c746e02085221d171e3942b6e1f">http://depot.galaxyproject.org/package/darwin/i386/samtools/samtools-0.1.16-Darwin-i386.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions os="darwin" architecture="x86_64">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/darwin/x86_64/samtools/samtools-0.1.16-Darwin-x86_64.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="4e74d7ce4eb5d26166ff6f9bb5939d9a0110d9bdb0baf9ff08cc9522a49e09cb">http://depot.galaxyproject.org/package/darwin/x86_64/samtools/samtools-0.1.16-Darwin-x86_64.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions>
-          <action type="download_by_url">http://depot.galaxyproject.org/package/source/samtools/samtools-0.1.16.tar.bz2</action>
+          <action type="download_by_url" sha256sum="ae37c49f2414d1fabe597f68f2351f6cce4b6c0a1a512a5d739bbf759f80a726">http://depot.galaxyproject.org/package/source/samtools/samtools-0.1.16.tar.bz2</action>
           <action type="shell_command">sed -i.bak 's/-lcurses/-lncurses/' Makefile</action>
           <action type="shell_command">make</action>
           <action type="move_file">

--- a/tests/tool_dependencies_good_1.xml
+++ b/tests/tool_dependencies_good_1.xml
@@ -4,35 +4,35 @@
     <install version="1.0">
       <actions_group>
         <actions os="linux" architecture="i386">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/linux/i386/samtools/samtools-0.1.16-linux-i386.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="7090bd62142df0ed3a2b4000292fc0edc917e773d0269c2f3f5b0d36b7888c22">http://depot.galaxyproject.org/package/linux/i386/samtools/samtools-0.1.16-linux-i386.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions os="linux" architecture="x86_64">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/linux/x86_64/samtools/samtools-0.1.16-linux-x86_64.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="1d050e70fb6570117f282e3ab827f1f37fd453a0558c55ea565092ec3b2b9db2">http://depot.galaxyproject.org/package/linux/x86_64/samtools/samtools-0.1.16-linux-x86_64.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions os="darwin" architecture="i386">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/darwin/i386/samtools/samtools-0.1.16-Darwin-i386.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="4b89dd5542809098269939f6eb913abcf0011c746e02085221d171e3942b6e1f">http://depot.galaxyproject.org/package/darwin/i386/samtools/samtools-0.1.16-Darwin-i386.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions os="darwin" architecture="x86_64">
-          <action type="download_by_url" target_filename="samtools-0.1.16.tgz">http://depot.galaxyproject.org/package/darwin/x86_64/samtools/samtools-0.1.16-Darwin-x86_64.tgz</action>
+          <action type="download_by_url" target_filename="samtools-0.1.16.tgz" sha256sum="4e74d7ce4eb5d26166ff6f9bb5939d9a0110d9bdb0baf9ff08cc9522a49e09cb">http://depot.galaxyproject.org/package/darwin/x86_64/samtools/samtools-0.1.16-Darwin-x86_64.tgz</action>
           <action type="move_directory_files">
             <source_directory>.</source_directory>
             <destination_directory>$INSTALL_DIR</destination_directory>
           </action>
         </actions>
         <actions>
-          <action type="download_by_url">http://depot.galaxyproject.org/package/source/samtools/samtools-0.1.16.tar.bz2</action>
+          <action type="download_by_url" sha256sum="ae37c49f2414d1fabe597f68f2351f6cce4b6c0a1a512a5d739bbf759f80a726">http://depot.galaxyproject.org/package/source/samtools/samtools-0.1.16.tar.bz2</action>
           <action type="shell_command">sed -i.bak 's/-lcurses/-lncurses/' Makefile</action>
           <action type="shell_command">make</action>
           <action type="move_file">


### PR DESCRIPTION
Looks at the ``download_by_url`` and ``download_file`` actions only, missing sha256sum is a warning, bad sha256sum is an error (e.g. not 64 characters, or non-hex characters present).

A future ``--verify`` switch could download the file and confirm the checksum matches.

TODO: Test case with a bad sha256sum entry (e.g. extra char)