### PR TITLE
planemo raise proper exception during `planemo ci_find_repos`

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -900,7 +900,7 @@ def _find_raw_repositories(path, **kwds):
             config = shed_repo_config(shed_file_dir, name=name)
         except Exception as e:
             error_message = PARSING_PROBLEM % (shed_file_dir, e)
-            return [RuntimeError(error_message)]
+            raise RuntimeError(error_message)
         config_name = config.get("name", None)
 
     if len(shed_file_dirs) > 1 and name is not None:


### PR DESCRIPTION
When I was running a travis test on a tool with an invalid `.shed.yml` file containing two colons at the same line):

```
categories:
- SAM
- RNA
description: tool: moretext
...
```

Planemo crashed with the following error:

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.9/bin/planemo", line 11, in <module>
    sys.exit(planemo())
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/planemo/cli.py", line 175, in handle_profile_options
    return f(*args, **kwds)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/planemo/commands/cmd_ci_find_repos.py", line 24, in cli
    raw_paths = [r.path for r in repos]
AttributeError: 'exceptions.RuntimeError' object has no attribute 'path'
```

This error is unclear and doesn't allow to trace the actual problem back very easily. In the `_find_raw_repositories`-function, the Exception was returned within a list, instead of being thrown. Other functions, like `find_raw_repositories`, expect it to return a list of strings containing repositories.

I hope this patch safely solves the issue without introducing any new problems.

Youri
