### PR TITLE
py3: subprocess with universal_newlines=True

### DIFF
--- a/planemo/git.py
+++ b/planemo/git.py
@@ -77,7 +77,9 @@ def diff(ctx, directory, range):
     cmd_template = "cd '%s' && git diff --name-only '%s' --"
     cmd = cmd_template % (directory, range)
     stdout, _ = io.communicate(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        cmd,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True
     )
     return [l.strip() for l in text_type(stdout).splitlines() if l]
 

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -608,7 +608,8 @@ def _handle_help(kwds):
                 help_from_command,
                 shell=True,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT
+                stderr=subprocess.STDOUT,
+                universal_newlines=True
             )
             help_text = p.communicate()[0]
 


### PR DESCRIPTION
This is a simple way to ensure we get a string back (and not bytes) under Python 3, intended to solve #763 where the output is used directly in XML output.