### PR TITLE
Fix resolving & installing shed repositories from workflows.

### DIFF
--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -6,41 +6,42 @@ from collections import namedtuple
 import yaml
 from bioblend.galaxy.client import Client
 
-try:
-    from ephemeris import shed_install
-except ImportError:
-    shed_install = None
-
-try:
-    from gxformat2.converter import python_to_workflow
-    from gxformat2.interface import BioBlendImporterGalaxyInterface
-    from gxformat2.interface import ImporterGalaxyInterface
-except ImportError:
-    python_to_workflow = None
-    BioBlendImporterGalaxyInterface = None
-    ImporterGalaxyInterface = object
+from ephemeris import generate_tool_list_from_ga_workflow_files
+from ephemeris import shed_tools
+from gxformat2.converter import python_to_workflow
+from gxformat2.interface import BioBlendImporterGalaxyInterface
+from gxformat2.interface import ImporterGalaxyInterface
 
 
 def load_shed_repos(runnable):
     if runnable.type.name != "galaxy_workflow":
         return []
 
-    # TODO: This is crap - doesn't handle nested repositories at all.
     path = runnable.path
     if path.endswith(".ga"):
-        with open(path, "r") as f:
-            workflow = json.load(f)
+        generate_tool_list_from_ga_workflow_files.generate_tool_list_from_workflow([path], "Tools from workflows", "tools.yml")
+        with open("tools.yml", "r") as f:
+            tools = yaml.load(f)["tools"]
+
     else:
+        # It'd be better to just infer this from the tool shed ID somehow than
+        # require explicit annotation like this... I think?
         with open(path, "r") as f:
             workflow = yaml.load(f)
 
-    return workflow.get("tools", [])
+        tools = workflow.get("tools", [])
+
+    return tools
 
 
 def install_shed_repos(runnable, admin_gi):
     tools_info = load_shed_repos(runnable)
     if tools_info:
-        shed_install.install_tools(tools_info, admin_gi, runnable.path, default_install_tool_dependencies=False)
+        shed_tools._ensure_log_configured("ephemeris")
+        install_tool_manager = shed_tools.InstallToolManager(tools_info, admin_gi)
+        install_tool_manager.install_repositories()
+        if install_tool_manager.errored_repositories:
+            raise Exception("Failed to install one or more repositories.")
 
 
 def import_workflow(path, admin_gi, user_gi, from_path=False):

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 import yaml
 from bioblend.galaxy.client import Client
-
 from ephemeris import generate_tool_list_from_ga_workflow_files
 from ephemeris import shed_tools
 from gxformat2.converter import python_to_workflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ glob2
 virtualenv
 lxml
 gxformat2>=0.2.0
-ephemeris>=0.2.0
+ephemeris>=0.8
 galaxy-lib>=17.9.12
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09
 cwltool==1.0.20170828135420


### PR DESCRIPTION
Used by run/serve/test of workflows.

- Update for modern ephemeris usage.
- Update to work with .ga files an not just explicit tool: sections in format 2 workflows.

Test case bundled into the not yet working #775. This part of that PR is working.