### PR TITLE
dependency_script: cp rather than symlink to $DOWNLOAD_CACHE

### DIFF
--- a/planemo/shed2tap/base.py
+++ b/planemo/shed2tap/base.py
@@ -516,11 +516,11 @@ def _commands_and_downloaded_file(url, target_filename=None, sha256sum=None):
         'elif [[ -f "$DOWNLOAD_CACHE/%s" ]]' % downloaded_filename,
         'then',
         '    echo "Reusing cached %s"' % downloaded_filename,
-        '    ln -s "$DOWNLOAD_CACHE/%s" "%s"' % (downloaded_filename, target_filename),
+        '    cp "$DOWNLOAD_CACHE/%s" "%s"' % (downloaded_filename, target_filename),
         'else',
         '    echo "Downloading %s"' % downloaded_filename,
         '    curl -L -o "$DOWNLOAD_CACHE/%s" "%s"' % (downloaded_filename, url),
-        '    ln -s "$DOWNLOAD_CACHE/%s" "%s"' % (downloaded_filename, target_filename),
+        '    cp "$DOWNLOAD_CACHE/%s" "%s"' % (downloaded_filename, target_filename),
         ]
     if sha256sum:
         # This is inserted into the if-else for a fresh download only.


### PR DESCRIPTION
Currently the ``dep_install.sh`` output from ``planemo dependency_script`` will use symlinks for download files in ``$DOWNLOAD_CACHE``, which is fast.

When the downloaded file is an archive which gets unpacked in the working directory, this is harmless. However, when the download file is moved directly to ``$INSTALL_DIR`` (e.g. JAR files) this leaves the installation with a symlink pointing at the cache - which might get deleted.

Also, some tools will look for their own dependencies relative to the real file (and not the symlink) which will point them at ``$DOWNLOAD_CACHE`` rather than ``$INSTALL_DIR``.

e.g. https://travis-ci.org/peterjc/pico_galaxy/jobs/154411030 and clinod

Here ``dep_install.sh`` contained:

``` bash
    if [[ -f "clinod-1.3.jar" ]]
    then
        echo "Reusing existing clinod-1.3.jar"
    elif [[ -f "$DOWNLOAD_CACHE/clinod_1.3_src_all.jar" ]]
    then
        echo "Reusing cached clinod_1.3_src_all.jar"
        ln -s "$DOWNLOAD_CACHE/clinod_1.3_src_all.jar" "clinod-1.3.jar"
    else
        echo "Downloading clinod_1.3_src_all.jar"
        curl -L -o "$DOWNLOAD_CACHE/clinod_1.3_src_all.jar" "https://depot.galaxyproject.org/software/clinod/clinod_1.3_src_all.jar"
        ln -s "$DOWNLOAD_CACHE/clinod_1.3_src_all.jar" "clinod-1.3.jar"
        echo "45d80662ba109a7af28aeafcfb2ca417a7d575ac3700f69bd40965a69d41e072  clinod-1.3.jar" | shasum -a 256 -c -
    fi
    mv clinod-1.3.jar $INSTALL_DIR/
    if [[ -f "SNNSv4.3.tar.gz" ]]
    then
        echo "Reusing existing SNNSv4.3.tar.gz"
    elif [[ -f "$DOWNLOAD_CACHE/SNNS_4.3_linux_x64.tar.gz" ]]
    then
        echo "Reusing cached SNNS_4.3_linux_x64.tar.gz"
        ln -s "$DOWNLOAD_CACHE/SNNS_4.3_linux_x64.tar.gz" "SNNSv4.3.tar.gz"
    else
        echo "Downloading SNNS_4.3_linux_x64.tar.gz"
        curl -L -o "$DOWNLOAD_CACHE/SNNS_4.3_linux_x64.tar.gz" "https://depot.galaxyproject.org/software/SNNS/SNNS_4.3_linux_x64.tar.gz"
        ln -s "$DOWNLOAD_CACHE/SNNS_4.3_linux_x64.tar.gz" "SNNSv4.3.tar.gz"
        echo "54bf92d23e9198f9030a3c3d2b741472e9b8660b27d3b419ade6393b1ebf6f62  SNNSv4.3.tar.gz" | shasum -a 256 -c -
    fi
    pushd . > /dev/null
    tar -zxvf SNNSv4.3.tar.gz
    popd > /dev/null
    mv SNNSv4.3/tools/bin/x86_64-pc-unknown-linux-gnuoldld/batchman $INSTALL_DIR/
```

Giving:

```
0.00s$ ls -l $DOWNLOAD_CACHE
total 25864
-rw-rw-r-- 1 travis travis  515854 Aug 23 10:27 clinod_1.3_src_all.jar
-rw-rw-r-- 1 travis travis   17202 Aug 23 10:27 NLStradamus_1.8_src_all.tar.gz
-rw-rw-r-- 1 travis travis 5076669 Aug 23 10:27 SNNS_4.3_linux_x64.tar.gz
-rw-rw-r-- 1 travis travis 4573569 Aug 23 10:27 TTSS_ANIMAL_1.0.1_src_all.jar
-rw-rw-r-- 1 travis travis 2463844 Aug 23 10:27 TTSS_GUI_1.0.1_src_all.jar
-rw-rw-r-- 1 travis travis 4574610 Aug 23 10:27 TTSS_PLANT_1.0.1_src_all.jar
-rw-rw-r-- 1 travis travis 4578395 Aug 23 10:27 TTSS_STD_1.0.1_src_all.jar
-rw-rw-r-- 1 travis travis 4673466 Aug 23 10:27 TTSS_STD_2.0.2_src_all.jar
```

```
$ ls -l $INSTALL_DIR
total 544
-rwxr-xr-x 1 travis travis 507720 Jun 25  2008 batchman
lrwxrwxrwx 1 travis travis     42 Aug 23 10:27 clinod-1.3.jar -> /tmp/download_cache/clinod_1.3_src_all.jar
drwxrwxr-x 2 travis travis   4096 Aug 23 10:27 module
-rwxrwxr-x 1 travis travis  44133 Aug 23 10:27 NLStradamus
lrwxrwxrwx 1 travis travis     46 Aug 23 10:27 TTSS_GUI-1.0.1.jar -> /tmp/download_cache/TTSS_GUI_1.0.1_src_all.jar
```

I want ``$INSTALL_DIR/clinod-1.3.jar`` (the symlink) to run ``$INSTALL_DIR/batchman`` (real file) but according to the logs it tried and failed to find  ``$DOWNLOAD_CACHE/clinod-1.3.jar`` (does not exist, but would be next to the real JAR file).