### PR TITLE
Update Planemo for recent CWL Galaxy work.

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1112,7 +1112,7 @@ def _galaxy_branch(kwds):
     branch = kwds.get("galaxy_branch", None)
     if branch is None:
         cwl = kwds.get("cwl", False)
-        branch = "cwl" if cwl else None
+        branch = "cwl-1.0" if cwl else None
     if branch is None:
         branch = DEFAULT_GALAXY_BRANCH
 
@@ -1133,8 +1133,6 @@ def _galaxy_source(kwds):
 def _install_with_command(ctx, config_directory, command, env, kwds):
     # TODO: --watchdog
     pip_installs = []
-    if kwds.get("cwl", False):
-        pip_installs.append("cwltool==1.0.20160626203316")
     if pip_installs:
         pip_install_command = PIP_INSTALL_CMD % " ".join(pip_installs)
     else:

--- a/project_templates/ga4gh_execution_challenge_phase_1/job.json
+++ b/project_templates/ga4gh_execution_challenge_phase_1/job.json
@@ -1,0 +1,1 @@
+{"input_file": {"class": "File", "location": "md5sum.input"}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ gxformat2>=0.1.1
 ephemeris>=0.2.0
 galaxy-lib>=17.5.6
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09 ; python_version == '2.7'
-cwltool==1.0.20160726135535 ; python_version == '2.7'
+cwltool==1.0.20170224141733 ; python_version == '2.7'


### PR DESCRIPTION
Target newer branch of Galaxy when running CWL tools and use newer version of cwltool (pinned to same version as Galaxy branch).