### PR TITLE
Revise CWL related testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   allow_failures:
     - env: TOX_ENV=py27-lint-docstrings
 
-script: PLANEMO_ENABLE_POSTGRES_TESTS=1 PLANEMO_SKIP_CWLTOOL_TESTS=1 PLANEMO_TEST_WORKFLOW_RUN_PROFILE=travisworkflowtests tox -e $TOX_ENV
+script: PLANEMO_ENABLE_POSTGRES_TESTS=1 PLANEMO_SKIP_GALAXY_CWL_TESTS=1 PLANEMO_TEST_WORKFLOW_RUN_PROFILE=travisworkflowtests tox -e $TOX_ENV
 
 after_success:
   - coveralls

--- a/tests/test_build_and_lint.py
+++ b/tests/test_build_and_lint.py
@@ -58,6 +58,7 @@ class BuildAndLintTestCase(CliTestCase):
                 test_dict = yaml.load(stream)
                 assert test_dict
 
+    @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_cwl_fail_on_empty_help(self):
         with self._isolate():
             self._check_exit_code(_cwl_init_command(help_text=False))

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -6,8 +6,8 @@ from .test_utils import (
     assert_exists,
     CliTestCase,
     PROJECT_TEMPLATES_DIR,
+    skip,
     skip_if_environ,
-    skip_unless_python_2_7,
     TEST_DATA_DIR,
 )
 
@@ -58,7 +58,6 @@ class CmdTestTestCase(CliTestCase):
             #        print(o.read())
             #    raise
 
-    @skip_unless_python_2_7()
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_cwltool_tool_test(self):
         """Test testing a CWL tool with cwltool."""
@@ -72,7 +71,7 @@ class CmdTestTestCase(CliTestCase):
             self._check_exit_code(test_command, exit_code=0)
             assert_exists(os.path.join(f, "tool_test_output.json"))
 
-    @skip_unless_python_2_7()
+    @skip  # Test is broken :(
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_output_checks(self):
         """Test testing a CWL tool with cwltool."""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,7 +6,6 @@ from .test_utils import (
     CWL_DRAFT3_DIR,
     PROJECT_TEMPLATES_DIR,
     skip_if_environ,
-    skip_unless_python_2_7,
     TEST_DATA_DIR,
 )
 
@@ -19,7 +18,6 @@ def _cwl_file(name):
 # of just arbitrarily exercising the code.
 class RunTestCase(CliTestCase):
 
-    @skip_unless_python_2_7()
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_run_cat_cwltool(self):
         with self._isolate():
@@ -34,7 +32,6 @@ class RunTestCase(CliTestCase):
             ]
             self._check_exit_code(test_cmd)
 
-    @skip_unless_python_2_7()
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_run_cat_cwltool_more_options(self):
         with self._isolate():
@@ -64,9 +61,9 @@ class RunTestCase(CliTestCase):
             ]
             self._check_exit_code(test_cmd)
 
-    @skip_unless_python_2_7()
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_CWL_TESTS")
     def test_run_cat(self):
         with self._isolate():
             tool_path = _cwl_file("cat1-tool.cwl")
@@ -79,9 +76,9 @@ class RunTestCase(CliTestCase):
             ]
             self._check_exit_code(test_cmd)
 
-    @skip_unless_python_2_7()
-    @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_CWL_TESTS")
     def test_run_output_directory(self):
         with self._isolate() as f:
             tool_path = _cwl_file("wc-tool.cwl")


### PR DESCRIPTION
- Remove requirement for Python 2, the version of cwltool Planemo currently requires works with Python 3 now and is now required unconditionally.
- Add a missing cwltool requirement decorator on test_cwl_fail_on_empty_help.
- Add a new decorator for tests that require the CWL branch of Galaxy - I'd expect we can run both the tests requiring cwltool and the tests requiring Galaxy with a much higher degree of confidence then the tests that require the CWL branch of Galaxy.
- Re-enable the cwltool tests - just disable the CWL branch of Galaxy tests now using this decorator.
- Add an unconditional skip to a broken cwltool related test.
