### PR TITLE
(simple fix) macOS `chmod` doesn't support `--recursive` flag.

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -788,7 +788,7 @@ class DockerGalaxyConfig(BaseGalaxyConfig):
         )
         chmod_command = [
             "chmod",
-            "--recursive",
+            "-R",
             "o+rwx",
             self.config_directory,
         ]


### PR DESCRIPTION
When launching `planemo serve --engine docker_galaxy ...` the following error msg appears on macOS:

```
chmod: illegal option -- -
usage:	chmod [-fhv] [-R [-H | -L | -P]] [-a | +a | =a  [i][# [ n]]] mode|entry file ...
	chmod [-fhv] [-R [-H | -L | -P]] [-E | -C | -N | -i | -I] file ...
```

Use `-R` instead of `--recursive` for better portability.