### PR TITLE
Fix import order throughout project.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,6 +18,7 @@ readme
 # Used for code checking.
 pyflakes
 flake8
+flake8-import-order
 
 # For release
 wheel

--- a/planemo/cli.py
+++ b/planemo/cli.py
@@ -6,14 +6,15 @@ import traceback
 
 import click
 
-from .io import error
-from .config import (
-    read_global_config,
-    OptionSource,
-)
-from planemo.galaxy import profiles
-from planemo.exit_codes import ExitCodeException
 from planemo import __version__
+from planemo.exit_codes import ExitCodeException
+from planemo.galaxy import profiles
+
+from .config import (
+    OptionSource,
+    read_global_config,
+)
+from .io import error
 
 PYTHON_2_7_COMMANDS = ["run", "cwl_script"]
 IS_PYTHON_2_7 = sys.version_info[0] == 2 and sys.version_info[1] >= 7

--- a/planemo/commands/cmd_brew.py
+++ b/planemo/commands/cmd_brew.py
@@ -1,15 +1,14 @@
 """Module describing the planemo ``brew`` command."""
 import click
 
-from planemo.cli import command_function
-from planemo import options
-
-from galaxy.tools.loader_directory import load_tool_elements_from_path
-
-from galaxy.tools.deps.requirements import parse_requirements_from_xml
 from galaxy.tools.deps import brew_exts
 from galaxy.tools.deps import brew_util
+from galaxy.tools.deps.requirements import parse_requirements_from_xml
+from galaxy.tools.loader_directory import load_tool_elements_from_path
 from galaxy.util import bunch
+
+from planemo import options
+from planemo.cli import command_function
 
 
 @click.command('brew')

--- a/planemo/commands/cmd_brew_env.py
+++ b/planemo/commands/cmd_brew_env.py
@@ -1,17 +1,18 @@
 """Module describing the planemo ``brew_env`` command."""
 from __future__ import print_function
-import click
 import os
 
-from planemo.cli import command_function
-from planemo import options
-from planemo.io import ps1_for_path
+import click
 
-from galaxy.tools.loader import load_tool
-from galaxy.tools.deps.requirements import parse_requirements_from_xml
 from galaxy.tools.deps import brew_exts
 from galaxy.tools.deps import brew_util
+from galaxy.tools.deps.requirements import parse_requirements_from_xml
+from galaxy.tools.loader import load_tool
 from galaxy.util import bunch
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.io import ps1_for_path
 
 
 @click.command('brew_env')

--- a/planemo/commands/cmd_brew_init.py
+++ b/planemo/commands/cmd_brew_init.py
@@ -1,8 +1,8 @@
 """Module describing the planemo ``brew_init`` command."""
-import click
-
 import urllib
 from tempfile import mkstemp
+
+import click
 
 from planemo.cli import command_function
 from planemo.io import shell

--- a/planemo/commands/cmd_conda_env.py
+++ b/planemo/commands/cmd_conda_env.py
@@ -1,16 +1,15 @@
 """Module describing the planemo ``conda_env`` command."""
 from __future__ import print_function
+
 import click
 
-from planemo.cli import command_function
-from planemo import options
-
-from planemo.io import ps1_for_path
-from planemo.io import error
-
-from planemo.conda import build_conda_context, collect_conda_targets
-
 from galaxy.tools.deps import conda_util
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.conda import build_conda_context, collect_conda_targets
+from planemo.io import error
+from planemo.io import ps1_for_path
 
 
 SOURCE_COMMAND = """

--- a/planemo/commands/cmd_conda_init.py
+++ b/planemo/commands/cmd_conda_init.py
@@ -1,11 +1,11 @@
 """Module describing the planemo ``conda_init`` command."""
 import click
 
-from planemo.cli import command_function
-from planemo import options
-from planemo.conda import build_conda_context
-
 from galaxy.tools.deps import conda_util
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.conda import build_conda_context
 
 
 @click.command('conda_init')

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -1,13 +1,12 @@
 """Module describing the planemo ``conda_install`` command."""
 import click
 
-from planemo.cli import command_function
-from planemo.io import coalesce_return_codes
-from planemo import options
-
-from planemo.conda import build_conda_context, collect_conda_targets
-
 from galaxy.tools.deps import conda_util
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.conda import build_conda_context, collect_conda_targets
+from planemo.io import coalesce_return_codes
 
 
 @click.command('conda_install')

--- a/planemo/commands/cmd_config_init.py
+++ b/planemo/commands/cmd_config_init.py
@@ -4,10 +4,10 @@ import sys
 
 import click
 
-from planemo.cli import command_function
-from planemo import options
 from planemo import config
-from planemo.io import warn, info
+from planemo import options
+from planemo.cli import command_function
+from planemo.io import info, warn
 
 CONFIG_TEMPLATE = """## Planemo Global Configuration File.
 ## Everything in this file is completely optional - these values can all be

--- a/planemo/commands/cmd_create_gist.py
+++ b/planemo/commands/cmd_create_gist.py
@@ -1,9 +1,9 @@
 """Module describing the planemo ``create_gist`` command."""
 import click
 
+from planemo import github_util
 from planemo.cli import command_function
 from planemo.io import info
-from planemo import github_util
 
 target_path = click.Path(
     file_okay=True,

--- a/planemo/commands/cmd_cwl_script.py
+++ b/planemo/commands/cmd_cwl_script.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.cwl import to_script
 
 

--- a/planemo/commands/cmd_database_create.py
+++ b/planemo/commands/cmd_database_create.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.database import create_database_source
 
 

--- a/planemo/commands/cmd_database_delete.py
+++ b/planemo/commands/cmd_database_delete.py
@@ -2,8 +2,8 @@
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.database import create_database_source
 
 

--- a/planemo/commands/cmd_database_list.py
+++ b/planemo/commands/cmd_database_list.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.database import create_database_source
 
 

--- a/planemo/commands/cmd_dependency_script.py
+++ b/planemo/commands/cmd_dependency_script.py
@@ -2,14 +2,13 @@
 import os
 import sys
 
-import click
-
 from xml.etree import ElementTree as ET
 
-from planemo.io import info, error
-from planemo.cli import command_function
-from planemo import options
+import click
 
+from planemo import options
+from planemo.cli import command_function
+from planemo.io import error, info
 from planemo.shed2tap.base import BasePackage, Dependency
 
 

--- a/planemo/commands/cmd_docker_build.py
+++ b/planemo/commands/cmd_docker_build.py
@@ -1,10 +1,12 @@
 """Module describing the planemo ``docker_build`` command."""
+
 import click
-from planemo.cli import command_function
-from planemo import options
-from planemo.io import error
 
 from galaxy.tools.deps import dockerfiles
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.io import error
 
 
 @click.command('docker_build')

--- a/planemo/commands/cmd_docker_shell.py
+++ b/planemo/commands/cmd_docker_shell.py
@@ -11,15 +11,17 @@ the identifier as a locally cached tag. (Tip: Use the docker_build to populate
 such a tag from a Dockerfile located in the tool's directory.
 """
 from __future__ import print_function
-import click
 import os
-from planemo.cli import command_function
-from planemo import options
 
-from galaxy.tools.loader import load_tool
+import click
+
 from galaxy.tools.deps import docker_util
 from galaxy.tools.deps import dockerfiles
 from galaxy.tools.deps.requirements import parse_requirements_from_xml
+from galaxy.tools.loader import load_tool
+
+from planemo import options
+from planemo.cli import command_function
 
 
 @click.command('docker_shell')

--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -1,9 +1,8 @@
 """Module describing the planemo ``lint`` command."""
 import click
 
-from planemo.cli import command_function
 from planemo import options
-
+from planemo.cli import command_function
 from planemo.tool_lint import build_lint_args
 from planemo.tool_lint import lint_tools_on_path
 

--- a/planemo/commands/cmd_normalize.py
+++ b/planemo/commands/cmd_normalize.py
@@ -3,14 +3,14 @@ from xml.etree import ElementTree
 
 import click
 
-from planemo.cli import command_function
-from planemo import options
-
+from galaxy.tools.linters.xml_order import TAG_ORDER
 from galaxy.tools.loader import (
     load_tool,
     raw_tool_xml_tree,
 )
-from galaxy.tools.linters.xml_order import TAG_ORDER
+
+from planemo import options
+from planemo.cli import command_function
 
 
 @click.command('normalize')

--- a/planemo/commands/cmd_profile_create.py
+++ b/planemo/commands/cmd_profile_create.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.galaxy import profiles
 
 

--- a/planemo/commands/cmd_profile_delete.py
+++ b/planemo/commands/cmd_profile_delete.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.galaxy import profiles
 
 

--- a/planemo/commands/cmd_project_init.py
+++ b/planemo/commands/cmd_project_init.py
@@ -1,16 +1,16 @@
 """Module describing the planemo ``project_init`` command."""
 import os
-import tempfile
 import shutil
+import tempfile
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.io import (
-    warn,
+    shell,
     untar_to,
-    shell
+    warn,
 )
 
 SOURCE_HOST = "https://codeload.github.com"

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -5,8 +5,8 @@ import json
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
+from planemo.cli import command_function
 from planemo.engine import engine_context
 from planemo.io import conditionally_captured_io, warn
 

--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -1,10 +1,10 @@
 """Module describing the planemo ``serve`` command."""
 import click
 
-from planemo.cli import command_function
-from planemo.runnable import for_paths
-from planemo.galaxy import galaxy_serve
 from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy import galaxy_serve
+from planemo.runnable import for_paths
 
 
 @click.command('serve')

--- a/planemo/commands/cmd_share_test.py
+++ b/planemo/commands/cmd_share_test.py
@@ -1,10 +1,10 @@
 """Module describing the planemo ``share_test`` command."""
 import click
 
-from planemo.cli import command_function
-from planemo import options
-from planemo.io import info
 from planemo import github_util
+from planemo import options
+from planemo.cli import command_function
+from planemo.io import info
 
 PLANEMO_TEST_VIEWER_URL_TEMPLATE = (
     "http://galaxyproject.github.io/planemo/tool_test_viewer.html"

--- a/planemo/commands/cmd_shed_build.py
+++ b/planemo/commands/cmd_shed_build.py
@@ -1,12 +1,13 @@
 """Module describing the planemo ``shed_build`` command."""
+
+import shutil
 import sys
 
 import click
-import shutil
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
+from planemo.cli import command_function
 
 
 @click.command("shed_build")
@@ -18,7 +19,6 @@ def cli(ctx, path, **kwds):
     This will use the .shed.yml file to prepare a tarball
     (which you could upload to the Tool Shed manually).
     """
-
     def build(realized_repository):
         tarpath = shed.build_tarball(realized_repository.path)
         outpath = realized_repository.real_path + ".tar.gz"

--- a/planemo/commands/cmd_shed_create.py
+++ b/planemo/commands/cmd_shed_create.py
@@ -3,9 +3,9 @@ import sys
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
+from planemo.cli import command_function
 from planemo.io import info
 
 

--- a/planemo/commands/cmd_shed_diff.py
+++ b/planemo/commands/cmd_shed_diff.py
@@ -1,16 +1,17 @@
 """Module describing the planemo ``shed_diff`` command."""
+import shutil
 import sys
 import tempfile
-import shutil
+
 from xml.sax.saxutils import escape
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
-from planemo.reports import build_report
+from planemo.cli import command_function
 from planemo.io import captured_io_for_xunit
+from planemo.reports import build_report
 
 
 @click.command("shed_diff")

--- a/planemo/commands/cmd_shed_download.py
+++ b/planemo/commands/cmd_shed_download.py
@@ -3,9 +3,9 @@ import sys
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
+from planemo.cli import command_function
 
 target_path = click.Path(
     file_okay=True,

--- a/planemo/commands/cmd_shed_init.py
+++ b/planemo/commands/cmd_shed_init.py
@@ -1,11 +1,11 @@
 """Module describing the planemo ``shed_init`` command."""
-import click
 import sys
 
-from planemo.cli import command_function
+import click
 
 from planemo import options
 from planemo import shed
+from planemo.cli import command_function
 
 
 @click.command("shed_init")

--- a/planemo/commands/cmd_shed_lint.py
+++ b/planemo/commands/cmd_shed_lint.py
@@ -1,10 +1,10 @@
 """Module describing the planemo ``shed_lint`` command."""
 import click
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
 from planemo import shed_lint
+from planemo.cli import command_function
 
 
 @click.command('shed_lint')

--- a/planemo/commands/cmd_shed_serve.py
+++ b/planemo/commands/cmd_shed_serve.py
@@ -2,11 +2,11 @@
 import time
 import click
 
-from planemo.cli import command_function
-from planemo import options
-from planemo.galaxy import shed_serve
-from planemo import shed
 from planemo import io
+from planemo import options
+from planemo import shed
+from planemo.cli import command_function
+from planemo.galaxy import shed_serve
 
 
 @click.command("shed_serve")

--- a/planemo/commands/cmd_shed_test.py
+++ b/planemo/commands/cmd_shed_test.py
@@ -4,10 +4,10 @@ import sys
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
-from planemo.galaxy.serve import shed_serve
 from planemo import shed
+from planemo.cli import command_function
+from planemo.galaxy.serve import shed_serve
 from planemo.galaxy.test import run_in_config
 
 

--- a/planemo/commands/cmd_shed_update.py
+++ b/planemo/commands/cmd_shed_update.py
@@ -3,12 +3,15 @@ import sys
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
-from planemo.io import info, error
+from planemo.cli import command_function
+from planemo.io import (
+    captured_io_for_xunit,
+    error,
+    info,
+)
 from planemo.reports import build_report
-from planemo.io import captured_io_for_xunit
 
 
 @click.command("shed_update")

--- a/planemo/commands/cmd_shed_upload.py
+++ b/planemo/commands/cmd_shed_upload.py
@@ -3,9 +3,9 @@ import sys
 
 import click
 
-from planemo.cli import command_function
 from planemo import options
 from planemo import shed
+from planemo.cli import command_function
 
 
 tar_path = click.Path(

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -1,22 +1,21 @@
 """Module describing the planemo ``test`` command."""
 import click
 
+from planemo import options
 from planemo.cli import command_function
 from planemo.engine import (
     engine_context,
     is_galaxy_engine,
 )
-from planemo import options
-from planemo.runnable import (
-    for_paths,
-    RunnableType,
-)
 from planemo.galaxy import galaxy_config
-from planemo.io import info
-
 from planemo.galaxy.test import (
     handle_reports_and_summary,
     run_in_config,
+)
+from planemo.io import info
+from planemo.runnable import (
+    for_paths,
+    RunnableType,
 )
 
 

--- a/planemo/commands/cmd_test_reports.py
+++ b/planemo/commands/cmd_test_reports.py
@@ -3,10 +3,10 @@ import os
 
 import click
 
-from planemo.cli import command_function
 from planemo import io
 from planemo import options
-from planemo.galaxy.test import StructuredData, handle_reports
+from planemo.cli import command_function
+from planemo.galaxy.test import handle_reports, StructuredData
 
 
 @click.command('test_reports')

--- a/planemo/commands/cmd_tool_factory.py
+++ b/planemo/commands/cmd_tool_factory.py
@@ -2,10 +2,11 @@
 import os
 
 import click
-from planemo.cli import command_function
-from planemo.runnable import for_paths
+
 from planemo import options
+from planemo.cli import command_function
 from planemo.galaxy import serve
+from planemo.runnable import for_paths
 
 
 @click.command('tool_factory')

--- a/planemo/commands/cmd_tool_init.py
+++ b/planemo/commands/cmd_tool_init.py
@@ -3,10 +3,10 @@ import os
 
 import click
 
-from planemo.cli import command_function
-from planemo import options
 from planemo import io
+from planemo import options
 from planemo import tool_builder
+from planemo.cli import command_function
 
 REUSING_MACROS_MESSAGE = ("Macros file macros.xml already exists, assuming "
                           " it has relevant planemo-generated definitions.")

--- a/planemo/commands/cmd_travis_init.py
+++ b/planemo/commands/cmd_travis_init.py
@@ -3,11 +3,12 @@ import os
 
 import click
 
-from planemo.cli import command_function
-from planemo.io import warn, info
+from galaxy.tools.deps.commands import shell
+
 from planemo import options
 from planemo import RAW_CONTENT_URL
-from galaxy.tools.deps.commands import shell
+from planemo.cli import command_function
+from planemo.io import info, warn
 
 PREPARE_MESSAGE = (
     "Place commands to prepare an Ubuntu VM for use with your tool(s) "

--- a/planemo/commands/cmd_virtualenv.py
+++ b/planemo/commands/cmd_virtualenv.py
@@ -1,8 +1,8 @@
 """Module describing the planemo ``virtualenv`` command."""
 import click
 
-from planemo.cli import command_function
 from planemo import virtualenv
+from planemo.cli import command_function
 
 VIRTUALENV_PATH_TYPE = click.Path(
     exists=False,

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -4,10 +4,10 @@ features with planemo specific idioms.
 from __future__ import absolute_import
 
 from galaxy.tools.deps import conda_util
-from planemo.io import shell
-
 from galaxy.tools.deps.requirements import parse_requirements_from_xml
 from galaxy.tools.loader_directory import load_tool_elements_from_path
+
+from planemo.io import shell
 
 
 def build_conda_context(**kwds):

--- a/planemo/config.py
+++ b/planemo/config.py
@@ -1,9 +1,10 @@
 """Module defines abstractions for configuring Planemo."""
+
 import os
-import yaml
 
 import aenum
 import click
+import yaml
 
 PLANEMO_CONFIG_ENV_PROP = "PLANEMO_GLOBAL_CONFIG_PATH"
 DEFAULT_CONFIG = {

--- a/planemo/cwl/run.py
+++ b/planemo/cwl/run.py
@@ -8,15 +8,15 @@ import json
 import tempfile
 
 from galaxy.tools.cwl.cwltool_deps import (
-    main,
     ensure_cwltool_available,
+    main,
 )
 
+from planemo.io import error, real_io
 from planemo.runnable import (
-    SuccessfulRunResponse,
     ErrorRunResponse,
+    SuccessfulRunResponse,
 )
-from planemo.io import real_io, error
 
 JSON_PARSE_ERROR_MESSAGE = ("Failed to parse JSON from cwltool output [%s] "
                             "in file [%s]. cwltool logs [%s].")

--- a/planemo/engine/cwltool.py
+++ b/planemo/engine/cwltool.py
@@ -1,8 +1,9 @@
 """Module contianing the :class:`CwlToolEngine` implementation of :class:`Engine`."""
-from .interface import BaseEngine
-from planemo.runnable import RunnableType
 
 from planemo import cwl
+from planemo.runnable import RunnableType
+
+from .interface import BaseEngine
 
 
 class CwlToolEngine(BaseEngine):

--- a/planemo/engine/factory.py
+++ b/planemo/engine/factory.py
@@ -2,9 +2,9 @@
 
 import contextlib
 
-from .galaxy import GalaxyEngine
-from .galaxy import DockerizedGalaxyEngine
 from .cwltool import CwlToolEngine
+from .galaxy import DockerizedGalaxyEngine
+from .galaxy import GalaxyEngine
 
 UNKNOWN_ENGINE_TYPE_MESSAGE = "Unknown engine type specified [%s]."
 

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -1,11 +1,12 @@
 """Module contianing the :class:`GalaxyEngine` implementation of :class:`Engine`."""
+
 import contextlib
 
-from .interface import BaseEngine
+from planemo.galaxy.activity import execute
+from planemo.galaxy.serve import serve_daemon
 from planemo.runnable import RunnableType
 
-from planemo.galaxy.serve import serve_daemon
-from planemo.galaxy.activity import execute
+from .interface import BaseEngine
 
 
 class GalaxyEngine(BaseEngine):

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -5,13 +5,12 @@ import json
 import os
 import tempfile
 
-from planemo.runnable import (
-    for_path,
-    cases,
-)
-
 from planemo.exit_codes import EXIT_CODE_UNSUPPORTED_FILE_TYPE
 from planemo.io import error
+from planemo.runnable import (
+    cases,
+    for_path,
+)
 from planemo.test.results import StructuredData
 
 

--- a/planemo/galaxy/__init__.py
+++ b/planemo/galaxy/__init__.py
@@ -4,11 +4,11 @@ from __future__ import absolute_import
 
 from .config import galaxy_config
 from .run import (
-    setup_venv,
     run_galaxy_command,
+    setup_venv,
 )
-from .serve import shed_serve
 from .serve import serve as galaxy_serve
+from .serve import shed_serve
 
 __all__ = [
     "galaxy_config",

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -5,18 +5,16 @@ import os
 import tempfile
 
 from bioblend.galaxy.client import Client
-
 from galaxy.tools.parser import get_tool_source
 from six import iteritems
 
-
+from planemo.io import wait_on
 from planemo.runnable import (
+    ErrorRunResponse,
     get_outputs,
     RunnableType,
     SuccessfulRunResponse,
-    ErrorRunResponse,
 )
-from planemo.io import wait_on
 
 DEFAULT_HISTORY_NAME = "CWL Target History"
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -7,33 +7,22 @@ import contextlib
 import os
 import random
 import shutil
-from six.moves.urllib.request import urlopen
-from six import iteritems
+
 from string import Template
 from tempfile import mkdtemp
-from six.moves.urllib.request import urlretrieve
 
 import click
+
 from galaxy.tools.deps import docker_util
 from galaxy.tools.deps.commands import argv_to_str
 
-from .run import (
-    setup_common_startup_args,
-    setup_venv,
-    DOWNLOAD_GALAXY,
-)
-from .api import (
-    DEFAULT_MASTER_API_KEY,
-    gi,
-    user_api_key,
-)
-from .workflows import (
-    import_workflow,
-    install_shed_repos,
-)
+from six import iteritems
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.request import urlretrieve
+
+from planemo import git
 from planemo.conda import build_conda_context
 from planemo.docker import docker_host_args
-from planemo import git
 from planemo.io import (
     communicate,
     kill_pid_file,
@@ -44,6 +33,21 @@ from planemo.io import (
     write_file,
 )
 from planemo.shed import tool_shed_url
+
+from .api import (
+    DEFAULT_MASTER_API_KEY,
+    gi,
+    user_api_key,
+)
+from .run import (
+    DOWNLOAD_GALAXY,
+    setup_common_startup_args,
+    setup_venv,
+)
+from .workflows import (
+    import_workflow,
+    install_shed_repos,
+)
 
 
 NO_TEST_DATA_MESSAGE = (

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -7,13 +7,14 @@ import json
 import os
 import shutil
 
-from .config import (
-    DATABASE_LOCATION_TEMPLATE,
-    attempt_database_preseed,
-)
-from planemo.database import create_database_source
 from planemo.config import (
     OptionSource,
+)
+from planemo.database import create_database_source
+
+from .config import (
+    attempt_database_preseed,
+    DATABASE_LOCATION_TEMPLATE,
 )
 
 PROFILE_OPTIONS_JSON_NAME = "planemo_profile_options.json"

--- a/planemo/galaxy/run.py
+++ b/planemo/galaxy/run.py
@@ -2,9 +2,10 @@
 import os
 import string
 
+from galaxy.tools.deps.commands import shell
+
 from planemo.io import info, shell_join
 from planemo.virtualenv import create_command
-from galaxy.tools.deps.commands import shell
 
 
 # Activate galaxy's virtualenv if present (needed for tests say but not for

--- a/planemo/galaxy/serve.py
+++ b/planemo/galaxy/serve.py
@@ -4,12 +4,13 @@ from __future__ import print_function
 import contextlib
 import time
 
+from planemo import io
+from planemo import network_util
+
 from .config import galaxy_config
 from .run import (
     run_galaxy_command,
 )
-from planemo import io
-from planemo import network_util
 
 
 def serve(ctx, runnables=[], **kwds):

--- a/planemo/galaxy/test/__init__.py
+++ b/planemo/galaxy/test/__init__.py
@@ -1,9 +1,9 @@
 """Entry point and interface for ``planemo.galaxy.test`` package."""
-from .actions import run_in_config
-from .structures import StructuredData
 from .actions import handle_reports
 from .actions import handle_reports_and_summary
+from .actions import run_in_config
 
+from .structures import StructuredData
 
 __all__ = [
     "handle_reports",

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -1,25 +1,27 @@
 """Actions related to running and reporting on Galaxy-specific testing."""
+
 import json
 import os
 
 import click
 
-from . import structures as test_structures
-from planemo.test.results import get_dict_value
-from planemo.io import error, info, warn, shell_join
+from galaxy.tools.deps.commands import shell
+
 from planemo.exit_codes import (
-    EXIT_CODE_OK,
     EXIT_CODE_GENERIC_FAILURE,
     EXIT_CODE_NO_SUCH_TARGET,
+    EXIT_CODE_OK,
 )
 from planemo.galaxy.run import (
     run_galaxy_command,
     setup_venv,
 )
+from planemo.io import error, info, shell_join, warn
 from planemo.reports import build_report
+from planemo.test.results import get_dict_value
 
+from . import structures as test_structures
 
-from galaxy.tools.deps.commands import shell
 
 NO_XUNIT_REPORT_MESSAGE = ("Cannot locate xUnit report [%s] for tests - "
                            "required to build planemo report and summarize "

--- a/planemo/galaxy/test/structures.py
+++ b/planemo/galaxy/test/structures.py
@@ -3,8 +3,9 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import os
-from collections import namedtuple
 import xml.etree.ElementTree as ET
+
+from collections import namedtuple
 
 from planemo.io import error
 from planemo.test.results import StructuredData as BaseStructuredData

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -1,7 +1,15 @@
 """Utilities for Galaxy workflows."""
-from collections import namedtuple
 import json
 import os
+
+from collections import namedtuple
+
+import yaml
+
+try:
+    from ephemeris import shed_install
+except ImportError:
+    shed_install = None
 
 try:
     from gxformat2.converter import python_to_workflow
@@ -11,13 +19,6 @@ except ImportError:
     python_to_workflow = None
     BioBlendImporterGalaxyInterface = None
     ImporterGalaxyInterface = object
-
-try:
-    from ephemeris import shed_install
-except ImportError:
-    shed_install = None
-
-import yaml
 
 
 def load_shed_repos(path):

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -7,15 +7,17 @@ import shutil
 import sys
 import tempfile
 import time
-from six import StringIO
 from xml.sax.saxutils import escape
 
 import click
+
 from galaxy.tools.deps import commands
 from galaxy.tools.deps.commands import download_command
+from six import StringIO
+
 from .exit_codes import (
-    EXIT_CODE_OK,
     EXIT_CODE_NO_SUCH_TARGET,
+    EXIT_CODE_OK,
 )
 
 

--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -1,13 +1,15 @@
 import os
+
 import requests
 
-from six.moves.urllib.request import (
-    urlopen,
-)
 from six.moves.urllib.error import (
     HTTPError,
     URLError,
 )
+from six.moves.urllib.request import (
+    urlopen,
+)
+
 from planemo.shed import find_urls_for_xml
 from planemo.xml import validation
 

--- a/planemo/linters/xsd.py
+++ b/planemo/linters/xsd.py
@@ -1,26 +1,24 @@
-""" Tool linting module that lints Galaxy tool against experimental XSD.
-"""
+"""Tool linting module that lints Galaxy tool against experimental XSD."""
 import copy
 import os
 import tempfile
 
-from planemo.xml import XSDS_PATH
 import planemo.lint
+
+from planemo.xml import XSDS_PATH
 
 TOOL_XSD = os.path.join(XSDS_PATH, "tool", "galaxy.xsd")
 
 
 def lint_tool_xsd(root, lint_ctx):
-    """ Write a temp file out and lint it.
-    """
+    """Write a temp file out and lint it."""
     with tempfile.NamedTemporaryFile() as tf:
         _clean_root(root).write(tf.name)
         planemo.lint.lint_xsd(lint_ctx, TOOL_XSD, tf.name)
 
 
 def _clean_root(root):
-    """ XSD assumes macros have been expanded, so remove them.
-    """
+    """XSD assumes macros have been expanded, so remove them."""
     clean_root = copy.deepcopy(root)
     to_remove = []
     for macros_el in clean_root.findall("macros"):

--- a/planemo/reports/build_report.py
+++ b/planemo/reports/build_report.py
@@ -1,6 +1,8 @@
 import json
-from pkg_resources import resource_string
+
 from jinja2 import Environment, PackageLoader
+from pkg_resources import resource_string
+
 env = Environment(loader=PackageLoader('planemo', 'reports'))
 
 

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -18,8 +18,9 @@ from galaxy.tools.loader_directory import (
     looks_like_a_tool_xml,
 )
 from galaxy.tools.parser import get_tool_source
-from planemo.galaxy.workflows import describe_outputs
+
 from planemo.exit_codes import EXIT_CODE_UNKNOWN_FILE_TYPE, ExitCodeException
+from planemo.galaxy.workflows import describe_outputs
 from planemo.io import error
 from planemo.test import check_output
 

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -1,5 +1,4 @@
 """Abstractions for shed related interactions used by the rest of planemo."""
-from collections import namedtuple
 import contextlib
 import copy
 import fnmatch
@@ -10,38 +9,41 @@ import re
 import shutil
 import sys
 import tarfile
+
+from collections import namedtuple
 from tempfile import (
     mkstemp,
 )
-from galaxy.util import odict
 
 import six
 import yaml
-from planemo.shed2tap.base import BasePackage
 
-from planemo.io import (
-    error,
-    shell,
-    info,
-    can_write_to_path,
-    temp_directory,
-    coalesce_return_codes,
-)
+from galaxy.util import odict
+
 from planemo import git
 from planemo import glob
-from planemo.tools import load_tool_elements_from_path
 from planemo import templates
-
-from .interface import (
-    username,
-    tool_shed_instance,
-    find_repository,
-    api_exception_to_message,
-    find_category_ids,
-    download_tar,
-    latest_installable_revision,
+from planemo.io import (
+    can_write_to_path,
+    coalesce_return_codes,
+    error,
+    info,
+    shell,
+    temp_directory,
 )
+from planemo.shed2tap.base import BasePackage
+from planemo.tools import load_tool_elements_from_path
+
 from .diff import diff_and_remove
+from .interface import (
+    api_exception_to_message,
+    download_tar,
+    find_category_ids,
+    find_repository,
+    latest_installable_revision,
+    tool_shed_instance,
+    username,
+)
 
 SHED_CONFIG_NAME = '.shed.yml'
 REPO_DEPENDENCIES_CONFIG_NAME = "repository_dependencies.xml"

--- a/planemo/shed/interface.py
+++ b/planemo/shed/interface.py
@@ -1,12 +1,12 @@
-""" Interface over bioblend and direct access to ToolShed
-API via requests.
-"""
+"""Interface over bioblend and direct access to ToolShed API via requests."""
+
 import json
-from planemo.io import untar_to
+
 from planemo.bioblend import (
-    toolshed,
     ensure_module,
+    toolshed,
 )
+from planemo.io import untar_to
 
 REPOSITORY_DOWNLOAD_TEMPLATE = (
     "%srepository/download?repository_id=%s"

--- a/planemo/shed2tap/base.py
+++ b/planemo/shed2tap/base.py
@@ -1,19 +1,20 @@
 from __future__ import print_function
 
-from xml.etree import ElementTree
-
-from six.moves import map as imap
-from six.moves.urllib.request import urlretrieve
-from six.moves.urllib.error import URLError
-from six import string_types
-from six import iteritems
-
 import os
-import sys
 import subprocess
+import sys
 import tarfile
 import zipfile
+
 from ftplib import all_errors as FTPErrors  # tuple of exceptions
+from xml.etree import ElementTree
+
+from six import string_types
+from six import iteritems
+from six.moves import map as imap
+from six.moves.urllib.error import URLError
+from six.moves.urllib.request import urlretrieve
+
 
 TOOLSHED_MAP = {
     "toolshed": "https://toolshed.g2.bx.psu.edu",

--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -1,32 +1,35 @@
 from __future__ import absolute_import
+
 import os
-import yaml
-from galaxy.tools.lint import LintContext
-from galaxy.tools.linters.help import rst_invalid
-from planemo.lint import lint_xsd
-from planemo.shed import (
-    REPO_TYPE_UNRESTRICTED,
-    REPO_TYPE_TOOL_DEP,
-    REPO_TYPE_SUITE,
-    CURRENT_CATEGORIES,
-    validate_repo_owner,
-    validate_repo_name,
-)
-from planemo.tool_lint import (
-    build_lint_args,
-    yield_tool_sources,
-    handle_tool_load_error,
-)
-from planemo.lint import lint_urls
-from planemo.shed2tap import base
-from planemo.xml import XSDS_PATH
+
 import xml.etree.ElementTree as ET
 
+import yaml
 
-from planemo.io import info
-from planemo.io import error
-
+from galaxy.tools.lint import LintContext
 from galaxy.tools.lint import lint_tool_source_with
+from galaxy.tools.linters.help import rst_invalid
+
+from planemo.io import error
+from planemo.io import info
+from planemo.lint import lint_urls
+from planemo.lint import lint_xsd
+from planemo.shed import (
+    CURRENT_CATEGORIES,
+    REPO_TYPE_SUITE,
+    REPO_TYPE_TOOL_DEP,
+    REPO_TYPE_UNRESTRICTED,
+    validate_repo_name,
+    validate_repo_owner,
+)
+from planemo.shed2tap import base
+from planemo.tool_lint import (
+    build_lint_args,
+    handle_tool_load_error,
+    yield_tool_sources,
+)
+from planemo.xml import XSDS_PATH
+
 
 TOOL_DEPENDENCIES_XSD = os.path.join(XSDS_PATH, "tool_dependencies.xsd")
 REPO_DEPENDENCIES_XSD = os.path.join(XSDS_PATH, "repository_dependencies.xsd")

--- a/planemo/test/_check_output.py
+++ b/planemo/test/_check_output.py
@@ -1,7 +1,8 @@
 """Check an output file from a generalize artifact test."""
-from galaxy.tools.verify import verify
 
 import os
+
+from galaxy.tools.verify import verify
 
 
 def check_output(runnable, output_properties, test_properties, **kwds):

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -3,13 +3,15 @@
 This class is used by the `tool_init` command and can be used to build
 Galaxy and CWL tool descriptions.
 """
-from collections import namedtuple
+
 import re
 import shlex
 import subprocess
 
-from planemo import templates
+from collections import namedtuple
+
 from planemo import io
+from planemo import templates
 
 
 TOOL_TEMPLATE = """<tool id="{{id}}" name="{{name}}" version="{{version}}">

--- a/planemo/tool_lint.py
+++ b/planemo/tool_lint.py
@@ -2,24 +2,25 @@ from __future__ import absolute_import
 
 import os
 
-from planemo.io import info
-from planemo.io import error
-from planemo.io import coalesce_return_codes
-from planemo.exit_codes import (
-    EXIT_CODE_OK,
-    EXIT_CODE_GENERIC_FAILURE,
-)
+from galaxy.tools.lint import lint_tool_source
 
 import planemo.linters.doi
 import planemo.linters.urls
 import planemo.linters.xsd
 
-
-from planemo.tools import (
-    load_tool_sources_from_path,
-    is_tool_load_error,
+from planemo.exit_codes import (
+    EXIT_CODE_GENERIC_FAILURE,
+    EXIT_CODE_OK,
 )
-from galaxy.tools.lint import lint_tool_source
+from planemo.io import (
+    coalesce_return_codes,
+    error,
+    info,
+)
+from planemo.tools import (
+    is_tool_load_error,
+    load_tool_sources_from_path,
+)
 
 SKIP_XML_MESSAGE = "Skipping XML file - does not appear to be a tool %s."
 LINTING_TOOL_MESSAGE = "Linting tool %s"

--- a/planemo/tools.py
+++ b/planemo/tools.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 
 import sys
 import traceback
-from planemo.io import error
 
 from galaxy.tools import loader_directory
+
+from planemo.io import error
 
 is_tool_load_error = loader_directory.is_tool_load_error
 

--- a/planemo/xml/validation.py
+++ b/planemo/xml/validation.py
@@ -1,9 +1,9 @@
 import abc
-from collections import namedtuple
 import subprocess
 
-from galaxy.tools.deps.commands import which
+from collections import namedtuple
 
+from galaxy.tools.deps.commands import which
 try:
     from lxml import etree
 except ImportError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,5 @@ logging-level=INFO
 max-line-length = 150
 max-complexity = 11
 exclude=planemo/cwl/cwl2script
+import-order-style = smarkets
+application-import-names = planemo,test

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ setenv =
 [testenv:py27-lint]
 commands = flake8 {[tox]source_dir} {[tox]source_dir}
 skip_install = True
-deps = flake8
+deps =
+     flake8
+     flake8-import-order
 
 [testenv:py27-lint-imports]
 commands = flake8 {[tox]source_dir} {[tox]source_dir}


### PR DESCRIPTION
- Fix order to the Galaxy standard throughout.
- Make flake8-import-order part of the normal linting process.
- Remove the tox import order specific test from Travis.