### PR TITLE
Update Conda support for recent Galaxy improvements.

### DIFF
--- a/planemo/commands/cmd_conda_env.py
+++ b/planemo/commands/cmd_conda_env.py
@@ -43,7 +43,7 @@ def cli(ctx, path, **kwds):
         % which bowtie2
         TODO_PLACE_PATH_HERE
     """
-    conda_context = build_conda_context(use_planemo_shell_exec=False, **kwds)
+    conda_context = build_conda_context(ctx, use_planemo_shell_exec=False, **kwds)
     conda_targets = collect_conda_targets(
         path, conda_context=conda_context
     )

--- a/planemo/commands/cmd_conda_init.py
+++ b/planemo/commands/cmd_conda_init.py
@@ -21,5 +21,5 @@ def cli(ctx, **kwds):
     license a 3-clause BSD 3 license. Please review full license at
     http://docs.continuum.io/anaconda/eula.
     """
-    conda_context = build_conda_context(**kwds)
+    conda_context = build_conda_context(ctx, **kwds)
     return conda_util.install_conda(conda_context=conda_context)

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -6,16 +6,35 @@ from galaxy.tools.deps import conda_util
 from planemo import options
 from planemo.cli import command_function
 from planemo.conda import build_conda_context, collect_conda_targets
-from planemo.io import coalesce_return_codes
+from planemo.exit_codes import EXIT_CODE_FAILED_DEPENDENCIES, ExitCodeException
+from planemo.io import coalesce_return_codes, error
 
 
 @click.command('conda_install')
 @options.optional_tools_arg()
 @options.conda_target_options()
+@options.conda_auto_init_option()
 @command_function
 def cli(ctx, path, **kwds):
     """Install conda packages for tool requirements."""
     conda_context = build_conda_context(ctx, **kwds)
+    if not conda_context.is_conda_installed():
+        auto_init = kwds.get("conda_auto_init", False)
+        failed = True
+        if auto_init:
+            if conda_context.can_install_conda():
+                if conda_util.install_conda(conda_context):
+                    error("Attempted to install conda and failed.")
+                else:
+                    failed = False
+            else:
+                error("Cannot install conda, failing conda_install.")
+        else:
+            error("Conda not configured - run planemo conda_init' or pass --conda_auto_init to continue.")
+
+        if failed:
+            raise ExitCodeException(EXIT_CODE_FAILED_DEPENDENCIES)
+
     return_codes = []
     for conda_target in collect_conda_targets(path):
         ctx.log("Install conda target %s" % conda_target)

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -15,7 +15,7 @@ from planemo.io import coalesce_return_codes
 @command_function
 def cli(ctx, path, **kwds):
     """Install conda packages for tool requirements."""
-    conda_context = build_conda_context(**kwds)
+    conda_context = build_conda_context(ctx, **kwds)
     return_codes = []
     for conda_target in collect_conda_targets(path):
         ctx.log("Install conda target %s" % conda_target)

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -1,7 +1,10 @@
-""" Planemo specific utilities for dealing with conda, extending Galaxy's
-features with planemo specific idioms.
+"""Planemo specific utilities for dealing with conda.
+
+The extend Galaxy/galaxy-lib's features with planemo specific idioms.
 """
 from __future__ import absolute_import
+
+import os
 
 from galaxy.tools.deps import conda_util
 from galaxy.tools.deps.requirements import parse_requirements_from_xml
@@ -10,20 +13,25 @@ from galaxy.tools.loader_directory import load_tool_elements_from_path
 from planemo.io import shell
 
 
-def build_conda_context(**kwds):
-    """ Build a Galaxy CondaContext tailored to planemo use
-    and common command-line arguments.
+def build_conda_context(ctx, **kwds):
+    """Build a galaxy-lib CondaContext tailored to planemo use.
+
+    Using planemo's common command-line/globa config options.
     """
+    condarc_override_default = os.path.join(ctx.workspace, "condarc")
     conda_prefix = kwds.get("conda_prefix", None)
     use_planemo_shell = kwds.get("use_planemo_shell_exec", True)
     ensure_channels = kwds.get("conda_ensure_channels", "")
+    condarc_override = kwds.get("condarc", condarc_override_default)
     shell_exec = shell if use_planemo_shell else None
     return conda_util.CondaContext(conda_prefix=conda_prefix,
                                    ensure_channels=ensure_channels,
+                                   condarc_override=condarc_override,
                                    shell_exec=shell_exec)
 
 
 def collect_conda_targets(path, found_tool_callback=None, conda_context=None):
+    """Load CondaTarget objects from supplied artifact sources."""
     conda_targets = []
     for (tool_path, tool_xml) in load_tool_elements_from_path(path):
         if found_tool_callback:

--- a/planemo/config.py
+++ b/planemo/config.py
@@ -72,6 +72,7 @@ def planemo_option(*args, **kwargs):
     """
     option_type = kwargs.get("type", None)
     use_global_config = kwargs.pop("use_global_config", False)
+    use_env_var = kwargs.pop("use_env_var", False)
 
     if "default" in kwargs:
         default = kwargs.pop("default")
@@ -93,7 +94,16 @@ def planemo_option(*args, **kwargs):
         kwargs["callback"] = callback
         kwargs["default"] = None
 
-    return click.option(*args, **kwargs)
+    if use_env_var:
+        name = None
+        for arg in args:
+            if arg.startswith("--"):
+                name = arg[len("--"):]
+        assert name
+        kwargs["envvar"] = "PLANEMO_%s" % name.upper()
+
+    option = click.option(*args, **kwargs)
+    return option
 
 
 def global_config_path(config_path=None):

--- a/planemo/exit_codes.py
+++ b/planemo/exit_codes.py
@@ -15,6 +15,9 @@ EXIT_CODE_UNKNOWN_FILE_TYPE = 4
 # An unsupported file type was supplied for a given operation.
 EXIT_CODE_UNSUPPORTED_FILE_TYPE = 5
 
+# A dependency of this operation was unavailable (e.g. conda).
+EXIT_CODE_FAILED_DEPENDENCIES = 6
+
 
 class ExitCodeException(Exception):
     """Exception used by planemo framework to track exit codes for CLI."""

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -432,7 +432,7 @@ def conda_ensure_channels_option():
         use_global_config=True,
         help=("Ensure conda is configured with specified comma separated "
               "list of channels."),
-        default="r,bioconda"
+        default="r,bioconda,iuc",
     )
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -49,6 +49,7 @@ def serve_engine_option():
         type=click.Choice(["galaxy", "docker_galaxy"]),
         default="galaxy",
         use_global_config=True,
+        use_env_var=True,
         help=("Select an engine to serve aritfacts such as tools "
               "and workflows. Defaults to a local Galaxy, but running Galaxy within "
               "a Docker container.")
@@ -102,6 +103,7 @@ def galaxy_email_option():
         type=str,
         default="planemo@galaxyproject.org",
         use_global_config=True,
+        use_env_var=True,
         help="E-mail address to use when launching single-user Galaxy server.",
     )
 
@@ -119,6 +121,7 @@ def galaxy_database_seed_option():
         "--galaxy_database_seed",
         default=None,
         use_global_config=True,
+        use_env_var=True,
         type=click.Path(exists=True, file_okay=True, resolve_path=True),
         help="Preseeded Galaxy sqlite database to target.",
     )
@@ -403,6 +406,7 @@ def conda_prefix_option():
     return planemo_option(
         "--conda_prefix",
         use_global_config=True,
+        use_env_var=True,
         type=click.Path(file_okay=False, dir_okay=True),
         help="Conda prefix to use for conda dependency commands."
     )
@@ -430,6 +434,7 @@ def conda_ensure_channels_option():
         "--conda_ensure_channels",
         type=str,
         use_global_config=True,
+        use_env_var=True,
         help=("Ensure conda is configured with specified comma separated "
               "list of channels."),
         default="r,bioconda,iuc",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ glob2
 virtualenv
 gxformat2>=0.1.1
 ephemeris>=0.2.0
-galaxy-lib>=16.7.10
+galaxy-lib>=16.10.0
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09 ; python_version == '2.7'
 cwltool==1.0.20160726135535 ; python_version == '2.7'


### PR DESCRIPTION
Rev to latest galaxy-lib so that Galaxy handling of conda in master branch matches planemo's. Update planemo for recent changes - including always setting a condarc file up when using planemo - this is needed to fix channel handling for galaxy-lib update which sets up a $HOME for every conda command. Also update the list of default channels and improve verbose logging around these things.