### PR TITLE
Disable shell warning added to galaxy-lib recently.

### DIFF
--- a/planemo/bioconda_scripts/bioconductor_skeleton.py
+++ b/planemo/bioconda_scripts/bioconductor_skeleton.py
@@ -21,9 +21,9 @@ import pyaml
 import requests
 from six.moves.urllib.parse import urljoin
 
-logging.basicConfig(level=logging.INFO, format='[bioconductor_skeleton.py %(asctime)s]: %(message)s')
+# logging.basicConfig(level=logging.INFO, format='[bioconductor_skeleton.py %(asctime)s]: %(message)s')
 logger = logging.getLogger()
-logging.getLogger("requests").setLevel(logging.WARNING)
+# logging.getLogger("requests").setLevel(logging.WARNING)
 
 base_url = 'http://bioconductor.org/packages/'
 


### PR DESCRIPTION
Planemo uses it extensively in context where trusted inputs don't matter.