### PR TITLE
Update_writing_using_seqtk02.rst

### DIFF
--- a/docs/_writing_suites.rst
+++ b/docs/_writing_suites.rst
@@ -19,7 +19,7 @@ is now we are adding the ``--macros`` flag).
                         --id 'seqtk_seq' \
                         --name 'Convert to FASTA (seqtk)' \
                         --requirement seqtk@1.0-r68 \
-                        --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                        --example_command 'seqtk seq -A 2.fastq > 2.fasta' \
                         --example_input 2.fastq \
                         --example_output 2.fasta \
                         --test_case \


### PR DESCRIPTION
`-A` replaced the `-a` as mentioned in the option section of seqtk seq, despite `-a` just did the job!!!!
A matter of consistency!!
as in:
https://github.com/galaxyproject/planemo/pull/561