### PR TITLE
Improve Galaxy root option specification.

### DIFF
--- a/planemo/cli.py
+++ b/planemo/cli.py
@@ -55,7 +55,7 @@ class Context(object):
 
     def get_option_source(self, param_name):
         """Return OptionSource value indicating how the option was set."""
-        assert param_name in self.option_source
+        assert param_name in self.option_source, "No option source for [%s]" % param_name
         return self.option_source[param_name]
 
     @property
@@ -163,7 +163,7 @@ class PlanemoCLI(click.MultiCommand):
 def command_function(f):
     """Extension point for processing kwds after click callbacks."""
     @functools.wraps(f)
-    def handle_profile_options(*args, **kwds):
+    def handle_blended_options(*args, **kwds):
         profile = kwds.get("profile", None)
         if profile:
             ctx = args[0]
@@ -172,12 +172,48 @@ def command_function(f):
             )
             _setup_profile_options(ctx, profile_defaults, kwds)
 
+        _setup_galaxy_source_options(args[0], kwds)
+
         try:
             return f(*args, **kwds)
         except ExitCodeException as e:
             sys.exit(e.exit_code)
 
-    return pass_context(handle_profile_options)
+    return pass_context(handle_blended_options)
+
+
+EXCLUSIVE_OPTIONS_LIST = [
+    ("galaxy_root", "galaxy_branch"),
+    ("galaxy_root", "galaxy_source"),
+]
+
+
+def _setup_galaxy_source_options(ctx, kwds):
+    for exclusive_options in EXCLUSIVE_OPTIONS_LIST:
+        option_source = {}
+        for option in exclusive_options:
+            if option in kwds:
+                option_source[option] = ctx.get_option_source(option)
+            else:
+                option_source[option] = None
+
+        most_authoratative_source = None
+        most_authoratative_source_options = []
+        for key, value in option_source.items():
+            if value is None:
+                continue
+            if most_authoratative_source is None or value.value < most_authoratative_source.value:
+                most_authoratative_source = value
+                most_authoratative_source_options = [key]
+            elif value == most_authoratative_source:
+                most_authoratative_source_options.append(key)
+
+        if most_authoratative_source != OptionSource.default and len(most_authoratative_source_options) > 1:
+            raise click.UsageError("Cannot specify multiple of %s" % most_authoratative_source_options)
+
+        for option in exclusive_options:
+            if option in kwds and option not in most_authoratative_source_options:
+                del kwds[option]
 
 
 def _setup_profile_options(ctx, profile_defaults, kwds):

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -121,6 +121,8 @@ def galaxy_email_option():
 def galaxy_root_option():
     return planemo_option(
         "--galaxy_root",
+        use_global_config=True,
+        use_env_var=True,
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
         help="Root of development galaxy directory to execute command with.",
     )
@@ -386,6 +388,7 @@ def galaxy_branch_option():
         "--galaxy_branch",
         default=None,
         use_global_config=True,
+        use_env_var=True,
         help=("Branch of Galaxy to target (defaults to master) if a Galaxy "
               "root isn't specified.")
     )


### PR DESCRIPTION
- Allow Galaxy root to specified via environment variable PLANEMO_GALAXY_ROOT and using the default_galaxy_root in ~/.planemo.yml. galaxy_root still works in ~/.planemo.yml but this follows the pattern of other option overries.
- Flag an error if both galaxy_branch and galaxy_root at the command-line (or via environment variable if one is not specified at the CLI, etc...)