### PR TITLE
Add a command to pre-install involucro.

### DIFF
--- a/planemo/commands/cmd_mulled_init.py
+++ b/planemo/commands/cmd_mulled_init.py
@@ -1,0 +1,18 @@
+"""Module describing the planemo ``conda_init`` command."""
+import click
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.mulled import build_involucro_context
+
+
+@click.command('mulled_init')
+@options.mulled_options()
+@command_function
+def cli(ctx, **kwds):
+    """Download and install involucro for mull command.
+
+    This will happen automatically when using the mull command, but this can
+    be pre-installed in an environment using this command.
+    """
+    build_involucro_context(ctx, **kwds)


### PR DESCRIPTION
This will allow planemo-machine to pre-install and configure involucro for VMs to reduce the amount of stuff that needs to be downloaded at runtime (for tutorials and such).