### PR TITLE
fix- pip ignores bioconda_scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ TEST_DIR = 'tests'
 PROJECT_DESCRIPTION = 'Command-line utilities to assist in building tools for the Galaxy project (http://galaxyproject.org/).'
 PACKAGES = [
     'planemo',
+    'planemo.bioconda_scripts',
     'planemo.cwl',
     'planemo.cwl.cwl2script',
     'planemo.commands',


### PR DESCRIPTION
This should fix this issue, https://github.com/galaxyproject/planemo/issues/493. 

```
(planemo_env) ~/test❯❯❯ planemo
Problem loading command bioc_conda_recipe_init, exception No module named bioconda_scripts
Problem loading command bioc_tool_init, exception No module named bioconda_scripts
Usage: planemo [OPTIONS] COMMAND [ARGS]...

  A command-line toolkit for building tools and workflows for Galaxy.

  Check out the full documentation for Planemo online
  http://planemo.readthedocs.org or open with ``planemo docs``.

Options:
  --version         Show the version and exit.
  -v, --verbose     Enables verbose mode.
  --config TEXT     Planemo configuration YAML file.
  --directory TEXT  Workspace for planemo.
  --help            Show this message and exit.

Commands:
  brew                   Install tool requirements using brew.
  brew_env               List commands to inject brew dependencies.
  brew_init              Download linuxbrew install & run it in ruby.
  ci_find_repos          Find all shed repositories in one or more...
  ci_find_tools          Find all tools in one or more directories.
  clone                  Short-cut to quickly clone, fork, and branch...
  conda_env              Activate a conda environment for tool.
  conda_init             Download and install conda.
  conda_install          Install conda packages for tool requirements.
  conda_lint             Check conda recipe for common issues.
  config_init            Initialise global configuration for Planemo.
  create_gist            Upload file to GitHub as a sharable gist.
...
```