### PR TITLE
Enhancements to Galaxy profiles and workflow testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: TOX_ENV=py34
     - env: TOX_ENV=py27-lint-docstrings
 
-script: PLANEMO_ENABLE_POSTGRES_TESTS=1 PLANEMO_SKIP_CWLTOOL_TESTS=1 tox -e $TOX_ENV
+script: PLANEMO_ENABLE_POSTGRES_TESTS=1 PLANEMO_SKIP_CWLTOOL_TESTS=1 PLANEMO_TEST_WORKFLOW_RUN_PROFILE=travisworkflowtests tox -e $TOX_ENV
 
 after_success:
   - coveralls

--- a/docs/commands/profile_create.rst
+++ b/docs/commands/profile_create.rst
@@ -17,9 +17,17 @@ Create a profile.
 
 
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development
@@ -33,5 +41,13 @@ Create a profile.
                                       tools and workflows. Defaults to a local
                                       Galaxy, but running Galaxy within a Docker
                                       container.
+      --docker_cmd TEXT               Command used to launch docker (defaults to
+                                      docker).
+      --docker_sudo / --no_docker_sudo
+                                      Flag to use sudo when running docker.
+      --docker_host TEXT              Docker host to target when executing docker
+                                      commands (defaults to localhost).
+      --docker_sudo_cmd TEXT          sudo command to use when --docker_sudo is
+                                      enabled (defaults to sudo).
       --help                          Show this message and exit.
     

--- a/docs/commands/profile_delete.rst
+++ b/docs/commands/profile_delete.rst
@@ -17,9 +17,17 @@ Delete a profile.
 
 
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development

--- a/docs/commands/run.rst
+++ b/docs/commands/run.rst
@@ -103,12 +103,21 @@ Planemo command for running tools and jobs.
                                       Conda dependency resolution for Galaxy will
                                       auto install conda itself using miniconda if
                                       not availabe on conda_prefix.
-      --profile TEXT                  Location of pid file is executed with
-                                      --daemon.
+      --profile TEXT                  Name of profile (created with the
+                                      profile_create command) to use with this
+                                      command.
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development

--- a/docs/commands/serve.rst
+++ b/docs/commands/serve.rst
@@ -129,12 +129,21 @@ Galaxy instance.
                                       Conda dependency resolution for Galaxy will
                                       auto install conda itself using miniconda if
                                       not availabe on conda_prefix.
-      --profile TEXT                  Location of pid file is executed with
-                                      --daemon.
+      --profile TEXT                  Name of profile (created with the
+                                      profile_create command) to use with this
+                                      command.
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development
@@ -149,7 +158,7 @@ Galaxy instance.
       --shed_tool_conf TEXT           Location of shed tools conf file for Galaxy.
       --shed_tool_path TEXT           Location of shed tools directory for Galaxy.
       --daemon                        Serve Galaxy process as a daemon.
-      --pid_file TEXT                 Location of pid file is executed with
+      --pid_file PATH                 Location of pid file is executed with
                                       --daemon.
       --cwl                           Configure Galaxy for use with CWL tool. (this
                                       option is experimental and will be replaced

--- a/docs/commands/shed_serve.rst
+++ b/docs/commands/shed_serve.rst
@@ -127,12 +127,21 @@ logged into and explored interactively.
                                       Conda dependency resolution for Galaxy will
                                       auto install conda itself using miniconda if
                                       not availabe on conda_prefix.
-      --profile TEXT                  Location of pid file is executed with
-                                      --daemon.
+      --profile TEXT                  Name of profile (created with the
+                                      profile_create command) to use with this
+                                      command.
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development
@@ -146,7 +155,7 @@ logged into and explored interactively.
       --database_connection TEXT      Database connection string to use for Galaxy.
       --shed_tool_conf TEXT           Location of shed tools conf file for Galaxy.
       --shed_tool_path TEXT           Location of shed tools directory for Galaxy.
-      --pid_file TEXT                 Location of pid file is executed with
+      --pid_file PATH                 Location of pid file is executed with
                                       --daemon.
       --skip_dependencies             Do not install shed dependencies as part of
                                       repository installation.

--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -123,12 +123,21 @@ please careful and do not try this against production Galaxy instances.
                                       Conda dependency resolution for Galaxy will
                                       auto install conda itself using miniconda if
                                       not availabe on conda_prefix.
-      --profile TEXT                  Location of pid file is executed with
-                                      --daemon.
+      --profile TEXT                  Name of profile (created with the
+                                      profile_create command) to use with this
+                                      command.
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development

--- a/docs/commands/tool_factory.rst
+++ b/docs/commands/tool_factory.rst
@@ -114,12 +114,21 @@ http://www.ncbi.nlm.nih.gov/pubmed/23024011.
                                       Conda dependency resolution for Galaxy will
                                       auto install conda itself using miniconda if
                                       not availabe on conda_prefix.
-      --profile TEXT                  Location of pid file is executed with
-                                      --daemon.
+      --profile TEXT                  Name of profile (created with the
+                                      profile_create command) to use with this
+                                      command.
       --postgres                      Use postgres database type.
-      --database_type [postgres|sqlite]
-                                      Type of database to use for profile -
-                                      currently only 'postgres' is available.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
       --postgres_psql_path TEXT       Name or or path to postgres client binary
                                       (psql).
       --postgres_database_user TEXT   Postgres username for managed development
@@ -134,7 +143,7 @@ http://www.ncbi.nlm.nih.gov/pubmed/23024011.
       --shed_tool_conf TEXT           Location of shed tools conf file for Galaxy.
       --shed_tool_path TEXT           Location of shed tools directory for Galaxy.
       --daemon                        Serve Galaxy process as a daemon.
-      --pid_file TEXT                 Location of pid file is executed with
+      --pid_file PATH                 Location of pid file is executed with
                                       --daemon.
       --help                          Show this message and exit.
     

--- a/docs/planemo.database.rst
+++ b/docs/planemo.database.rst
@@ -28,6 +28,14 @@ planemo\.database\.postgres module
     :undoc-members:
     :show-inheritance:
 
+planemo\.database\.postgres\_docker module
+------------------------------------------
+
+.. automodule:: planemo.database.postgres_docker
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/planemo/commands/cmd_profile_create.py
+++ b/planemo/commands/cmd_profile_create.py
@@ -12,6 +12,7 @@ from planemo.galaxy import profiles
 @options.profile_name_argument()
 @options.profile_database_options()
 @options.serve_engine_option()
+@options.docker_config_options()
 @command_function
 def cli(ctx, profile_name, **kwds):
     """Create a profile."""

--- a/planemo/database/factory.py
+++ b/planemo/database/factory.py
@@ -1,12 +1,25 @@
 """Create a DatabaseSource from supplied planemo configuration."""
+from galaxy.tools.deps.commands import which
+
 from .postgres import LocalPostgresDatabaseSource
+from .postgres_docker import DockerPostgresDatabaseSource
 
 
 def create_database_source(**kwds):
     """Return a :class:`planemo.database.DatabaseSource` for configuration."""
-    database_type = kwds.get("database_type", "postgres")
+    database_type = kwds.get("database_type", "auto")
+    if database_type == "auto":
+        if which("psql"):
+            database_type = "postgres"
+        elif which("docker"):
+            database_type = "postgres_docker"
+        else:
+            raise Exception("Cannot find executables for psql or docker, cannot configure a database source.")
+
     if database_type == "postgres":
         return LocalPostgresDatabaseSource(**kwds)
+    elif database_type == "postgres_docker":
+        return DockerPostgresDatabaseSource(**kwds)
     # TODO
     # from .sqlite import SqliteDatabaseSource
     # elif database_type == "sqlite":

--- a/planemo/database/postgres_docker.py
+++ b/planemo/database/postgres_docker.py
@@ -1,0 +1,80 @@
+"""Module describes a :class:`DatabaseSource` for managed, dockerized postgres databases."""
+import time
+
+from galaxy.tools.deps import docker_util
+from galaxy.tools.deps import dockerfiles
+from galaxy.tools.deps.commands import execute
+
+from .interface import DatabaseSource
+from .postgres import _CommandBuilder, ExecutesPostgresSqlMixin
+
+DEFAULT_CONTAINER_NAME = "planemopostgres"
+DEFAULT_POSTGRES_PASSWORD = "mysecretpassword"
+DEFAULT_POSTGRES_PORT_EXPOSE = 15432
+
+
+def docker_ps(args, **kwds):
+    return docker_util.command_list("ps", args, **kwds)
+
+
+def docker_exec(name, commands=[], **kwds):
+    return docker_util.command_list("exec", [name] + commands, **kwds)
+
+
+def is_running_container(name=DEFAULT_CONTAINER_NAME, **kwds):
+    ps_command = docker_ps(["--format", "{{.Names}}"], **kwds)
+    running_containers = execute(ps_command)
+    containers = running_containers.splitlines()
+    return name in containers
+
+
+def start_postgres_docker(name=DEFAULT_CONTAINER_NAME, password=DEFAULT_POSTGRES_PASSWORD, port=DEFAULT_POSTGRES_PORT_EXPOSE, **kwds):
+    run_command = docker_util.command_list(
+        "run",
+        ["-p", "%d:5432" % port, "--name", name, "-e", "POSTGRES_PASSWORD=%s" % password, "--rm", "-d", "postgres"],
+        **kwds
+    )
+    execute(run_command)
+
+
+class DockerPostgresDatabaseSource(ExecutesPostgresSqlMixin, DatabaseSource):
+    """Postgres database running inside a Docker container."""
+
+    def __init__(self, **kwds):
+        """Construct a postgres database source from planemo configuration."""
+        self.psql_path = 'psql'
+        self.database_user = 'postgres'
+        self.database_password = DEFAULT_POSTGRES_PASSWORD
+        self.database_host = 'localhost'  # TODO: Make docker host
+        self.database_port = DEFAULT_POSTGRES_PORT_EXPOSE
+        self._kwds = kwds
+        self._docker_host_kwds = dockerfiles.docker_host_args(**kwds)
+        if not is_running_container(**self._docker_host_kwds):
+            start_postgres_docker(**self._docker_host_kwds)
+            # Hack to give docker a bit of time to boot up and allow psql to start.
+            time.sleep(30)
+
+    def sqlalchemy_url(self, identifier):
+        """Return URL or form postgresql://username:password@localhost/mydatabase."""
+        return "postgresql://%s:%s@%s:%d/%s" % (
+            self.database_user,
+            self.database_password,
+            self.database_host,
+            self.database_port,
+            identifier
+        )
+
+    def _psql_command_builder(self, *args):
+        base_command = docker_exec(DEFAULT_CONTAINER_NAME, [self.psql_path], **self._docker_host_kwds)
+        command_builder = _CommandBuilder(*base_command)
+        # Print only tuples so output is easier to parse
+        command_builder.append_command("--tuples-only")
+        command_builder.append_command("--username", self.database_user)
+        command_builder.append_command("-P", "pager=off")
+        command_builder.extend_command(args)
+        return command_builder
+
+
+__all__ = (
+    'DockerPostgresDatabaseSource',
+)

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -7,6 +7,8 @@ import json
 import os
 import shutil
 
+from galaxy.tools.deps.commands import which
+
 from planemo.config import (
     OptionSource,
 )
@@ -73,7 +75,15 @@ def _create_profile_docker(profile_directory, profile_name, kwds):
 
 
 def _create_profile_local(profile_directory, profile_name, kwds):
-    database_type = kwds.get("database_type", "sqlite")
+    database_type = kwds.get("database_type", "auto")
+    if database_type == "auto":
+        if which("psql"):
+            database_type = "postgres"
+        elif which("docker"):
+            database_type = "postgres_docker"
+        else:
+            database_type = "sqlite"
+
     if database_type != "sqlite":
         database_source = create_database_source(**kwds)
         database_identifier = _profile_to_database_identifier(profile_name)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -995,7 +995,8 @@ def profile_option():
         "--profile",
         type=str,
         default=None,
-        help="Location of pid file is executed with --daemon."
+        help=("Name of profile (created with the profile_create command) to use "
+              "with this command.")
     )
 
 
@@ -1160,14 +1161,21 @@ def postgres_datatype_type_option():
 def database_type_option():
     return planemo_option(
         "--database_type",
-        default="postgres",
+        default="auto",
         type=click.Choice([
             "postgres",
+            "postgres_docker",
             "sqlite",
+            "auto",
         ]),
         use_global_config=True,
         help=("Type of database to use for profile - "
-              "currently only 'postgres' is available."),
+              "'auto', 'sqlite', 'postgres', and 'postgres_docker' are available options. "
+              "Use postgres to use an existing postgres server you user can "
+              "access without a password via the psql command. Use postgres_docker "
+              "to have Planemo manage a docker container running postgres. "
+              "Data with postgres_docker is not yet persisted past when you restart "
+              "the docker container launched by Planemo so be careful with this option."),
     )
 
 

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -25,6 +25,9 @@ class CmdTestTestCase(CliTestCase):
             test_command = [
                 "--verbose",
                 "test",
+            ]
+            test_command = self.append_profile_argument_if_needed(test_command)
+            test_command += [
                 "--extra_tools", random_lines,
                 "--extra_tools", cat,
                 test_artifact,
@@ -82,3 +85,17 @@ class CmdTestTestCase(CliTestCase):
                 data = test_i["data"]
                 expected_status = expected_statuses[i]
                 assert data["status"] == expected_status
+
+    def append_profile_argument_if_needed(self, command):
+        # Hook into tests to allow leveraging postgres databases to prevent Galaxy locking errors
+        # while running tests.
+        profile_name = os.getenv("PLANEMO_TEST_WORKFLOW_RUN_PROFILE", None)
+
+        if not profile_name:
+            command += ["--profile", profile_name]
+
+            database_type = os.getenv("PLANEMO_TEST_WORKFLOW_RUN_PROFILE_DATABASE_TYPE", None)
+            if database_type:
+                command += ["--database_type", database_type]
+
+        return command


### PR DESCRIPTION
Add a new profile database type option "postgres_docker". The existing "postgres" type option expects a local database to be accessible via the "psql" command on Planemo's PATH - probably few people have postgres running directly on their development machine and fewer still have it configured to allow passwordless entry. This newer variant is a much simpler interface - it starts a named container for the official Docker postgres image and uses that to manage the profile. This should make using profiles easier for most developers.

This new modality does have some shortcomings - it should probably be redone to persist the database somewhere -or- start and stop the same container (currently when the container is stopped the data is gone).

This also updates the workflow test that encounters Galaxy locks to pickup the environment variable PLANEMO_TEST_WORKFLOW_RUN_PROFILE and PLANEMO_TEST_WORKFLOW_RUN_PROFILE_DATABASE_TYPE and use these to create and use a profile during testing if set as well as setting that variable in Travis to leverage the postgres service already configured for other tests. This more or less fixes what I had in mind with #772 but it would be nice to leverage galaxyproject/galaxy#4887 for greater test isolation.