### PR TITLE
Update_writing_using_seqtk.rst

### DIFF
--- a/docs/_writing_using_seqtk.rst
+++ b/docs/_writing_using_seqtk.rst
@@ -37,7 +37,7 @@ command - ``seq`` which converts FASTQ files into FASTA.
 ::
 
     $ wget https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/2.fastq
-    $ seqtk seq -a 2.fastq > 2.fasta
+    $ seqtk seq -A 2.fastq > 2.fasta
     $ cat 2.fasta
     >EAS54_6_R1_2_1_413_324
     CCCTTCTTGTCTTCAGCGTTTCTCC


### PR DESCRIPTION
`-A` replaced the `-a` as mentioned in the option section of seqtk seq, despite `-a` just did the job!!!!
A matter of consistency!!