### PR TITLE
handle None versions

### DIFF
--- a/planemo/commands/cmd_container_register.py
+++ b/planemo/commands/cmd_container_register.py
@@ -159,7 +159,14 @@ class RegistryTarget(object):
 
     def write_targets(self, ctx, target_filename, mulled_targets):
         with open(target_filename, "w") as f:
-            contents = ",".join(["%s=%s" % (t.package_name, t.version) for t in mulled_targets])
+            target_strings = list()
+            for target in mulled_targets:
+                if target.version:
+                    target_str = "%s=%s" % (target.package_name, target.version)
+                else:
+                    target_str = target.package_name
+                target_strings.append(target_str)
+            contents = ",".join(target_strings)
             f.write(contents)
             ctx.vlog("Wrote requirements [%s] to file [%s]" % (contents, target_filename))
 


### PR DESCRIPTION
Handles package definitions without a version number: https://github.com/galaxyproteomics/tools-galaxyp/blob/master/tools/peptideshaker/searchgui.xml#L10

might fix: https://github.com/BioContainers/multi-package-containers/pull/329
completely untested ...