### PR TITLE
Implement linting requirements against best practice Conda channels.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ install:
 
 setup-venv: ## setup a development virutalenv in current directory
 	if [ ! -d $(VENV) ]; then virtualenv $(VENV); exit; fi;
-	$(IN_VENV) pip install -r requirements.txt && pip install -r dev-requirements.txt
+	$(IN_VENV) pip install --upgrade pip && pip install -r requirements.txt && pip install -r dev-requirements.txt
 
 setup-git-hook-lint: ## setup precommit hook for linting project
 	cp $(BUILD_SCRIPTS_DIR)/pre-commit-lint .git/hooks/pre-commit

--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -27,6 +27,12 @@ from planemo.tool_lint import lint_tools_on_path
     default=False,
     help="Check validity of DOIs in XML files",
 )
+@click.option(
+    "--conda_requirements",
+    is_flag=True,
+    default=False,
+    help="Check tool requirements for availability in best practice Conda channels.",
+)
 # @click.option(
 # "--verify",
 # is_flag=True,

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -7,8 +7,7 @@ from __future__ import absolute_import
 import os
 
 from galaxy.tools.deps import conda_util
-from galaxy.tools.deps.requirements import parse_requirements_from_xml
-from galaxy.tools.loader_directory import load_tool_elements_from_path
+from galaxy.tools.loader_directory import load_tool_sources_from_path
 
 from planemo.io import shell
 
@@ -33,9 +32,21 @@ def build_conda_context(ctx, **kwds):
 def collect_conda_targets(path, found_tool_callback=None, conda_context=None):
     """Load CondaTarget objects from supplied artifact sources."""
     conda_targets = []
-    for (tool_path, tool_xml) in load_tool_elements_from_path(path):
+    for (tool_path, tool_source) in load_tool_sources_from_path(path):
         if found_tool_callback:
             found_tool_callback(tool_path)
-        requirements, containers = parse_requirements_from_xml(tool_xml)
-        conda_targets.extend(conda_util.requirements_to_conda_targets(requirements))
+        conda_targets.extend(tool_source_conda_targets(tool_source))
     return conda_targets
+
+
+def tool_source_conda_targets(tool_source):
+    """Load CondaTarget object from supplied abstract tool source."""
+    requirements, _ = tool_source.parse_requirements_and_containers()
+    return conda_util.requirements_to_conda_targets(requirements)
+
+
+__all__ = [
+    "build_conda_context",
+    "collect_conda_targets",
+    "tool_source_conda_targets",
+]

--- a/planemo/conda_lint.py
+++ b/planemo/conda_lint.py
@@ -1,8 +1,10 @@
 """Logic for linting conda recipes."""
 
-import os
+from __future__ import absolute_import
 
 from functools import wraps
+
+from galaxy.tools.deps.conda_compat import raw_metadata
 
 from planemo.conda_verify.recipe import (
     check_build_number,
@@ -16,8 +18,6 @@ from planemo.conda_verify.recipe import (
     FIELDS,
     get_field,
     RecipeError,
-    render_jinja2,
-    yamlize,
 )
 from planemo.exit_codes import (
     EXIT_CODE_GENERIC_FAILURE,
@@ -93,12 +93,7 @@ def lints_metadata(f):
 
     @wraps(f)
     def wrapper(recipe_dir, lint_ctx):
-        meta_path = os.path.join(recipe_dir, 'meta.yaml')
-        with open(meta_path, 'rb') as fi:
-            data = fi.read()
-            if b'{{' in data:
-                data = render_jinja2(recipe_dir)
-        meta = dict(yamlize(data))
+        meta = raw_metadata(recipe_dir)
         f(meta, lint_ctx)
 
     return wrapper

--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -14,6 +14,7 @@ from six.moves.urllib.request import (
     urlopen,
 )
 
+import planemo.linters.conda_requirements
 import planemo.linters.doi
 import planemo.linters.urls
 import planemo.linters.xsd
@@ -54,6 +55,9 @@ def _lint_extra_modules(**kwds):
 
     if kwds.get("urls", False):
         linters.append(planemo.linters.urls)
+
+    if kwds.get("conda_requirements", False):
+        linters.append(planemo.linters.conda_requirements)
 
     return linters
 
@@ -117,7 +121,7 @@ def lint_xsd(lint_ctx, schema_path, path):
         msg = msg % (name, validation_result.output)
         lint_ctx.error(msg)
     else:
-        lint_ctx.info("%s found and appears to be valid XML" % name)
+        lint_ctx.info("File validates against XML schema.")
 
 
 def lint_urls(root, lint_ctx):

--- a/planemo/linters/conda_requirements.py
+++ b/planemo/linters/conda_requirements.py
@@ -1,0 +1,29 @@
+"""Ensure requirements are matched in best practice conda channels."""
+
+from galaxy.tools.deps.conda_util import best_search_result
+
+from planemo.conda import tool_source_conda_targets
+
+BEST_PRACTICE_CHANNELS = ["conda-forge", "anaconda", "r", "bioconda"]
+
+
+def lint_requirements_in_conda(tool_source, lint_ctx):
+    """Check requirements of tool source against best practice Conda channels."""
+    conda_targets = tool_source_conda_targets(tool_source)
+    for conda_target in conda_targets:
+        (best_hit, exact) = best_search_result(conda_target, channels_override=BEST_PRACTICE_CHANNELS)
+        conda_target_str = conda_target.package
+        if conda_target.version:
+            conda_target_str += "@%s" % (conda_target.version)
+        if best_hit and exact:
+            template = "Requirement [%s] matches target in best practice Conda channel [%s]."
+            message = template % (conda_target_str, best_hit.get("channel"))
+            lint_ctx.info(message)
+        elif best_hit:
+            template = "Requirement [%s] doesn't exactly match available version [%s] in best practice Conda channel [%s]."
+            message = template % (conda_target_str, best_hit['version'], best_hit.get("channel"))
+            lint_ctx.warn(message)
+        else:
+            template = "Requirement [%s] doesn't match any recipe in a best practice conda channel [%s]."
+            message = template % (conda_target_str, BEST_PRACTICE_CHANNELS)
+            lint_ctx.warn(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ virtualenv
 lxml
 gxformat2>=0.1.1
 ephemeris>=0.2.0
-galaxy-lib>=16.10.0
+galaxy-lib>=16.10.2
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09 ; python_version == '2.7'
 cwltool==1.0.20160726135535 ; python_version == '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ virtualenv
 lxml
 gxformat2>=0.1.1
 ephemeris>=0.2.0
-galaxy-lib>=16.10.2
+galaxy-lib>=16.10.3
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09 ; python_version == '2.7'
 cwltool==1.0.20160726135535 ; python_version == '2.7'


### PR DESCRIPTION
- Rev galaxy-lib to bring in an initial PyPI conda-build compatibility layer (use conda-build when present and use local hacks if not). 
- Implement a ``--conda_requirements`` flag on ``lint`` to check if requirements are available in best practice channels.
- Some small cleanups here and there.