### PR TITLE
Implement a planemo open (or planemo o) command.

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -32,6 +32,7 @@ documentation describes these commands.
 .. include:: commands/lint.rst
 .. include:: commands/mull.rst
 .. include:: commands/normalize.rst
+.. include:: commands/open.rst
 .. include:: commands/profile_create.rst
 .. include:: commands/profile_delete.rst
 .. include:: commands/profile_list.rst

--- a/docs/commands/open.rst
+++ b/docs/commands/open.rst
@@ -1,0 +1,20 @@
+
+``open`` command
+======================================
+
+This section is auto-generated from the help text for the planemo command
+``open``. This help message can be generated with ``planemo open
+--help``.
+
+**Usage**::
+
+    planemo open [OPTIONS] PATH
+
+**Help**
+
+Open latest Planemo test results in a web browser.
+**Options**::
+
+
+      --help  Show this message and exit.
+    

--- a/planemo/cli.py
+++ b/planemo/cli.py
@@ -23,6 +23,7 @@ IS_PYTHON_2_7 = sys.version_info[0] == 2 and sys.version_info[1] >= 7
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='PLANEMO')
 COMMAND_ALIASES = {
     "l": "lint",
+    "o": "open",
     "t": "test",
     "s": "serve",
 }

--- a/planemo/commands/cmd_docs.py
+++ b/planemo/commands/cmd_docs.py
@@ -3,11 +3,11 @@ import click
 
 from planemo.cli import command_function
 
-SYNTAX_URL = "http://planemo.readthedocs.org/en/latest/"
+DOCS_URL = "http://planemo.readthedocs.io/en/latest/"
 
 
-@click.command("syntax")
+@click.command("docs")
 @command_function
 def cli(ctx, **kwds):
     """Open Planemo documentation in web browser."""
-    click.launch(SYNTAX_URL)
+    click.launch(DOCS_URL)

--- a/planemo/commands/cmd_open.py
+++ b/planemo/commands/cmd_open.py
@@ -1,0 +1,23 @@
+"""Module describing the planemo ``docs`` command."""
+import click
+
+from planemo.cli import command_function
+
+
+@click.command("docs")
+@click.argument(
+    "path",
+    metavar="PATH",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+    ),
+    default="tool_test_output.html",
+)
+@command_function
+def cli(ctx, path, **kwds):
+    """Open latest Planemo test results in a web browser."""
+    click.launch(path)


### PR DESCRIPTION
A quick, cross-platform way to open previous tool tests in a web browser.