### PR TITLE
Implement some ad-hoc documentation tests.

### DIFF
--- a/docs/_writing_testing.rst
+++ b/docs/_writing_testing.rst
@@ -10,7 +10,7 @@ install BWA - but however you obtain it should be fine.
 
 ::
 
-    $ conda install -c bioconda bwa
+    $ conda install --force -c bioconda bwa
         ... bwa installation ...
     $ bwa
     Program: bwa (alignment via Burrows-Wheeler transformation)

--- a/docs/_writing_using_seqtk.rst
+++ b/docs/_writing_using_seqtk.rst
@@ -7,7 +7,7 @@ install Seqtk - but however you obtain it should be fine.
 
 ::
 
-    $ conda install -c bioconda seqtk=1.2
+    $ conda install --force -c bioconda seqtk=1.2
         ... seqtk installation ...
     $ seqtk seq
             Usage:   seqtk seq [options] <in.fq>|<in.fa>

--- a/docs/tests/tests_all.sh
+++ b/docs/tests/tests_all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o xtrace
+
+set -e
+
+DOC_TESTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bash "${DOC_TESTS_DIRECTORY}/tests_building.sh"
+
+bash "${DOC_TESTS_DIRECTORY}/tests_tdd.sh"
+
+bash "${DOC_TESTS_DIRECTORY}/tests_conda.sh"
+
+bash "${DOC_TESTS_DIRECTORY}/tests_docker.sh"

--- a/docs/tests/tests_building.sh
+++ b/docs/tests/tests_building.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -o xtrace
+
+set -e
+
+# Preconditions - tool init directory doesn't exist and in home directory.
+cd
+rm -rf tool_init_exercise
+
+# Tests
+
+conda install --force -c bioconda seqtk=1.2
+
+seqtk seq
+
+mkdir tool_init_exercise
+
+cd tool_init_exercise
+
+wget https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/2.fastq
+
+seqtk seq -A 2.fastq > 2.fasta
+
+cat 2.fasta
+
+planemo tool_init --id 'seqtk_seq' --name 'Convert to FASTA (seqtk)'
+
+cat seqtk_seq.xml
+
+planemo tool_init --force \
+                    --id 'seqtk_seq' \
+                    --name 'Convert to FASTA (seqtk)' \
+                    --requirement seqtk@1.2 \
+                    --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                    --example_input 2.fastq \
+                    --example_output 2.fasta
+
+cat seqtk_seq.xml
+
+planemo tool_init --force \
+                    --id 'seqtk_seq' \
+                    --name 'Convert to FASTA (seqtk)' \
+                    --requirement seqtk@1.2 \
+                    --example_command 'seqtk seq -a 2.fastq > 2.fasta' \
+                    --example_input 2.fastq \
+                    --example_output 2.fasta \
+                    --test_case \
+                    --cite_url 'https://github.com/lh3/seqtk' \
+                    --help_from_command 'seqtk seq'
+
+planemo l
+
+planemo t
+
+planemo shed_init --name=seqtk_seq \
+                    --owner=planemo \
+                    --description=seqtk_seq \
+                    --long_description="Tool that converts FASTQ to FASTA files using seqtk" \
+                    --category="Fastq Manipulation"
+
+planemo shed_lint --tools
+
+planemo shed_create --shed_target local
+
+planemo shed_update --shed_target local
+
+planemo tool_init --force \
+                    --macros \
+                    --id 'seqtk_seq' \
+                    --name 'Convert to FASTA (seqtk)' \
+                    --requirement seqtk@1.2 \
+                    --example_command 'seqtk seq -A 2.fastq > 2.fasta' \
+                    --example_input 2.fastq \
+                    --example_output 2.fasta \
+                    --test_case \
+                    --help_from_command 'seqtk seq'
+
+cat seqtk_seq.xml
+

--- a/docs/tests/tests_conda.sh
+++ b/docs/tests/tests_conda.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -o xtrace
+
+set -e
+
+shopt -s expand_aliases  # Needed for conda_env test
+
+# Preconditions:
+# - seqtk_example doesn't exist and in home directory
+# - conda_exercises doesn't exist in home directory.
+# - seqtk environment is absent
+
+cd
+
+rm -rf seqtk_example
+rm -rf conda_exercises
+echo "Remove existing seqtk environment - it is fine if it doesn't exist."
+conda remove --force --name '__seqtk@1.2' --all || true
+
+# Tests
+
+echo "Try planemo conda_init - this may fail and will always fail on planemo-machine"
+echo "still good to see a decent error message though."
+planemo conda_init || true
+
+echo "Setup completed seqtk example"
+planemo project_init --template=seqtk_complete seqtk_example
+cd seqtk_example
+
+echo "Check conda_requirements - should see them linting properly"
+planemo lint --conda_requirements seqtk_seq.xml
+
+
+planemo conda_install seqtk_seq.xml
+
+echo "Checking for seqtk - shouldn't be present"
+which seqtk || true
+
+echo "Simulating '. <(planemo conda_env seqtk_seq.xml)', subshell-ism doesn't seem to work in script"
+planemo conda_env seqtk_seq.xml > .conda_env
+. .conda_env
+
+echo "Inside conda_env I should see seqtk"
+which seqtk
+
+conda_env_deactivate
+
+sleep 5  # Need to wait for the package to get cleaned up.
+
+planemo test seqtk_seq.xml
+
+echo "Doing a search - should see seqtk in bioconda results along with versions"
+planemo conda_search seqt
+
+cd
+
+planemo project_init --template conda_exercises conda_exercises
+cd conda_exercises/exercise_1
+ls
+
+echo "Running test wrong - this should fail"
+planemo test pear.xml || true
+echo "Linting pear without requirements - this should fail"
+planemo lint --conda_requirements pear.xml || true
+
+echo "Should see pear from bioconda at 0.9.6"
+planemo conda_search pear
+
+wget https://raw.githubusercontent.com/galaxyproject/planemo/master/project_templates/conda_answers/exercise_1/pear.xml -O pear.xml
+planemo lint --conda_requirements pear.xml || true
+
+planemo test pear.xml
+
+cd ../exercise_2
+
+# Fetch and build recipe.
+
+mkdir fleeqtk
+cd fleeqtk
+
+wget https://raw.githubusercontent.com/galaxyproject/planemo/master/project_templates/conda_answers/exercise_2/fleeqtk/build.sh
+wget https://raw.githubusercontent.com/galaxyproject/planemo/master/project_templates/conda_answers/exercise_2/fleeqtk/meta.yaml
+
+cd ..
+conda build fleeqtk
+
+# Update to fix tool and see it work.
+
+wget https://raw.githubusercontent.com/galaxyproject/planemo/master/project_templates/conda_answers/exercise_2/fleeqtk_seq.xml -O fleeqtk_seq.xml
+planemo conda_install --conda_use_local fleeqtk_seq.xml
+planemo test fleeqtk_seq.xml

--- a/docs/tests/tests_docker.sh
+++ b/docs/tests/tests_docker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o xtrace
+
+set -e
+
+# Preconditions - seqtk_example directory doesn't exist and in home directory.
+cd
+rm -rf seqtk_example
+rm -rf conda_testing
+
+
+echo "Setup completed seqtk example"
+planemo project_init --template=seqtk_complete seqtk_example
+cd seqtk_example
+
+echo "We should see biocontainer found for this tool"
+planemo lint --biocontainers seqtk_seq.xml
+
+echo "This should pass and we should see container was used."
+planemo test --biocontainers seqtk_seq.xml
+
+cd ..
+
+planemo project_init --template=conda_testing conda_testing
+cd conda_testing/
+echo "Should show quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:03dc1d2818d9de56938078b8b78b82d967c1f820-0 is built"
+planemo mull bwa_and_samtools.xml
+
+
+echo "Should see quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:03dc1d2818d9de56938078b8b78b82d967c1f820-0. "
+docker images 
+
+echo "Should see cached container was used for this"
+planemo test --biocontainers bwa_and_samtools.xml

--- a/docs/tests/tests_tdd.sh
+++ b/docs/tests/tests_tdd.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o xtrace
+
+set -e
+
+# Preconditions - bwa directory doesn't exist and in home directory.
+cd
+rm -rf bwa
+
+# Tests
+conda install -c bioconda bwa
+
+echo "Executing bwa to see help - should see output, but it has a non-zero exit code."
+bwa | true
+
+planemo project_init --template bwa bwa
+cd bwa
+
+cd test-data
+bwa index -a is bwa-mem-mt-genome.fa
+bwa mem bwa-mem-mt-genome.fa bwa-mem-fastq1.fq bwa-mem-fastq2.fq | \
+  samtools view -Sb - > temporary_bam_file.bam && \
+  (samtools sort -f temporary_bam_file.bam bwa-aln-test2.bam || samtools sort -o bwa-aln-test2.bam temporary_bam_file.bam)
+
+cd ..
+
+wget https://raw.githubusercontent.com/galaxyproject/planemo/master/docs/writing/bwa-mem_v2.xml -O bwa-mem.xml
+
+echo "Running test we expect to fail..."
+
+planemo t || true
+
+echo "Fixing tool"
+
+wget https://raw.githubusercontent.com/galaxyproject/planemo/master/docs/writing/bwa-mem_v3.xml -O bwa-mem.xml
+
+echo "Running test we expect to be fixed."
+
+planemo t --failed 
+
+# TODO: Finish remaining BWA examples if time.


### PR DESCRIPTION
I just walked through the documentation and turned the examples into little bash scripts that can be executed and the result inspected to quickly test planemo-machine in an ongoing fashion. I intend to create a pre-GCC checklist for planemo-machine and I'll put reviewing these scripts against the docs on that.

I guess the next step would be actually annotate the docs - I should do that. Also these should probably be an Jupyter script instead of a bash script? Extract commands from RST into a Jupyter notebook - a bit that exists - or maybe we should go the other way. Who knows...