### PR TITLE
Update BWA-MEM examples in the TDD docs.

### DIFF
--- a/docs/_writing_testing.rst
+++ b/docs/_writing_testing.rst
@@ -10,9 +10,7 @@ install BWA - but however you obtain it should be fine.
 
 ::
 
-    $ conda config --add channels r
-    $ conda config --add channels bioconda
-    $ conda install bwa
+    $ conda install -c bioconda bwa
         ... bwa installation ...
     $ bwa
     Program: bwa (alignment via Burrows-Wheeler transformation)
@@ -57,9 +55,6 @@ using Planemo's ``project_init`` command.
 
     $ planemo project_init --template bwa bwa
     $ cd bwa
-
-.. note:: The above command shows the following warning but works fine.
-  ``mv: cannot move '/tmp/tmpG59z0F/bwa/..' to '/opt/galaxy/tools/bwa/..': Device or resource busy``
 
 This will create a folder with a ``bwa-mem.xml`` as follows:
 
@@ -269,7 +264,7 @@ the procedure described in the `tutorial <http://planemo.readthedocs.io/en/lates
 
 .. note:: A full list of the current assertion elements like these that are
     allowed can be found `on the tool syntax page
-    <https://wiki.galaxyproject.org/Admin/Tools/ToolConfigSyntax#A.3Cassert_contents.3E_tag_set_.28functional_tests.29>`__.
+    <https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-tests-test-output-assert-contents>`__.
 
     In additon to the assertion-based testing of the command, the jobs standard
     output and standard error can be checked using ``assert_stdout`` and

--- a/docs/writing/bwa-mem_v2.xml
+++ b/docs/writing/bwa-mem_v2.xml
@@ -2,8 +2,8 @@
 <tool id="bwa_mem_test" name="Map with BWA-MEM" version="0.0.1">
     <description>- map medium and long reads</description>
     <requirements>
-        <requirement type="package" version="0.7.7">bwa</requirement>
-        <requirement type="package" version="0.1.16">samtools</requirement>
+        <requirement type="package" version="0.7.15">bwa</requirement>
+        <requirement type="package" version="1.3">samtools</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
       ## Build reference
@@ -20,7 +20,7 @@
       "${fastq_input1}"
 
       | samtools view -Sb - > temporary_bam_file.bam &&
-      samtools sort -f temporary_bam_file.bam ${bam_output}
+      samtools sort -o ${bam_output} temporary_bam_file.bam
     ]]></command>
 
     <inputs>

--- a/docs/writing/bwa-mem_v3.xml
+++ b/docs/writing/bwa-mem_v3.xml
@@ -2,8 +2,8 @@
 <tool id="bwa_mem_test" name="Map with BWA-MEM" version="0.0.1">
     <description>- map medium and long reads</description>
     <requirements>
-        <requirement type="package" version="0.7.7">bwa</requirement>
-        <requirement type="package" version="0.1.16">samtools</requirement>
+        <requirement type="package" version="0.7.15">bwa</requirement>
+        <requirement type="package" version="1.3">samtools</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
       ## Build reference
@@ -24,7 +24,7 @@
       "${input_type_conditional.fastq_input.forward}" "${input_type_conditional.fastq_input.reverse}"
       #end if
       | samtools view -Sb - > temporary_bam_file.bam &&
-      samtools sort -f temporary_bam_file.bam ${bam_output}
+      samtools sort -o ${bam_output} temporary_bam_file.bam
     ]]></command>
 
     <inputs>

--- a/docs/writing/bwa-mem_v4.xml
+++ b/docs/writing/bwa-mem_v4.xml
@@ -2,8 +2,8 @@
 <tool id="bwa_mem_test" name="Map with BWA-MEM" version="0.0.1">
     <description>- map medium and long reads</description>
     <requirements>
-        <requirement type="package" version="0.7.7">bwa</requirement>
-        <requirement type="package" version="0.1.16">samtools</requirement>
+        <requirement type="package" version="0.7.15">bwa</requirement>
+        <requirement type="package" version="1.3">samtools</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
       ## Build reference
@@ -24,7 +24,7 @@
       "${input_type_conditional.fastq_input.forward}" "${input_type_conditional.fastq_input.reverse}"
       #end if
       | samtools view -Sb - > temporary_bam_file.bam &&
-      samtools sort -f temporary_bam_file.bam ${bam_output}
+      samtools sort -o ${bam_output} temporary_bam_file.bam
     ]]></command>
 
     <inputs>

--- a/docs/writing/bwa-mem_v5.xml
+++ b/docs/writing/bwa-mem_v5.xml
@@ -2,8 +2,8 @@
 <tool id="bwa_mem_test" name="Map with BWA-MEM" version="0.0.1">
     <description>- map medium and long reads</description>
     <requirements>
-        <requirement type="package" version="0.7.7">bwa</requirement>
-        <requirement type="package" version="0.1.16">samtools</requirement>
+        <requirement type="package" version="0.7.15">bwa</requirement>
+        <requirement type="package" version="1.3">samtools</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
       ## Build reference
@@ -28,7 +28,7 @@
       "${input_type_conditional.fastq_input.forward}" "${input_type_conditional.fastq_input.reverse}"
       #end if
       | samtools view -Sb - > temporary_bam_file.bam &&
-      samtools sort -f temporary_bam_file.bam ${bam_output}
+      samtools sort -o ${bam_output} temporary_bam_file.bam
     ]]></command>
 
     <inputs>

--- a/docs/writing/show_diffs.sh
+++ b/docs/writing/show_diffs.sh
@@ -1,0 +1,15 @@
+
+echo "Diff from project_template..."
+diff ../../project_templates/bwa/bwa-mem.xml  bwa-mem_v1.xml
+
+echo "Diff from 1 to 2 (adding test)"
+diff bwa-mem_v1.xml bwa-mem_v2.xml
+
+echo "Diff from 2 to 3 (filling in test)"
+diff bwa-mem_v2.xml bwa-mem_v3.xml
+
+echo "Diff from 3 to 4 (scoring test)"
+diff bwa-mem_v3.xml bwa-mem_v4.xml
+
+echo "Diff from 4 to 5 (filling in scoring test)"
+diff bwa-mem_v4.xml bwa-mem_v5.xml


### PR DESCRIPTION
I originally updated BWA-MEM for Conda in https://github.com/galaxyproject/planemo/commit/9af67bfd46509cc6d59ff6f2d86e2ddca613b2f9 but I didn't update the remaining doc examples.

Also adding diff script to see diffs between versions and cleaning up some of the content of the tutorial itself (including dropping a warning about an older error that has been fixed).