### PR TITLE
Fix ci_find_repos command to not filter repos whose only modifications where in subdirs

### DIFF
--- a/planemo/commands/cmd_ci_find_repos.py
+++ b/planemo/commands/cmd_ci_find_repos.py
@@ -25,5 +25,5 @@ def cli(ctx, paths, **kwds):
     # Since fail_fast is True, all repos are actual raw repo objects and
     # not exceptions.
     raw_paths = [r.path for r in repos]
-    paths = filter_paths(ctx, raw_paths, path_type="dir", **kwds)
+    paths = filter_paths(ctx, raw_paths, path_type="repo", **kwds)
     print_path_list(paths, **kwds)


### PR DESCRIPTION
E.g. in the Travis job:

https://travis-ci.org/galaxyproject/tools-iuc/jobs/240866693

for the pull request:

https://github.com/galaxyproject/tools-iuc/pull/1349

changed_repositories.list should also have contained the repo `data_managers/data_manager_bowtie_index_builder`.