### PR TITLE
Print fake shell commands.

### DIFF
--- a/planemo/commands/cmd_project_init.py
+++ b/planemo/commands/cmd_project_init.py
@@ -8,6 +8,7 @@ import click
 from planemo import options
 from planemo.cli import command_function
 from planemo.io import (
+    info,
     untar_to,
     warn,
 )
@@ -42,6 +43,7 @@ def cli(ctx, path, template=None, **kwds):
         untar_args = UNTAR_ARGS % (tempdir)
         untar_to(DOWNLOAD_URL, tempdir, untar_args)
         template_dir = os.path.join(tempdir, template)
+        info("mv '%s'/* '%s'" % (template_dir, path))
         for entry in os.listdir(template_dir):
             shutil.move(os.path.join(template_dir, entry), path)
     finally:

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -45,6 +45,26 @@ def communicate(cmds, **kwds):
     return output
 
 
+def copy(source, dest):
+    info("cp '%s' '%s'" % (source, dest))
+    shutil.copy(source, dest)
+
+
+def mkdir(path):
+    info("mkdir '%s'" % path)
+    os.mkdir(path)
+
+
+def makedirs(path):
+    info("mkdir -p '%s'" % path)
+    os.makedirs(path)
+
+
+def rm_rf_tree(path):
+    info("rm -rf '%s'" % path)
+    shutil.rmtree(path, ignore_errors=True)
+
+
 def shell(cmds, **kwds):
     if isinstance(cmds, list):
         cmd_string = commands.argv_to_str(cmds)

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import os
 import re
-import shutil
 import sys
 import tarfile
 from collections import namedtuple
@@ -25,9 +24,12 @@ from planemo import templates
 from planemo.io import (
     can_write_to_path,
     coalesce_return_codes,
+    copy as io_copy,
     error,
     find_matching_directories,
     info,
+    mkdir,
+    rm_rf_tree,
     shell,
     temp_directory,
     warn,
@@ -205,7 +207,7 @@ def shed_init(ctx, path, **kwds):
         workflow_name = os.path.basename(from_workflow)
         workflow_target = os.path.join(path, workflow_name)
         if not os.path.exists(workflow_target):
-            shutil.copyfile(from_workflow, workflow_target)
+            io_copy(from_workflow, workflow_target)
 
         if not can_write_to_path(repo_dependencies_path, **kwds):
             return 1
@@ -287,7 +289,7 @@ def upload_repository(ctx, realized_repository, **kwds):
         tar_path = build_tarball(path, **kwds)
     if kwds.get("tar_only", False):
         name = realized_repository.pattern_to_file_name("shed_upload.tar.gz")
-        shutil.copy(tar_path, name)
+        io_copy(tar_path, name)
         return 0
     shed_context = get_shed_context(ctx, **kwds)
     update_kwds = {}
@@ -393,9 +395,9 @@ def _diff_in(ctx, working, realized_repository, **kwds):
         )
     else:
         tar_path = build_tarball(path)
-        os.mkdir(mine)
+        mkdir(mine)
         shell(['tar', '-xzf', tar_path, '-C', mine])
-        shutil.rmtree(tar_path, ignore_errors=True)
+        rm_rf_tree(tar_path)
 
     output = kwds.get("output", None)
     raw = kwds.get("raw", False)

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -848,7 +848,7 @@ def write_tool_description(ctx, tool_description, **kwds):
     if tool_description.test_files:
         if not os.path.exists("test-data"):
             io.info("No test-data directory, creating one.")
-            os.makedirs('test-data')
+            io.makedirs('test-data')
         for test_file in tool_description.test_files:
             io.info("Copying test-file %s" % test_file)
             try:


### PR DESCRIPTION
A bunch of raw shell scripting was replaced with Python system calls in 953958932384ff7ebd1a09806e6c290c556f9dea, that is great but the cool reporting of the shell commands was lost. This restores the reporting as fake shell commands corresponding to what is happening (sort of).

In the spirit of something @erasche proposed doing in #100. 