### PR TITLE
[WIP] Implement external Galaxy engine.

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -5,7 +5,6 @@ from planemo import options
 from planemo.cli import command_function
 from planemo.engine import (
     engine_context,
-    is_galaxy_engine,
 )
 from planemo.galaxy import galaxy_config
 from planemo.galaxy.test import (

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -64,7 +64,7 @@ def cli(ctx, paths, **kwds):
     """
     runnables = for_paths(paths)
     enable_beta_test = any([r.type not in [RunnableType.galaxy_tool, RunnableType.directory] for r in runnables])
-    enable_beta_test = enable_beta_test or kwds.get("engine", "galaxy") != "engine"
+    enable_beta_test = enable_beta_test or kwds.get("engine", "galaxy") != "galaxy"
     if enable_beta_test:
         info("Enable beta testing mode for testing.")
         with engine_context(ctx, **kwds) as engine:

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -65,9 +65,9 @@ def cli(ctx, paths, **kwds):
     """
     runnables = for_paths(paths)
     enable_beta_test = any([r.type not in [RunnableType.galaxy_tool, RunnableType.directory] for r in runnables])
-    enable_beta_test = enable_beta_test or not is_galaxy_engine(**kwds)
+    enable_beta_test = enable_beta_test or kwds.get("engine", "galaxy") != "engine"
     if enable_beta_test:
-        info("Enable beta testing mode to test artifact that isn't a Galaxy tool.")
+        info("Enable beta testing mode for testing.")
         with engine_context(ctx, **kwds) as engine:
             test_data = engine.test(runnables)
             return_value = handle_reports_and_summary(ctx, test_data.structured_data, kwds=kwds)

--- a/planemo/engine/factory.py
+++ b/planemo/engine/factory.py
@@ -3,8 +3,12 @@
 import contextlib
 
 from .cwltool import CwlToolEngine
-from .galaxy import DockerizedGalaxyEngine
-from .galaxy import GalaxyEngine
+from .galaxy import (
+    DockerizedManagedGalaxyEngine,
+    ExternalGalaxyEngine,
+    LocalManagedGalaxyEngine,
+)
+
 
 UNKNOWN_ENGINE_TYPE_MESSAGE = "Unknown engine type specified [%s]."
 
@@ -12,16 +16,18 @@ UNKNOWN_ENGINE_TYPE_MESSAGE = "Unknown engine type specified [%s]."
 def is_galaxy_engine(**kwds):
     """Return True iff the engine configured is :class:`GalaxyEngine`."""
     engine_type_str = kwds.get("engine", "galaxy")
-    return engine_type_str in ["galaxy", "docker_galaxy"]
+    return engine_type_str in ["galaxy", "docker_galaxy", "external_galaxy"]
 
 
 def build_engine(ctx, **kwds):
     """Build an engine from the supplied planemo configuration."""
     engine_type_str = kwds.get("engine", "galaxy")
     if engine_type_str == "galaxy":
-        engine_type = GalaxyEngine
+        engine_type = LocalManagedGalaxyEngine
     elif engine_type_str == "docker_galaxy":
-        engine_type = DockerizedGalaxyEngine
+        engine_type = DockerizedManagedGalaxyEngine
+    elif engine_type_str == "external_galaxy":
+        engine_type = ExternalGalaxyEngine
     elif engine_type_str == "cwltool":
         engine_type = CwlToolEngine
     else:

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -1,18 +1,25 @@
 """Module contianing the :class:`GalaxyEngine` implementation of :class:`Engine`."""
+from __future__ import absolute_import
 
+import abc
 import contextlib
 
+from galaxy.tools.verify import interactor
+
 from planemo.galaxy.activity import execute
+from planemo.galaxy.config import external_galaxy_config
 from planemo.galaxy.serve import serve_daemon
 from planemo.runnable import RunnableType
 from .interface import BaseEngine
 
 
 class GalaxyEngine(BaseEngine):
-    """An :class:`Engine` implementation backed by Galaxy.
+    """An :class:`Engine` implementation backed by a managed Galaxy.
 
     More information on Galaxy can be found at http://galaxyproject.org/.
     """
+
+    __metaclass__ = abc.ABCMeta
 
     handled_runnable_types = [
         RunnableType.cwl_tool,
@@ -24,14 +31,71 @@ class GalaxyEngine(BaseEngine):
     def _run(self, runnable, job_path):
         """Run CWL job in Galaxy."""
         self._ctx.vlog("Serving artifact [%s] with Galaxy." % (runnable,))
-        with self.serve_runnables([runnable]) as config:
+        with self.ensure_runnables_served([runnable]) as config:
             self._ctx.vlog("Running job path [%s]" % job_path)
             run_response = execute(self._ctx, config, runnable, job_path, **self._kwds)
 
         return run_response
 
+    @abc.abstractmethod
+    def ensure_runnables_served(self, runnables):
+        """Use a context manager and describe Galaxy instance with runnables being served."""
+
+    def _run_test_case(self, test_case):
+        if hasattr(test_case, "job_path"):
+            # Simple file-based job path.
+            super(GalaxyEngine, self)._run_test_case(test_case)
+        else:
+            with self.ensure_runnables_served([test_case.runnable]) as config:
+                galaxy_interactor_kwds = {
+                    "galaxy_url": config.galaxy_url,
+                    "master_api_key": config.master_api_key,
+                    "api_key": config.user_api_key,
+                    "keep_outputs_dir": "",  # TODO: this...
+                }
+                tool_id = test_case.tool_id
+                test_index = test_case.test_index
+                tool_version = test_case.tool_version
+                galaxy_interactor = interactor.GalaxyInteractorApi(**galaxy_interactor_kwds)
+
+                test_results = []
+
+                def _register_job_data(job_data):
+                    test_results.append({
+                        'id': tool_id + "-" + str(test_index),
+                        'has_data': True,
+                        'data': job_data,
+                    })
+
+                verbose = self._ctx.verbose
+                try:
+                    if verbose:
+                        # TODO: this is pretty hacky, it'd be better to send a stream
+                        # and capture the output information somehow.
+                        interactor.VERBOSE_GALAXY_ERRORS = True
+
+                    interactor.verify_tool(
+                        tool_id,
+                        galaxy_interactor,
+                        test_index=test_index,
+                        tool_version=tool_version,
+                        register_job_data=_register_job_data,
+                        quiet=not verbose,
+                    )
+                except Exception:
+                    pass
+
+                return test_results[0]
+
+
+class LocalManagedGalaxyEngine(BaseEngine):
+    """An :class:`Engine` implementation backed by a managed Galaxy.
+
+    More information on Galaxy can be found at http://galaxyproject.org/.
+    """
+
     @contextlib.contextmanager
-    def serve_runnables(self, runnables):
+    def ensure_runnables_served(self, runnables):
         # TODO: define an interface for this - not everything in config would make sense for a
         # pre-existing Galaxy interface.
         with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
@@ -41,7 +105,7 @@ class GalaxyEngine(BaseEngine):
         return self._kwds.copy()
 
 
-class DockerizedGalaxyEngine(GalaxyEngine):
+class DockerizedManagedGalaxyEngine(LocalManagedGalaxyEngine):
     """An :class:`Engine` implementation backed by Galaxy running in Docker.
 
     More information on Galaxy can be found at http://galaxyproject.org/.
@@ -53,7 +117,20 @@ class DockerizedGalaxyEngine(GalaxyEngine):
         return serve_kwds
 
 
+class ExternalGalaxyEngine(GalaxyEngine):
+    """An :class:`Engine` implementation backed by an external Galaxy instance.
+    """
+
+    @contextlib.contextmanager
+    def ensure_runnables_served(self, runnables):
+        # TODO: ensure tools are available
+        with external_galaxy_config(self._ctx, runnables, **self._kwds) as config:
+            config.install_workflows()
+            yield config
+
+
 __all__ = (
-    "GalaxyEngine",
-    "DockerizedGalaxyEngine",
+    "DockerizedManagedGalaxyEngine",
+    "ExternalGalaxyEngine",
+    "LocalManagedGalaxyEngine",
 )

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -44,7 +44,7 @@ class GalaxyEngine(BaseEngine):
     def _run_test_case(self, test_case):
         if hasattr(test_case, "job_path"):
             # Simple file-based job path.
-            super(GalaxyEngine, self)._run_test_case(test_case)
+            return super(GalaxyEngine, self)._run_test_case(test_case)
         else:
             with self.ensure_runnables_served([test_case.runnable]) as config:
                 galaxy_interactor_kwds = {

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -88,7 +88,7 @@ class GalaxyEngine(BaseEngine):
                 return test_results[0]
 
 
-class LocalManagedGalaxyEngine(BaseEngine):
+class LocalManagedGalaxyEngine(GalaxyEngine):
     """An :class:`Engine` implementation backed by a managed Galaxy.
 
     More information on Galaxy can be found at http://galaxyproject.org/.

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -63,7 +63,7 @@ class BaseEngine(Engine):
 
     def _check_can_run(self, runnable):
         if not self.can_run(runnable):
-            template = "Engine type %s can not execute %ss"
+            template = "Engine type [%s] cannot execute [%s]s"
             message = template % (self.__class__, runnable.type)
             error(message)
             self._ctx.exit(EXIT_CODE_UNSUPPORTED_FILE_TYPE)

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -95,27 +95,7 @@ class BaseEngine(Engine):
             self._ctx.vlog(
                 "Running tests %s" % test_case
             )
-            runnable = test_case.runnable
-            job_path = test_case.job_path
-            tmp_path = None
-            if job_path is None:
-                job = test_case.job
-                f = tempfile.NamedTemporaryFile(
-                    dir=test_case.tests_directory,
-                    suffix=".json",
-                    prefix="plnmotmptestjob",
-                    delete=False,
-                    mode="w+",
-                )
-                tmp_path = f.name
-                job_path = tmp_path
-                json.dump(job, f)
-                f.close()
-            try:
-                run_response = self._run(runnable, job_path)
-            finally:
-                if tmp_path:
-                    os.remove(tmp_path)
+            run_response = self._run_test_case(test_case)
             self._ctx.vlog(
                 "Test case [%s] resulted in run response [%s]",
                 test_case,
@@ -123,6 +103,30 @@ class BaseEngine(Engine):
             )
             test_results.append((test_case, run_response))
         return test_results
+
+    def _run_test_case(self, test_case):
+        runnable = test_case.runnable
+        job_path = test_case.job_path
+        tmp_path = None
+        if job_path is None:
+            job = test_case.job
+            f = tempfile.NamedTemporaryFile(
+                dir=test_case.tests_directory,
+                suffix=".json",
+                prefix="plnmotmptestjob",
+                delete=False,
+                mode="w+",
+            )
+            tmp_path = f.name
+            job_path = tmp_path
+            json.dump(job, f)
+            f.close()
+        try:
+            run_response = self._run(runnable, job_path)
+        finally:
+            if tmp_path:
+                os.remove(tmp_path)
+        return run_response
 
     def _process_test_results(self, test_results):
         for (test_case, run_response) in test_results:

--- a/planemo/galaxy/api.py
+++ b/planemo/galaxy/api.py
@@ -7,13 +7,18 @@ from planemo.bioblend import galaxy
 DEFAULT_MASTER_API_KEY = "test_key"
 
 
-def gi(port, key=None):
+def gi(port=None, url=None, key=None):
     """Return a bioblend ``GalaxyInstance`` for Galaxy on this port."""
     ensure_module()
     if key is None:
         key = DEFAULT_MASTER_API_KEY
+    if port is None:
+        url = url
+    else:
+        url = "http://localhost:%d" % int(port)
+
     return galaxy.GalaxyInstance(
-        url="http://localhost:%d" % int(port),
+        url=url,
         key=key
     )
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -251,8 +251,12 @@ DEFAULT_GALAXY_BRAND = 'Configured by Planemo'
 @contextlib.contextmanager
 def galaxy_config(ctx, runnables, **kwds):
     """Set up a ``GalaxyConfig`` in an auto-cleaned context."""
-    dockerize = kwds.get("dockerize", False)
-    c = docker_galaxy_config if dockerize else local_galaxy_config
+    c = local_galaxy_config
+    if kwds.get("dockerize", False):
+        c = docker_galaxy_config
+    elif kwds.get("external", False):
+        c = external_galaxy_config
+
     with c(ctx, runnables, **kwds) as config:
         yield config
 
@@ -584,8 +588,20 @@ def _shared_galaxy_properties(config_directory, kwds, for_tests):
     return properties
 
 
+@contextlib.contextmanager
+def external_galaxy_config(ctx, runnables, for_tests=False, **kwds):
+    yield BaseGalaxyConfig(
+        ctx=ctx,
+        galaxy_url=kwds.get("galaxy_url", None),
+        master_api_key=_get_master_api_key(kwds),
+        user_api_key=kwds.get("galaxy_user_key", None),
+        runnables=runnables,
+        kwds=kwds
+    )
+
+
 def _get_master_api_key(kwds):
-    master_api_key = kwds.get("master_api_key", DEFAULT_MASTER_API_KEY)
+    master_api_key = kwds.get("galaxy_admin_key") or DEFAULT_MASTER_API_KEY
     return master_api_key
 
 
@@ -678,79 +694,51 @@ class GalaxyConfig(GalaxyInterface):
     def log_contents(self):
         """Retrieve text of log for running Galaxy instance."""
 
-    @abc.abstractproperty
-    def gi(self):
-        """Return an admin bioblend Galaxy instance for API interactions."""
-
-    @abc.abstractproperty
-    def user_gi(self):
-        """Return a user-backed bioblend Galaxy instance for API interactions."""
-
-    @abc.abstractmethod
-    def install_repo(self, *args, **kwds):
-        """Install specified tool shed repository."""
-
-    @abc.abstractproperty
-    def tool_shed_client(self):
-        """Return a admin bioblend tool shed client."""
-
-    @abc.abstractmethod
-    def wait_for_all_installed(self):
-        """Wait for all queued up repositories installs to complete."""
-
-    @abc.abstractmethod
-    def install_workflows(self):
-        """Install all workflows configured with these planemo arguments."""
-
-    @abc.abstractmethod
-    def workflow_id(self, path):
-        """Get installed workflow API ID for input path."""
-
     @abc.abstractmethod
     def cleanup(self):
         """Cleanup allocated resources to run this instance."""
 
 
-class BaseGalaxyConfig(GalaxyConfig):
+class BaseGalaxyConfig(GalaxyInterface):
 
     def __init__(
         self,
         ctx,
-        config_directory,
-        env,
-        test_data_dir,
-        port,
-        server_name,
+        galaxy_url,
         master_api_key,
+        user_api_key,
         runnables,
         kwds,
     ):
         self._ctx = ctx
-        self._kwds = kwds
-        self.config_directory = config_directory
-        self.env = env
-        self.test_data_dir = test_data_dir
-        self.port = port
-        self.server_name = server_name
+        self.galaxy_url = galaxy_url
         self.master_api_key = master_api_key
+        self._user_api_key = user_api_key
         self.runnables = runnables
-        self._user_api_key = None
         self._workflow_ids = {}
 
     @property
     def gi(self):
-        return gi(self.port, self.master_api_key)
+        assert self.galaxy_url
+        return gi(url=self.galaxy_url, key=self.master_api_key)
 
     @property
     def user_gi(self):
+        user_api_key = self.user_api_key
+        assert user_api_key
+        return self._gi_for_key(user_api_key)
+
+    @property
+    def user_api_key(self):
         # TODO: thread-safe
         if self._user_api_key is None:
+            # TODO: respect --galaxy_email - seems like a real bug
             self._user_api_key = user_api_key(self.gi)
 
-        return self._gi_for_key(self._user_api_key)
+        return self._user_api_key
 
     def _gi_for_key(self, key):
-        return gi(self.port, key)
+        return gi(port=self.port, key=key)
 
     def install_repo(self, *args, **kwds):
         self.tool_shed_client.install_repository_revision(
@@ -796,7 +784,37 @@ class BaseGalaxyConfig(GalaxyConfig):
         return self._workflow_ids[path]
 
 
-class DockerGalaxyConfig(BaseGalaxyConfig):
+class BaseManagedGalaxyConfig(BaseGalaxyConfig):
+
+    def __init__(
+        self,
+        ctx,
+        config_directory,
+        env,
+        test_data_dir,
+        port,
+        server_name,
+        master_api_key,
+        runnables,
+        kwds,
+    ):
+        galaxy_url = "http://localhost:%d" % port
+        super(BaseManagedGalaxyConfig, self).__init__(
+            ctx=ctx,
+            galaxy_url=galaxy_url,
+            master_api_key=master_api_key,
+            user_api_key=None,
+            runnables=runnables,
+            kwds=kwds
+        )
+        self.config_directory = config_directory
+        self.env = env
+        self.test_data_dir = test_data_dir
+        self.port = port
+        self.server_name = server_name
+
+
+class DockerGalaxyConfig(BaseManagedGalaxyConfig):
     """A :class:`GalaxyConfig` description of a Dockerized Galaxy instance."""
 
     def __init__(
@@ -886,7 +904,7 @@ class DockerGalaxyConfig(BaseGalaxyConfig):
         shutil.rmtree(self.config_directory, CLEANUP_IGNORE_ERRORS)
 
 
-class LocalGalaxyConfig(BaseGalaxyConfig):
+class LocalGalaxyConfig(BaseManagedGalaxyConfig):
     """A local, non-containerized implementation of :class:`GalaxyConfig`."""
 
     def __init__(

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -715,6 +715,7 @@ class BaseGalaxyConfig(GalaxyInterface):
         self.master_api_key = master_api_key
         self._user_api_key = user_api_key
         self.runnables = runnables
+        self._kwds = kwds
         self._workflow_ids = {}
 
     @property

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -33,7 +33,7 @@ def skip_venv_option():
 def run_engine_option():
     return planemo_option(
         "--engine",
-        type=click.Choice(["galaxy", "docker_galaxy", "cwltool"]),
+        type=click.Choice(["galaxy", "docker_galaxy", "cwltool", "external_galaxy"]),
         default="galaxy",
         use_global_config=True,
         help=("Select an engine to run or test aritfacts such as tools "
@@ -55,7 +55,7 @@ def non_strict_cwl_option():
 def serve_engine_option():
     return planemo_option(
         "--engine",
-        type=click.Choice(["galaxy", "docker_galaxy"]),
+        type=click.Choice(["galaxy", "docker_galaxy", "external_galaxy"]),
         default="galaxy",
         use_global_config=True,
         use_env_var=True,
@@ -383,6 +383,39 @@ def docker_galaxy_image_option():
         help=("Docker image identifier for docker-galaxy-flavor used if "
               "engine type is specified as ``docker-galaxy``. Defaults to "
               "to bgruening/galaxy-stable.")
+    )
+
+
+def galaxy_url_option():
+    return planemo_option(
+        "--galaxy_url",
+        use_global_config=True,
+        extra_global_config_vars=["galaxy_url"],
+        use_env_var=True,
+        type=str,
+        help="Remote Galaxy URL to use with external Galaxy engine.",
+    )
+
+
+def galaxy_admin_key_option():
+    return planemo_option(
+        "--galaxy_admin_key",
+        use_global_config=True,
+        extra_global_config_vars=["admin_key"],
+        use_env_var=True,
+        type=str,
+        help="Admin key to use with external Galaxy engine.",
+    )
+
+
+def galaxy_user_key_option():
+    return planemo_option(
+        "--galaxy_user_key",
+        use_global_config=True,
+        extra_global_config_vars=["admin_key"],
+        use_env_var=True,
+        type=str,
+        help="User key to use with external Galaxy engine.",
     )
 
 
@@ -1127,6 +1160,9 @@ def engine_options():
         cwltool_no_container_option(),
         docker_galaxy_image_option(),
         ignore_dependency_problems_option(),
+        galaxy_url_option(),
+        galaxy_admin_key_option(),
+        galaxy_user_key_option(),
     )
 
 

--- a/tests/test_cmd_serve.py
+++ b/tests/test_cmd_serve.py
@@ -114,7 +114,7 @@ class ServeTestCase(CliTestCase):
     def _user_gi(self):
         admin_gi = api.gi(self._port)
         user_api_key = api.user_api_key(admin_gi)
-        user_gi = api.gi(self._port, user_api_key)
+        user_gi = api.gi(self._port, key=user_api_key)
         return user_gi
 
     def _launch_thread_and_wait(self, func, args=[]):


### PR DESCRIPTION
This work is focused on getting the "test" and "run" commands for Galaxy tools and workflows to be able to target already running Galaxy servers, though it should enable other combinations of artifacts and commands such as serving workflows and various CWL artifact operations against that fork of Galaxy.

The tool piece of this requires an unreleased version of galaxy-lib (https://github.com/galaxyproject/galaxy-lib/pull/91) and development APIs in Galaxy for external tool testing (https://github.com/galaxyproject/galaxy-lib/pull/103).

Implements #592.
Implements #508.
