### PR TITLE
Remove stdio from generated tools - just use exit_code for everything.

### DIFF
--- a/docs/_writing_intro.rst
+++ b/docs/_writing_intro.rst
@@ -53,7 +53,7 @@ definitions for the input and output as well as an actual command template.
 
 .. literalinclude:: writing/seqtk_seq_v2.xml
    :language: xml
-   :emphasize-lines: 8-16
+   :emphasize-lines: 5-13
 
 .. include:: _writing_from_help_command.rst
 
@@ -76,7 +76,7 @@ underlying tool. The resulting tool XML file is:
 
 .. literalinclude:: writing/seqtk_seq_v3.xml
    :language: xml
-   :emphasize-lines: 17-58
+   :emphasize-lines: 14-55
 
 .. include:: _writing_lint_intro.rst
 

--- a/docs/_writing_parameters.rst
+++ b/docs/_writing_parameters.rst
@@ -50,7 +50,7 @@ At this point the tool would look like:
 
 .. literalinclude:: writing/seqtk_seq_v4.xml
    :language: xml
-   :emphasize-lines: 10-13,17-23
+   :emphasize-lines: 7-10,14-20
 
 
 Conditional Parameters
@@ -121,7 +121,7 @@ The newest version of this tool is now
 
 .. literalinclude:: writing/seqtk_seq_v5.xml
    :language: xml
-   :emphasize-lines: 13-19,31-43
+   :emphasize-lines: 10-16,28-40
 
 For tools like this where there are many options but in the most uses the defaults
 are preferred - a common idiom is to break the parameters into simple and
@@ -131,4 +131,4 @@ Updating this tool to use that idiom might look as follows.
 
 .. literalinclude:: writing/seqtk_seq_v6.xml
    :language: xml
-   :emphasize-lines: 10-21,26-33,54-55
+   :emphasize-lines: 7-18,23-30,51-52

--- a/docs/_writing_suites.rst
+++ b/docs/_writing_suites.rst
@@ -30,7 +30,7 @@ This will produce the two files in your current directory instead of just one
 
 .. literalinclude:: writing/seqtk_seq_with_macros.xml
    :language: xml
-   :emphasize-lines: 2-6,46
+   :emphasize-lines: 2-5,45
 
 .. literalinclude:: writing/seqtk_macros.xml
    :language: xml

--- a/docs/writing/gen.sh
+++ b/docs/writing/gen.sh
@@ -5,7 +5,7 @@ mv seqtk_seq.xml seqtk_seq_v1.xml
 planemo tool_init --force \
                   --id 'seqtk_seq' \
                   --name 'Convert to FASTA (seqtk)' \
-                  --requirement seqtk@1.0-r68 \
+                  --requirement seqtk@1.2 \
                   --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
                   --example_input 2.fastq \
                   --example_output 2.fasta
@@ -13,7 +13,7 @@ mv seqtk_seq.xml seqtk_seq_v2.xml
 planemo tool_init --force \
                   --id 'seqtk_seq' \
                   --name 'Convert to FASTA (seqtk)' \
-                  --requirement seqtk@1.0-r68 \
+                  --requirement seqtk@1.2 \
                   --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
                   --example_input 2.fastq \
                   --example_output 2.fasta \

--- a/docs/writing/seqtk_macros.xml
+++ b/docs/writing/seqtk_macros.xml
@@ -5,11 +5,6 @@
             <yield/>
         </requirements>
     </xml>
-    <xml name="stdio">
-        <stdio>
-            <exit_code range="1:" />
-        </stdio>
-    </xml>
     <xml name="citations">
         <citations>
             <yield />

--- a/docs/writing/seqtk_seq_v1.xml
+++ b/docs/writing/seqtk_seq_v1.xml
@@ -1,10 +1,7 @@
 <tool id="seqtk_seq" name="Convert to FASTA (seqtk)" version="0.1.0">
     <requirements>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         TODO: Fill in command template.
     ]]></command>
     <inputs>

--- a/docs/writing/seqtk_seq_v2.xml
+++ b/docs/writing/seqtk_seq_v2.xml
@@ -2,10 +2,7 @@
     <requirements>
         <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         seqtk seq -a "$input1" > "$output1"
     ]]></command>
     <inputs>

--- a/docs/writing/seqtk_seq_v3.cwl
+++ b/docs/writing/seqtk_seq_v3.cwl
@@ -3,7 +3,7 @@ cwlVersion: 'cwl:draft-3'
 class: CommandLineTool
 id: "seqtk_seq"
 label: "Convert to FASTA (seqtk)"
-requirements:
+hints:
   - class: DockerRequirement
     dockerPull: dukegcb/seqtk
 inputs:

--- a/docs/writing/seqtk_seq_v3.xml
+++ b/docs/writing/seqtk_seq_v3.xml
@@ -2,10 +2,7 @@
     <requirements>
         <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         seqtk seq -a "$input1" > "$output1"
     ]]></command>
     <inputs>

--- a/docs/writing/seqtk_seq_v4.xml
+++ b/docs/writing/seqtk_seq_v4.xml
@@ -2,10 +2,7 @@
     <requirements>
         <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         seqtk seq
               $shift_quality
               -q $quality_min

--- a/docs/writing/seqtk_seq_v5.xml
+++ b/docs/writing/seqtk_seq_v5.xml
@@ -2,20 +2,17 @@
     <requirements>
         <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         seqtk seq
               $shift_quality
               -q $quality_min
               -X $quality_max
               #if $mask_regions
-              -M '$mask_regions'
+                  -M '$mask_regions'
               #end if
               #if $sample.sample
-              -f $sample.fraction
-              -s $sample.seed
+                  -f $sample.fraction
+                  -s $sample.seed
               #end if
               -a '$input1' > '$output1'
     ]]></command>

--- a/docs/writing/seqtk_seq_v6.xml
+++ b/docs/writing/seqtk_seq_v6.xml
@@ -2,22 +2,19 @@
     <requirements>
         <requirement type="package" version="1.2">seqtk</requirement>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         seqtk seq
               #if $settings.advanced == "advanced"
-              $settings.shift_quality
-              -q $settings.quality_min
-              -X $settings.quality_max
-              #if $settings.mask_regions
-              -M '$settings.mask_regions'
-              #end if
-              #if $settings.sample.sample
-              -f $settings.sample.fraction
-              -s $settings.sample.seed
-              #end if
+                  $settings.shift_quality
+                  -q $settings.quality_min
+                  -X $settings.quality_max
+                  #if $settings.mask_regions
+                      -M '$settings.mask_regions'
+                  #end if
+                  #if $settings.sample.sample
+                      -f $settings.sample.fraction
+                      -s $settings.sample.seed
+                  #end if
               #end if
               -a '$input1' > '$output1'
     ]]></command>

--- a/docs/writing/seqtk_seq_with_macros.xml
+++ b/docs/writing/seqtk_seq_with_macros.xml
@@ -3,9 +3,8 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" />
-    <expand macro="stdio" />
-    <command><![CDATA[
-        seqtk seq -a "$input1" > "$output1"
+    <command detect_errors="exit_code"><![CDATA[
+        seqtk seq -a '$input1' > '$output1'
     ]]></command>
     <inputs>
         <param type="data" name="input1" format="fastq" />

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -27,7 +27,6 @@ TOOL_TEMPLATE = """<tool id="{{id}}" name="{{name}}" version="{{version}}">
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements" />
-    <expand macro="stdio" />
 {%- if version_command %}
     <expand macro="version_command" />
 {%- endif %}
@@ -40,14 +39,11 @@ TOOL_TEMPLATE = """<tool id="{{id}}" name="{{name}}" version="{{version}}">
         {{ container }}
 {%- endfor %}
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
 {%- if version_command %}
     <version_command>{{ version_command }}</version_command>
 {%- endif %}
 {%- endif %}
-    <command><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
 {%- if command %}
         {{ command }}
 {%- else %}
@@ -113,11 +109,6 @@ MACROS_TEMPLATE = """<macros>
         {{ container }}
 {%- endfor %}
         </requirements>
-    </xml>
-    <xml name="stdio">
-        <stdio>
-            <exit_code range="1:" />
-        </stdio>
     </xml>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Other small formatting tweaks - but less than #674 since I'm trying to keep these tools the way they are when tool_init generates them - at least for those options. This also doesn't strip stdio from other places like the bwa test tool that broke the tests in #674.

Cleans up docs pre-GCC.