### PR TITLE
Elevate missing .shed.yml to error

### DIFF
--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -289,7 +289,7 @@ def lint_shed_yaml(realized_repository, lint_ctx):
     path = realized_repository.real_path
     shed_yaml = os.path.join(path, ".shed.yml")
     if not os.path.exists(shed_yaml):
-        lint_ctx.info("No .shed.yml file found, skipping.")
+        lint_ctx.error("No .shed.yml file found.")
         return
     try:
         yaml.load(open(shed_yaml, "r"))


### PR DESCRIPTION
From https://github.com/galaxyproject/planemo/issues/107#issuecomment-312948255

This change will probably cause repositories which passed linting before, to fail now, if people were passing directories which weren't things which should be uploaded to the tool shed. Is that acceptable, or should this be hidden behind a strictness falg or something?