### PR TITLE
Implement a --no_dependency_resolution option.

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -102,6 +102,9 @@ DEFAULT_DEPENDENCY_RESOLUTION_CONF = """<dependency_resolvers>
 </dependency_resolvers>
 """
 
+NO_DEPENDENCY_RESOLUTION_CONF = """<dependency_resolvers>
+</dependency_resolvers>
+"""
 
 BREW_DEPENDENCY_RESOLUTION_CONF = """<dependency_resolvers>
   <homebrew />
@@ -208,6 +211,7 @@ STOCK_DEPENDENCY_RESOLUTION_STRATEGIES = {
     "brew_dependency_resolution": BREW_DEPENDENCY_RESOLUTION_CONF,
     "shed_dependency_resolution": SHED_DEPENDENCY_RESOLUTION_CONF,
     "conda_dependency_resolution": CONDA_DEPENDENCY_RESOLUTION_CONF,
+    "no_dependency_resolution": NO_DEPENDENCY_RESOLUTION_CONF,
     "default_dependency_resolution": DEFAULT_DEPENDENCY_RESOLUTION_CONF,
 }
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -236,6 +236,14 @@ def cwl_conformance_test():
     )
 
 
+def no_dependency_resolution():
+    return planemo_option(
+        "--no_dependency_resolution",
+        is_flag=True,
+        help="Configure Galaxy with no dependency resolvers.",
+    )
+
+
 def brew_dependency_resolution():
     return planemo_option(
         "--brew_dependency_resolution",
@@ -890,6 +898,7 @@ def galaxy_config_options():
         dependency_resolvers_option(),
         brew_dependency_resolution(),
         shed_dependency_resolution(),
+        no_dependency_resolution(),
         conda_target_options(),
         conda_dependency_resolution(),
         conda_copy_dependencies_option(),


### PR DESCRIPTION
As requested by @mvdbeek https://github.com/galaxyproject/planemo/issues/633. Prior to the latest release of Planemo Conda would only be enabled with --conda_dependency_resolution despite being on by default in Galaxy.

Fixes #633.

Ping @mvdbeek - I haven't tested it yet - but I wanted to at least take a quick pass. I'll try to come back to this and merge it soon unless you want to test it and merge it first.