### PR TITLE
Raise an exception in ci_find_repos if an error is encountered.

### DIFF
--- a/planemo/commands/cmd_ci_find_repos.py
+++ b/planemo/commands/cmd_ci_find_repos.py
@@ -20,7 +20,10 @@ def cli(ctx, paths, **kwds):
     file.
     """
     kwds["recursive"] = True
+    kwds["fail_fast"] = True
     repos = find_raw_repositories(ctx, paths, **kwds)
+    # Since fail_fast is True, all repos are actual raw repo objects and
+    # not exceptions.
     raw_paths = [r.path for r in repos]
     paths = filter_paths(ctx, raw_paths, path_type="dir", **kwds)
     print_path_list(paths, **kwds)

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -900,7 +900,9 @@ def _find_raw_repositories(path, **kwds):
             config = shed_repo_config(shed_file_dir, name=name)
         except Exception as e:
             error_message = PARSING_PROBLEM % (shed_file_dir, e)
-            return [RuntimeError(error_message)]
+            exception = RuntimeError(error_message)
+            _handle_realization_error(exception, **kwds)
+            return [exception]
         config_name = config.get("name", None)
 
     if len(shed_file_dirs) > 1 and name is not None:


### PR DESCRIPTION
An alternative to #600 which would always throw an exception - even when we would want to continue to process valid repositories (such as in shed linting).