### PR TITLE
Various Conda Usability Improvements

### DIFF
--- a/docs/_writing_intro.rst
+++ b/docs/_writing_intro.rst
@@ -43,7 +43,7 @@ as follows.
     $ planemo tool_init --force \
                         --id 'seqtk_seq' \
                         --name 'Convert to FASTA (seqtk)' \
-                        --requirement seqtk@1.0-r68 \
+                        --requirement seqtk@1.2 \
                         --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
                         --example_input 2.fastq \
                         --example_output 2.fasta
@@ -62,7 +62,7 @@ definitions for the input and output as well as an actual command template.
     $ planemo tool_init --force \
                         --id 'seqtk_seq' \
                         --name 'Convert to FASTA (seqtk)' \
-                        --requirement seqtk@1.0-r68 \
+                        --requirement seqtk@1.2 \
                         --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
                         --example_input 2.fastq \
                         --example_output 2.fasta \

--- a/docs/_writing_suites.rst
+++ b/docs/_writing_suites.rst
@@ -18,7 +18,7 @@ is now we are adding the ``--macros`` flag).
                         --macros \
                         --id 'seqtk_seq' \
                         --name 'Convert to FASTA (seqtk)' \
-                        --requirement seqtk@1.0-r68 \
+                        --requirement seqtk@1.2 \
                         --example_command 'seqtk seq -A 2.fastq > 2.fasta' \
                         --example_input 2.fastq \
                         --example_output 2.fasta \

--- a/docs/writing/seqtk_macros.xml
+++ b/docs/writing/seqtk_macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
-        <requirement type="package" version="1.0-r68">seqtk</requirement>
+        <requirement type="package" version="1.2">seqtk</requirement>
             <yield/>
         </requirements>
     </xml>

--- a/docs/writing/seqtk_seq_v2.xml
+++ b/docs/writing/seqtk_seq_v2.xml
@@ -1,6 +1,6 @@
 <tool id="seqtk_seq" name="Convert to FASTA (seqtk)" version="0.1.0">
     <requirements>
-        <requirement type="package" version="1.0-r68">seqtk</requirement>
+        <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />

--- a/docs/writing/seqtk_seq_v3.xml
+++ b/docs/writing/seqtk_seq_v3.xml
@@ -1,6 +1,6 @@
 <tool id="seqtk_seq" name="Convert to FASTA (seqtk)" version="0.1.0">
     <requirements>
-        <requirement type="package" version="1.0-r68">seqtk</requirement>
+        <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />

--- a/docs/writing/seqtk_seq_v4.xml
+++ b/docs/writing/seqtk_seq_v4.xml
@@ -1,6 +1,6 @@
 <tool id="seqtk_seq" name="Convert to FASTA (seqtk)" version="0.1.0">
     <requirements>
-        <requirement type="package" version="1.0-r68">seqtk</requirement>
+        <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />

--- a/docs/writing/seqtk_seq_v5.xml
+++ b/docs/writing/seqtk_seq_v5.xml
@@ -1,6 +1,6 @@
 <tool id="seqtk_seq" name="Convert to FASTA (seqtk)" version="0.1.0">
     <requirements>
-        <requirement type="package" version="1.0-r68">seqtk</requirement>
+        <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />

--- a/docs/writing/seqtk_seq_v6.xml
+++ b/docs/writing/seqtk_seq_v6.xml
@@ -1,6 +1,6 @@
 <tool id="seqtk_seq" name="Convert to FASTA (seqtk)" version="0.1.0">
     <requirements>
-        <requirement type="package" version="1.0-r68">seqtk</requirement>
+        <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />

--- a/planemo/commands/cmd_conda_init.py
+++ b/planemo/commands/cmd_conda_init.py
@@ -6,6 +6,13 @@ from galaxy.tools.deps import conda_util
 from planemo import options
 from planemo.cli import command_function
 from planemo.conda import build_conda_context
+from planemo.exit_codes import EXIT_CODE_ALREADY_EXISTS
+from planemo.io import info, warn
+
+
+MESSAGE_ERROR_ALREADY_EXISTS = "conda_init failed - Conda appears to already be installed at '%s'"
+MESSAGE_ERROR_FAILED = "conda_init failed - failed to install to '%s'"
+MESSAGE_INSTALL_OKAY = "Conda installation succeeded - Conda is available at '%s'"
 
 
 @click.command('conda_init')
@@ -20,6 +27,19 @@ def cli(ctx, **kwds):
     By running this command, you are agreeing to the terms of the conda
     license a 3-clause BSD 3 license. Please review full license at
     http://docs.continuum.io/anaconda/eula.
+
+    Planemo will print a warning and terminate with an exit code of 7
+    if Conda is already installed.
     """
     conda_context = build_conda_context(ctx, **kwds)
-    return conda_util.install_conda(conda_context=conda_context)
+    if conda_context.is_conda_installed():
+        warn(MESSAGE_ERROR_ALREADY_EXISTS % conda_context.conda_exec)
+        exit = EXIT_CODE_ALREADY_EXISTS
+    else:
+        exit = conda_util.install_conda(conda_context=conda_context)
+        if exit:
+            warn(MESSAGE_ERROR_FAILED % conda_context.conda_exec)
+        else:
+            info(MESSAGE_INSTALL_OKAY % conda_context.conda_exec)
+
+    ctx.exit(exit)

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -10,8 +10,9 @@ from planemo.io import coalesce_return_codes
 
 
 @click.command('conda_install')
-@options.optional_tools_arg(multiple=True)
+@options.optional_tools_or_packages_arg(multiple=True)
 @options.conda_target_options()
+@options.conda_global_option()
 @options.conda_auto_init_option()
 @command_function
 def cli(ctx, paths, **kwds):
@@ -21,7 +22,7 @@ def cli(ctx, paths, **kwds):
     for conda_target in collect_conda_targets(ctx, paths):
         ctx.log("Install conda target %s" % conda_target)
         return_code = conda_util.install_conda_target(
-            conda_target, conda_context=conda_context
+            conda_target, conda_context=conda_context, skip_environment=kwds.get("global", False)
         )
         return_codes.append(return_code)
     return coalesce_return_codes(return_codes, assert_at_least_one=True)

--- a/planemo/commands/cmd_conda_install.py
+++ b/planemo/commands/cmd_conda_install.py
@@ -6,8 +6,7 @@ from galaxy.tools.deps import conda_util
 from planemo import options
 from planemo.cli import command_function
 from planemo.conda import build_conda_context, collect_conda_targets
-from planemo.exit_codes import EXIT_CODE_FAILED_DEPENDENCIES, ExitCodeException
-from planemo.io import coalesce_return_codes, error
+from planemo.io import coalesce_return_codes
 
 
 @click.command('conda_install')
@@ -17,24 +16,7 @@ from planemo.io import coalesce_return_codes, error
 @command_function
 def cli(ctx, paths, **kwds):
     """Install conda packages for tool requirements."""
-    conda_context = build_conda_context(ctx, **kwds)
-    if not conda_context.is_conda_installed():
-        auto_init = kwds.get("conda_auto_init", False)
-        failed = True
-        if auto_init:
-            if conda_context.can_install_conda():
-                if conda_util.install_conda(conda_context):
-                    error("Attempted to install conda and failed.")
-                else:
-                    failed = False
-            else:
-                error("Cannot install conda, failing conda_install.")
-        else:
-            error("Conda not configured - run planemo conda_init' or pass --conda_auto_init to continue.")
-
-        if failed:
-            raise ExitCodeException(EXIT_CODE_FAILED_DEPENDENCIES)
-
+    conda_context = build_conda_context(ctx, handle_auto_init=True, **kwds)
     return_codes = []
     for conda_target in collect_conda_targets(ctx, paths):
         ctx.log("Install conda target %s" % conda_target)

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -9,8 +9,13 @@ import os
 
 from galaxy.tools.deps import conda_util
 
-from planemo.io import shell
+from planemo.exit_codes import EXIT_CODE_FAILED_DEPENDENCIES, ExitCodeException
+from planemo.io import error, shell
 from planemo.tools import yield_tool_sources_on_paths
+
+MESSAGE_ERROR_FAILED_INSTALL = "Attempted to install conda and failed."
+MESSAGE_ERROR_CANNOT_INSTALL = "Cannot install Conda - perhaps due to a failed installation or permission problems."
+MESSAGE_ERROR_NOT_INSTALLING = "Conda not configured - run ``planemo conda_init`` or pass ``--conda_auto_init`` to continue."
 
 
 def build_conda_context(ctx, **kwds):
@@ -24,10 +29,28 @@ def build_conda_context(ctx, **kwds):
     ensure_channels = kwds.get("conda_ensure_channels", "")
     condarc_override = kwds.get("condarc", condarc_override_default)
     shell_exec = shell if use_planemo_shell else None
-    return conda_util.CondaContext(conda_prefix=conda_prefix,
-                                   ensure_channels=ensure_channels,
-                                   condarc_override=condarc_override,
-                                   shell_exec=shell_exec)
+    conda_context = conda_util.CondaContext(conda_prefix=conda_prefix,
+                                            ensure_channels=ensure_channels,
+                                            condarc_override=condarc_override,
+                                            shell_exec=shell_exec)
+    handle_auto_init = kwds.get("handle_auto_init", False)
+    if handle_auto_init and not conda_context.is_installed():
+        auto_init = kwds.get("conda_auto_init", True)
+        failed = True
+        if auto_init:
+            if conda_context.can_install_conda():
+                if conda_util.install_conda(conda_context):
+                    error(MESSAGE_ERROR_FAILED_INSTALL)
+                else:
+                    failed = False
+            else:
+                error(MESSAGE_ERROR_CANNOT_INSTALL)
+        else:
+            error(MESSAGE_ERROR_NOT_INSTALLING)
+
+        if failed:
+            raise ExitCodeException(EXIT_CODE_FAILED_DEPENDENCIES)
+    return conda_context
 
 
 def collect_conda_targets(ctx, paths, found_tool_callback=None, conda_context=None):

--- a/planemo/conda.py
+++ b/planemo/conda.py
@@ -60,12 +60,35 @@ def collect_conda_targets(ctx, paths, found_tool_callback=None, conda_context=No
     appear once in the output.
     """
     conda_targets = set([])
-    for (tool_path, tool_source) in yield_tool_sources_on_paths(ctx, paths):
+    real_paths = []
+    for path in paths:
+        if not os.path.exists(path):
+            targets = target_str_to_targets(path)
+            [conda_targets.add(_) for _ in targets]
+        else:
+            real_paths.append(path)
+
+    for (tool_path, tool_source) in yield_tool_sources_on_paths(ctx, real_paths):
         if found_tool_callback:
             found_tool_callback(tool_path)
         for target in tool_source_conda_targets(tool_source):
             conda_targets.add(target)
     return conda_targets
+
+
+# Copied and modified from mulled stuff - need to syncronize these concepts.
+def target_str_to_targets(targets_raw):
+    def parse_target(target_str):
+        if "=" in target_str:
+            package_name, version = target_str.split("=", 1)
+        else:
+            package_name = target_str
+            version = None
+        target = conda_util.CondaTarget(package_name, version)
+        return target
+
+    targets = [parse_target(_) for _ in targets_raw.split(",")]
+    return targets
 
 
 def collect_conda_target_lists(ctx, paths, found_tool_callback=None):

--- a/planemo/exit_codes.py
+++ b/planemo/exit_codes.py
@@ -18,6 +18,9 @@ EXIT_CODE_UNSUPPORTED_FILE_TYPE = 5
 # A dependency of this operation was unavailable (e.g. conda).
 EXIT_CODE_FAILED_DEPENDENCIES = 6
 
+# Attempt to do a one time action that already happened.
+EXIT_CODE_ALREADY_EXISTS = 7
+
 
 class ExitCodeException(Exception):
     """Exception used by planemo framework to track exit codes for CLI."""

--- a/planemo/linters/conda_requirements.py
+++ b/planemo/linters/conda_requirements.py
@@ -10,6 +10,10 @@ BEST_PRACTICE_CHANNELS = ["conda-forge", "anaconda", "r", "bioconda"]
 def lint_requirements_in_conda(tool_source, lint_ctx):
     """Check requirements of tool source against best practice Conda channels."""
     conda_targets = tool_source_conda_targets(tool_source)
+    if not conda_targets:
+        lint_ctx.warn("No valid package requirement tags found to check against Conda.")
+        return
+
     for conda_target in conda_targets:
         (best_hit, exact) = best_search_result(conda_target, channels_override=BEST_PRACTICE_CHANNELS)
         conda_target_str = conda_target.package

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -481,6 +481,18 @@ def conda_auto_init_option():
     )
 
 
+def conda_global_option():
+    return planemo_option(
+        "--global",
+        is_flag=True,
+        default=False,
+        help=("Install Conda dependencies globally instead of in requirement specific "
+              "environments packaged for tools. If the Conda bin directory is on your "
+              "PATH, tools may still use binaries but this is more designed for "
+              "interactive testing and debugging.")
+    )
+
+
 def required_tool_arg():
     """ Decorate click method as requiring the path to a single tool.
     """
@@ -512,6 +524,20 @@ def _optional_tools_default(ctx, param, value):
         return [os.path.abspath(os.getcwd())]
     else:
         return value
+
+
+def optional_tools_or_packages_arg(multiple=False):
+    """ Decorate click method as optionally taking in the path to a tool
+    or directory of tools or a Conda package. If no such argument is given
+    the current working directory will be treated as a directory of tools.
+    """
+    name = "paths" if multiple else "path"
+    nargs = -1 if multiple else 1
+    return click.argument(
+        name,
+        metavar="TARGET",
+        nargs=nargs,
+    )
 
 
 def optional_tools_arg(multiple=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ virtualenv
 lxml
 gxformat2>=0.1.1
 ephemeris>=0.2.0
-galaxy-lib>=17.01.2
+galaxy-lib>=17.5.0
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09 ; python_version == '2.7'
 cwltool==1.0.20160726135535 ; python_version == '2.7'

--- a/tests/data/tools/bwa_invalid_version.xml
+++ b/tests/data/tools/bwa_invalid_version.xml
@@ -1,6 +1,6 @@
 <tool id="bwa" name="BWA" version="0.1.0">
     <requirements>
-        <requirement type="package" version="0.7.12">bwa</requirement>
+        <requirement type="package" version="0.4.12">bwa</requirement>
     </requirements>
     <stdio>
         <exit_code range="2:" />

--- a/tests/data/tools/bwa_without_requirements.xml
+++ b/tests/data/tools/bwa_without_requirements.xml
@@ -1,7 +1,4 @@
 <tool id="bwa" name="BWA" version="0.1.0">
-    <requirements>
-        <requirement type="package" version="0.7.12">bwa</requirement>
-    </requirements>
     <stdio>
         <exit_code range="2:" />
     </stdio>

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -75,11 +75,11 @@ class LintTestCase(CliTestCase):
         lint_cmd = ["lint", bwa_no_reqs]
         self._check_exit_code(lint_cmd)
         lint_cmd = ["lint", "--conda_requirements", bwa_no_reqs]
-        self._check_exit_code(lint_cmd, exit_code=1)
+        self._check_exit_code(lint_cmd, exit_code=self.non_zero_exit_code)
 
     def test_lint_conda_requirements_wrong_version(self):
         bwa_wrong_version = os.path.join(TEST_TOOLS_DIR, "bwa_invalid_version.xml")
         lint_cmd = ["lint", bwa_wrong_version]
         self._check_exit_code(lint_cmd)
         lint_cmd = ["lint", "--conda_requirements", bwa_wrong_version]
-        self._check_exit_code(lint_cmd, exit_code=1)
+        self._check_exit_code(lint_cmd, exit_code=self.non_zero_exit_code)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -69,3 +69,17 @@ class LintTestCase(CliTestCase):
         fail_doi = os.path.join(TEST_TOOLS_DIR, "invalid_doi.xml")
         lint_cmd = ["lint", "--doi", fail_doi]
         self._check_exit_code(lint_cmd, exit_code=1)
+
+    def test_lint_conda_requirements_empty(self):
+        bwa_no_reqs = os.path.join(TEST_TOOLS_DIR, "bwa_without_requirements.xml")
+        lint_cmd = ["lint", bwa_no_reqs]
+        self._check_exit_code(lint_cmd)
+        lint_cmd = ["lint", "--conda_requirements", bwa_no_reqs]
+        self._check_exit_code(lint_cmd, exit_code=1)
+
+    def test_lint_conda_requirements_wrong_version(self):
+        bwa_wrong_version = os.path.join(TEST_TOOLS_DIR, "bwa_invalid_version.xml")
+        lint_cmd = ["lint", bwa_wrong_version]
+        self._check_exit_code(lint_cmd)
+        lint_cmd = ["lint", "--conda_requirements", bwa_wrong_version]
+        self._check_exit_code(lint_cmd, exit_code=1)


### PR DESCRIPTION
- Improve error handling and info reporting when using ``conda_init``.
- Allow ``conda_install`` to install package specifiers in addition to tool environments.
- Add ``--global`` option to ``conda_install`` to install requirements into global Conda setup instead of using an environment.
- Make ``lint --conda_requirements`` ensure there is at least one requirement available.
- Add tests for ``lint --conda_requirements``.
- Update the seqtk examples in the documentation to target an actual version of the package available on Bioconda.