### PR TITLE
Mulled support

### DIFF
--- a/planemo/commands/cmd_conda_env.py
+++ b/planemo/commands/cmd_conda_env.py
@@ -46,7 +46,7 @@ def cli(ctx, path, **kwds):
     """
     conda_context = build_conda_context(ctx, use_planemo_shell_exec=False, **kwds)
     conda_targets = collect_conda_targets(
-        path, conda_context=conda_context
+        ctx, path, conda_context=conda_context
     )
     installed_conda_targets = conda_util.filter_installed_targets(
         conda_targets, conda_context=conda_context

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -11,11 +11,11 @@ from planemo.io import coalesce_return_codes, error
 
 
 @click.command('conda_install')
-@options.optional_tools_arg()
+@options.optional_tools_arg(multiple=True)
 @options.conda_target_options()
 @options.conda_auto_init_option()
 @command_function
-def cli(ctx, path, **kwds):
+def cli(ctx, paths, **kwds):
     """Install conda packages for tool requirements."""
     conda_context = build_conda_context(ctx, **kwds)
     if not conda_context.is_conda_installed():
@@ -36,7 +36,7 @@ def cli(ctx, path, **kwds):
             raise ExitCodeException(EXIT_CODE_FAILED_DEPENDENCIES)
 
     return_codes = []
-    for conda_target in collect_conda_targets(path):
+    for conda_target in collect_conda_targets(ctx, paths):
         ctx.log("Install conda target %s" % conda_target)
         return_code = conda_util.install_conda_target(
             conda_target, conda_context=conda_context

--- a/planemo/commands/cmd_mull.py
+++ b/planemo/commands/cmd_mull.py
@@ -1,0 +1,33 @@
+"""Module describing the planemo ``mull`` command."""
+import click
+
+from galaxy.tools.deps.mulled.mulled_build import mull_targets
+from galaxy.tools.deps.mulled.util import build_target
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.conda import collect_conda_target_lists
+from planemo.mulled import build_mull_target_kwds
+
+
+@click.command('mull')
+@options.optional_tools_arg(multiple=True)
+@options.recursive_option()
+@command_function
+def cli(ctx, paths, **kwds):
+    """Build containers for specified tools.
+
+    Supplied tools will be inspected for referenced requirement packages. For
+    each combination of requirements a "mulled" container will be built. Galaxy
+    can automatically discover this container and subsequently use it to run
+    or test the tool.
+
+    For this to work, the tool's requirements will need to be present in a known
+    Conda channel such as bioconda (https://github.com/bioconda/bioconda-recipes).
+    This can be verified by running ``planemo lint --conda_requirements`` on the
+    target tool(s).
+    """
+    for conda_targets in collect_conda_target_lists(ctx, paths):
+        mulled_targets = map(lambda c: build_target(c.package, c.version), conda_targets)
+        mull_target_kwds = build_mull_target_kwds(ctx, **kwds)
+        mull_targets(mulled_targets, command="build", **mull_target_kwds)

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -44,6 +44,20 @@ def collect_conda_targets(ctx, paths, found_tool_callback=None, conda_context=No
     return conda_targets
 
 
+def collect_conda_target_lists(ctx, paths, found_tool_callback=None):
+    """Load CondaTarget lists from supplied artifact sources.
+
+    If a tool contains more than one requirement, the requirements will all
+    appear together as one list element of the output list.
+    """
+    conda_target_lists = set([])
+    for (tool_path, tool_source) in yield_tool_sources_on_paths(ctx, paths):
+        if found_tool_callback:
+            found_tool_callback(tool_path)
+        conda_target_lists.add(frozenset(tool_source_conda_targets(tool_source)))
+    return conda_target_lists
+
+
 def tool_source_conda_targets(tool_source):
     """Load CondaTarget object from supplied abstract tool source."""
     requirements, _ = tool_source.parse_requirements_and_containers()
@@ -53,5 +67,6 @@ def tool_source_conda_targets(tool_source):
 __all__ = [
     "build_conda_context",
     "collect_conda_targets",
+    "collect_conda_target_lists",
     "tool_source_conda_targets",
 ]

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import
 import os
 
 from galaxy.tools.deps import conda_util
-from galaxy.tools.loader_directory import load_tool_sources_from_path
 
 from planemo.io import shell
+from planemo.tools import yield_tool_sources_on_paths
 
 
 def build_conda_context(ctx, **kwds):
@@ -29,13 +29,18 @@ def build_conda_context(ctx, **kwds):
                                    shell_exec=shell_exec)
 
 
-def collect_conda_targets(path, found_tool_callback=None, conda_context=None):
-    """Load CondaTarget objects from supplied artifact sources."""
-    conda_targets = []
-    for (tool_path, tool_source) in load_tool_sources_from_path(path):
+def collect_conda_targets(ctx, paths, found_tool_callback=None, conda_context=None):
+    """Load CondaTarget objects from supplied artifact sources.
+
+    If a tool contains more than one requirement, the requirements will each
+    appear once in the output.
+    """
+    conda_targets = set([])
+    for (tool_path, tool_source) in yield_tool_sources_on_paths(ctx, paths):
         if found_tool_callback:
             found_tool_callback(tool_path)
-        conda_targets.extend(tool_source_conda_targets(tool_source))
+        for target in tool_source_conda_targets(tool_source):
+            conda_targets.add(target)
     return conda_targets
 
 

--- a/planemo/mulled.py
+++ b/planemo/mulled.py
@@ -1,0 +1,46 @@
+"""Planemo specific utilities for dealing with mulled containers.
+
+The extend Galaxy/galaxy-lib's features with planemo specific idioms.
+"""
+from __future__ import absolute_import
+
+import os
+
+from galaxy.tools.deps.mulled.mulled_build import (
+    DEFAULT_CHANNELS,
+    ensure_installed,
+    InvolucroContext,
+)
+
+from planemo.io import shell
+
+
+def build_involucro_context(ctx, **kwds):
+    """Build a galaxy-lib CondaContext tailored to planemo use.
+
+    Using planemo's common command-line/global config options.
+    """
+    involucro_path_default = os.path.join(ctx.workspace, "involucro")
+    involucro_path = kwds.get("involucro_path", involucro_path_default)
+    use_planemo_shell = kwds.get("use_planemo_shell_exec", True)
+    shell_exec = shell if use_planemo_shell else None
+    involucro_context = InvolucroContext(involucro_bin=involucro_path,
+                                         shell_exec=shell_exec)
+    if not ensure_installed(involucro_context, True):
+        raise Exception("Failed to install involucro for Planemo.")
+    return involucro_context
+
+
+def build_mull_target_kwds(ctx, **kwds):
+    """Adapt Planemo's CLI and workspace configuration to galaxy-lib's mulled_build options."""
+    involucro_context = build_involucro_context(ctx, **kwds)
+    channels = kwds.get("conda_ensure_channels", ",".join(DEFAULT_CHANNELS))
+
+    return {
+        'involucro_context': involucro_context,
+        'channels': channels.split(","),
+    }
+
+__all__ = [
+    "build_involucro_context",
+]

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -333,6 +333,14 @@ def job_config_option():
     )
 
 
+def mulled_containers_option():
+    return planemo_option(
+        "--mulled_containers",
+        is_flag=True,
+        help="Test tools against mulled containers (forces --docker).",
+    )
+
+
 def install_galaxy_option():
     return planemo_option(
         "--install_galaxy",
@@ -430,6 +438,8 @@ def conda_debug_option():
 
 def conda_ensure_channels_option():
     return planemo_option(
+        "conda_ensure_channels",
+        "--conda_channels",
         "--conda_ensure_channels",
         type=str,
         use_global_config=True,
@@ -878,6 +888,7 @@ def galaxy_target_options():
         no_cleanup_option(),
         galaxy_email_option(),
         galaxy_docker_options(),
+        mulled_containers_option(),
         # Profile options...
         job_config_option(),
         tool_dependency_dir_option(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ virtualenv
 lxml
 gxformat2>=0.1.1
 ephemeris>=0.2.0
-galaxy-lib>=16.10.3
+galaxy-lib>=16.10.5
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09 ; python_version == '2.7'
 cwltool==1.0.20160726135535 ; python_version == '2.7'

--- a/scripts/update_bioconda.bash
+++ b/scripts/update_bioconda.bash
@@ -2,24 +2,57 @@
 
 set -e
 
-BIOCONDA_PROJECT="jmchilton/bioconda-recipes"
-RECIPE="recipes/planemo"
-VERSION=`python -c "import xmlrpclib; print xmlrpclib.ServerProxy('https://pypi.python.org/pypi').package_releases('planemo')[0]"`
-URL=`python -c "import xmlrpclib; import re; print re.escape([s for s in xmlrpclib.ServerProxy('https://pypi.python.org/pypi').release_urls('planemo', '$VERSION') if s['filename'].endswith('.tar.gz')][0]['url'])"`
-MD5SUM=`md5sum dist/planemo-$VERSION.tar.gz | cut -d' ' -f1`
+PACKAGE="planemo"
+CONDA_RECIPES="bioconda-recipes"
+UPSTREAM="bioconda"
 
-if [ ! -d bioconda ];
+HUB_EXEC=${HUB_EXEC:-`which hub | echo ''`}
+if [ -z "$HUB_EXEC" ];
 then
-    git clone git@github.com:$BIOCONDA_PROJECT.git bioconda-recipes
+    HUB_EXEC="./hub/hub"
 fi
-cd bioconda-recipes
+HUB_EXEC=`python2 -c "import os; print os.path.abspath('$HUB_EXEC')"`
+echo "Using hub executable $HUB_EXEC"
 
-sed -E -i "s/^  version: .*$/  version: \"$VERION\"" $RECIPE/meta.yaml
-sed -E -i "s/^  url: .*$/  url: $URL/" $RECIPE/meta.yaml
-sed -E -i "s/^  md5: .*$/  md5: $MD5SUM/" $RECIPE/meta.yaml
+CONDA_EXEC=${CONDA_EXEC:-`which conda | echo ''`}
+if [ -z "$CONDA_EXEC" ];
+then
+    CONDA_EXEC=~/miniconda2/bin/conda
+fi
+CONDA_EXEC=`python2 -c "import os; print os.path.abspath('$CONDA_EXEC')"`
 
-conda build $RECIPE --channel bioconda --channel r
-git add 
-git add $RECIPE/meta.yaml
-git commit -m "Rev planemo to version $VERSION"
-git push origin master
+RECIPE="recipes/$PACKAGE"
+VERSION=`python2 -c "import xmlrpclib; print xmlrpclib.ServerProxy('https://pypi.python.org/pypi').package_releases('$PACKAGE')[0]"`
+URL=`python2 -c "import xmlrpclib; import re; print re.escape([s for s in xmlrpclib.ServerProxy('https://pypi.python.org/pypi').release_urls('$PACKAGE', '$VERSION') if s['filename'].endswith('.tar.gz')][0]['url'])"`
+MD5SUM=`md5sum dist/$PACKAGE-$VERSION.tar.gz | cut -d' ' -f1`
+GITHUB_USER=`python2 -c "import json; import os.path; print json.loads(open(os.path.expanduser('~/.github.json'), 'r').read())['login']"`
+BRANCH="$PACKAGE-$VERSION"
+
+if [ ! -d $CONDA_RECIPES ];
+then
+    $HUB_EXEC clone $UPSTREAM/$CONDA_RECIPES
+fi
+cd $CONDA_RECIPES
+$HUB_EXEC fork | true
+
+git checkout master
+git merge --ff-only origin/master
+
+METADATA="$RECIPE/meta.yaml"
+OLD_VERSION=`python2 -c "import yaml; print yaml.load(open('$METADATA', 'r').read())['package']['version']"`
+
+OLD_RECIPE="$RECIPE/$OLD_VERSION"
+mkdir "$OLD_RECIPE"
+find "$RECIPE" -maxdepth 1 -type f | xargs -I {} cp {} "$OLD_RECIPE"
+
+git checkout -b "$BRANCH"
+
+sed -E -i "s/^  version: .*$/  version: \"$VERSION\"/" $METADATA
+sed -E -i "s/^  url: .*$/  url: $URL/" $METADATA
+sed -E -i "s/^  md5: .*$/  md5: $MD5SUM/" $METADATA
+
+"$CONDA_EXEC" build "$RECIPE" --channel bioconda --channel r
+git add "$RECIPE/meta.yaml"
+git add "$OLD_RECIPE"
+git commit -m "Update $PACKAGE to version $VERSION"
+git push "$GITHUB_USER" "$BRANCH"


### PR DESCRIPTION
Implement option to build mulled containers for tools:

```
    planemo mull [/path/to/tools]*
```

Implement option to force tool serving and execution to occur in mulled containers.

```
    planemo test --mulled_containers [/path/to/tools]*
    planemo serve --mulled_containers [/path/to/tools]*
```

These runtime options (test and serve) will require target Galaxy to include https://github.com/galaxyproject/galaxy/pull/2986.