### PR TITLE
Revise README and touch up documentation in general.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ This quick start demonstrates using ``planemo`` commands to help
 develop Galaxy tools.
 
 -----------------
-Obtaining Planemo
+Obtaining
 -----------------
 
 For a traditional Python installation of Planemo, first set up a virtualenv
@@ -59,11 +59,11 @@ You can choose from open virtualization format (OVA_, .ova), Docker_,
 or Vagrant_ appliances.
 
 --------------
-Planemo Basics
+Basics
 --------------
 
-This quick start will assume you have a directory with one or more
-tool XML files. If none is available, one can be quickly created for
+This quick start will assume you have a directory with one or more Galaxy
+tool XML files. If no such directory is available, one can be quickly created for
 demonstrating ``planemo`` as follows ``mkdir mytools; cd mytools; planemo
 project_init --template=demo``.
 
@@ -129,207 +129,57 @@ Like ``test``, ``serve`` requires a Galaxy root and one can be
 explicitly specified with ``--galaxy_root`` or installed dynamically
 with ``--install_galaxy``.
 
+For more information on building Galaxy tools in general please check out
+`Building Galaxy Tools Using Planemo`_.
+
 ---------
 Tool Shed
 ---------
 
 Planemo can help you publish tools to the Galaxy Tool Shed.
-Check out `Publishing to the Tool Shed`_.
+Check out `Publishing to the Tool Shed`_ for more information.
 
+------
+Conda
+------
 
-Experimental Features
----------------------
+Planemo can help develop tools and Conda packages in unison.
+Check out `Dependencies and Conda`_ for more information.
 
-Planemo can also be used to explore some more experimental features related to
-Galaxy tooling - including support for Conda_, `Travis CI`_, Docker_,
-`Common Workflow Language`_ (CWL), and Homebrew_.
+--------
+Docker
+--------
 
----------------------
-Conda Package Manager
----------------------
-
-Conda_ is package manager that among many other things can be used
-to manage Python packages. Please read a few notes regarding the setup:
-
-* Planemo cannot be installed via Conda and then run Galaxy inside
-  the same Conda environment currently.
-
-* `galaxy-lib <https://github.com/galaxyproject/galaxy-lib>`_ is a
-  dependency of Planemo and having this on the Python path prevents
-  correct operation of Galaxy.
-
-* Conda dependency resolution can be used for Galaxy tools,
-
-    This allows Galaxy to map conda recipes to ``requirement`` tags on tools
-
-    Just install planemo normally via pip into a virtual environment or via brew and
-    use the appropriate commands and options:
-
-    ::
-
-        $ planemo conda_init
-        $ planemo conda_install .
-        $ planemo test --galaxy_branch release_16.04 --conda_dependency_resolution .
-        $ planemo serve --galaxy_branch release_16.04 --conda_dependency_resolution .
-
-    The test and serve commands above require the target Galaxy to be 16.01 or higher.
-
-* Galaxy can also simply run inside an existing conda environment and
-  rather than using dependency resolution Conda packages can just be picked
-  up from the ``PATH``.
-
-    Note: This isn't a well supported approach yet, and when possible Planemo
-    and Galaxy should not be installed inside of Conda and the conda dependency
-    resolution (as described above) should be used to allow tools to find Conda
-    packages.
-
-    To run Galaxy within a Conda environment, Planemo must be installed outside the
-    Conda environment - via pip into a virtual environment or via homebrew. In the
-    former case, don't place the virtualenv's ``bin`` directory on your PATH - it
-    will conflict with Conda. Just reference Planemo directly
-    ``/path/to/planemo_venv/bin/planemo test``.
-
-    To run Galaxy from within the environment you will need to install Galaxy
-    dependencies into the conda environment. Target the development branch of Galaxy
-    for this since it has "unpinned" dependencies that are easier to fullfill for
-    conda.
-
-    ::
-
-        (conda-env-test) $ conda install numpy bx-python pysam # install the hard ones using conda
-        (conda-env-test) $ cd $GALAXY_ROOT
-        (conda-env-test) $ ./scripts/common_startup.sh --skip-venv --dev-wheels # install remaining ones using pip via Galaxy
-        (conda-env-test) $ cd /path/to/my/tools
-        (conda-env-test) $ /path/to/planemo_venv/bin/planemo test --skip_venv  .
-        (conda-env-test) $ /path/to/planemo_venv/bin/planemo serve --skip_venv  .
-
-    A small `test script <https://github.com/galaxyproject/planemo/blob/master/tests/scripts/conda_test.sh>`__
-    in the Planemo source tree demonstrates this.
-
------------
-TravisCI
------------
-
-When tools are ready to be published to GitHub_, it may be valuable to setup
-continuous integration to test changes committed and new pull requests.
-`Travis CI`_ is a service providing free testing and deep integration with
-GitHub_.
-
-The ``travis_init`` `command
-<http://planemo.readthedocs.org/en/latest/commands.html#travis_init-
-command>`__ will bootstrap a project with files to ease continuous integration
-testing of tools using a Planemo driven approach inspired by this great `blog
-post <http://bit.ly/gxtravisci>`_ by `Peter Cock
-<https://github.com/peterjc>`_.
-
-::
-
-    $ planemo travis_init .
-    $ # setup Ubuntu 12.04 w/tool dependencies
-    $ vim .travis/setup_custom_dependencies.bash
-    $ git add .travis.yml .travis
-    $ git commit -m "Add Travis CI testing infrastructure for tools."
-    $ git push # and register repository @ http://travis-ci.org/
-
-In this example the file ``.travis/setup_custom_dependencies.bash`` should
-install the dependencies required to test your files on to the Travis user's
-``PATH``.
-
-This testing approach may only make sense for smaller repositories with a
-handful of tools. For larger repositories, such as `tools-devteam`_ or
-`tools-iuc`_ simply linting tool and tool shed artifacts may be more feasible.
-Check out the ``.travis.yml`` file used by the IUC as `example
-<https://github.com/galaxyproject/tools-iuc/blob/master/.travis.yml>`__.
-
------------------
-Docker Containers
------------------
-
-Galaxy has `experimental support
-<https://wiki.galaxyproject.org/Admin/Tools/Docker>`_ for running jobs in
-Docker_ containers. Planemo contains tools to assist in development of Docker
-images for Galaxy tools.
-
-A shell can be launched to explore the Docker environment referenced by tools
-that are annotated with publically registered Docker images.
-
-::
-
-    $ (planemo docker_shell bowtie2.xml)
-
-For Docker containers still in development - a Dockerfile can be associated
-with a tool by sticking it in the tool's directory. Planemo can then build
-and tag a Docker image for this tool and launch a shell into it using the
-following commands.
-
-::
-
-    $ planemo docker_build bowtie2.xml # assumes Dockerfile in same dir
-    $ (planemo docker_shell --from_tag bowtie2.xml)
-
-For more details see the documentation for the `docker_build
-<http://planemo.readthedocs.org/en/latest/commands.html#docker_build-command>`__
-and `docker_shell
-<http://planemo.readthedocs.org/en/latest/commands.html#docker_shell-command>`__
-commands.
+Planemo can help develop tools deployable via Docker.
+Check out `Dependencies and Docker`_ for more information.
 
 --------------------------
 Common Workflow Language
 --------------------------
 
-Planemo includes highly experimental support for running a subset of valid
-`Common Workflow Language`_ (CWL) tools using a fork of Galaxy enhanced to run
-CWL tools.
+Planemo includes experimental support for running a subset of valid
+`Common Workflow Language`_ (CWL) tools using either the reference implementation cwltool or
+a fork of Galaxy enhanced to run CWL tools.
 
 ::
 
     $ planemo project_init --template cwl_draft3_spec
     $ planemo serve --cwl cwl_draft3_spec/cat1-tool.cwl
 
------------
-Brew
------------
-
-The Galaxy development team was exploring (the effort has since shifted towards
-Conda_) different options for integrating Homebrew_ and linuxbrew_ with Galaxy.
-One angle is resolving the tool requirements using ``brew``. An experimental
-approach for versioning of brew recipes will be used. See full discussion on
-the homebrew-science issues page
-`here <https://github.com/Homebrew/homebrew-science/issues/1191>`_.
-Information on the implementation can be found
-https://github.com/jmchilton/platform-brew until a more permanent project home
-is setup.
-
-::
-
-    $ planemo brew_init # install linuxbrew (only need if not already installed)
-    $ planemo brew # install dependencies for all tools in directory.
-    $ planemo brew bowtie2.xml # install dependencies for one tool
-    $ which bowtie2
-    bowtie2 not found
-    $ . <(planemo brew_env --shell bowtie2.xml) # shell w/brew deps resolved
-    (bowtie2)$ which bowtie2
-    /home/john/.linuxbrew/Cellar/bowtie2/2.1.0/bin/bowtie2
-    (bowtie2)$ exit
-    $ . <(planemo brew_env bowtie2.xml) # or just source deps in cur env
-    $ which bowtie2
-    /home/john/.linuxbrew/Cellar/bowtie2/2.1.0/bin/bowtie2
-
-For more information see the documentation for the `brew
-<http://planemo.readthedocs.org/en/latest/commands.html#brew-command>`__
-and `brew_env
-<http://planemo.readthedocs.org/en/latest/commands.html#brew_env-command>`__ commands.
+Checko out `Building Common Workflow Language Tools`_ for more information.
 
 .. _Galaxy: http://galaxyproject.org/
 .. _GitHub: https://github.com/
 .. _Conda: http://conda.pydata.org/
 .. _Docker: https://www.docker.com/
-.. _Homebrew: http://brew.sh/
-.. _linuxbrew: https://github.com/Homebrew/linuxbrew
 .. _Vagrant: https://www.vagrantup.com/
 .. _Travis CI: http://travis-ci.org/
 .. _`tools-devteam`: https://github.com/galaxyproject/tools-devteam
 .. _`tools-iuc`: https://github.com/galaxyproject/tools-iuc
+.. _Building Galaxy Tools Using Planemo: http://planemo.readthedocs.io/en/latest/writing_standalone.html
 .. _Publishing to the Tool Shed: http://planemo.readthedocs.org/en/latest/publishing.html
+.. _Dependencies and Conda: http://planemo.readthedocs.io/en/latest/writing_advanced.html#dependencies-and-conda
+.. _Dependencies and Docker: http://planemo.readthedocs.io/en/latest/writing_advanced.html#dependencies-and-docker
 .. _Common Workflow Language: http://common-workflow-language.github.io
+.. _Building Common Workflow Language Tools: http://planemo.readthedocs.io/en/latest/writing_cwl_standalone.html
 .. _OVA: https://en.wikipedia.org/wiki/Open_Virtualization_Format

--- a/docs/_writing_cwl_intro.rst
+++ b/docs/_writing_cwl_intro.rst
@@ -116,6 +116,8 @@ tests with Galaxy but we can also specify the use of ``cwltool`` (the
 reference implementation of CWL) which will be quicker and more robust until
 while Galaxy support for the CWL is still in development.
 
+::
+
     $ planemo test --no-container --engine cwltool seqtk_seq.cwl
     Enable beta testing mode to test artifact that isn't a Galaxy tool.
     All 1 test(s) executed passed.

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -60,3 +60,4 @@ documentation describes these commands.
 .. include:: commands/tool_init.rst
 .. include:: commands/travis_init.rst
 .. include:: commands/virtualenv.rst
+.. include:: commands/workflow_convert.rst

--- a/docs/commands/workflow_convert.rst
+++ b/docs/commands/workflow_convert.rst
@@ -1,0 +1,146 @@
+
+``workflow_convert`` command
+======================================
+
+This section is auto-generated from the help text for the planemo command
+``workflow_convert``. This help message can be generated with ``planemo workflow_convert
+--help``.
+
+**Usage**::
+
+    planemo workflow_convert [OPTIONS] WORKFLOW_PATH
+
+**Help**
+
+Convert Format 2 workflow to a native Galaxy workflow.
+
+**Options**::
+
+
+      -f, --force                     Overwrite existing files if present.
+      -o, --output PATH
+      --galaxy_root DIRECTORY         Root of development galaxy directory to
+                                      execute command with.
+      --galaxy_database_seed PATH     Preseeded Galaxy sqlite database to target.
+      --extra_tools PATH              Extra tool sources to include in Galaxy's tool
+                                      panel (file or directory). These will not be
+                                      linted/tested/etc... but they will be
+                                      available to workflows and for interactive
+                                      use.
+      --install_galaxy                Download and configure a disposable copy of
+                                      Galaxy from github.
+      --galaxy_branch TEXT            Branch of Galaxy to target (defaults to
+                                      master) if a Galaxy root isn't specified.
+      --galaxy_source TEXT            Git source of Galaxy to target (defaults to
+                                      the official galaxyproject github source if a
+                                      Galaxy root isn't specified.
+      --skip_venv                     Do not create or source a virtualenv
+                                      environment for Galaxy, this should be used or
+                                      instance to preserve an externally configured
+                                      virtual environment or conda environment.
+      --no_cache_galaxy               Skip caching of Galaxy source and dependencies
+                                      obtained with --install_galaxy. Not caching
+                                      this results in faster downloads (no git) - so
+                                      is better on throw away instances such with
+                                      TravisCI.
+      --no_cleanup                    Do not cleanup temp files created for and by
+                                      Galaxy.
+      --galaxy_email TEXT             E-mail address to use when launching single-
+                                      user Galaxy server.
+      --docker / --no_docker          Run Galaxy tools in Docker if enabled.
+      --docker_cmd TEXT               Command used to launch docker (defaults to
+                                      docker).
+      --docker_sudo / --no_docker_sudo
+                                      Flag to use sudo when running docker.
+      --docker_host TEXT              Docker host to target when executing docker
+                                      commands (defaults to localhost).
+      --docker_sudo_cmd TEXT          sudo command to use when --docker_sudo is
+                                      enabled (defaults to sudo).
+      --mulled_containers, --biocontainers
+                                      Test tools against mulled containers (forces
+                                      --docker).
+      --job_config_file PATH          Job configuration file for Galaxy to target.
+      --tool_dependency_dir DIRECTORY
+                                      Tool dependency dir for Galaxy to target.
+      --port INTEGER                  Port to serve Galaxy on (default is 9090).
+      --host TEXT                     Host to bind Galaxy to. Default is 127.0.0.1
+                                      that is restricted to localhost connections
+                                      for security reasons set to 0.0.0.0 to bind
+                                      Galaxy to all ports including potentially
+                                      publicly accessible ones.
+      --engine [galaxy|docker_galaxy]
+                                      Select an engine to serve aritfacts such as
+                                      tools and workflows. Defaults to a local
+                                      Galaxy, but running Galaxy within a Docker
+                                      container.
+      --non_strict_cwl                Disable strict validation of CWL.
+      --docker_galaxy_image TEXT      Docker image identifier for docker-galaxy-
+                                      flavor used if engine type is specified as
+                                      ``docker-galaxy``. Defaults to to bgruening
+                                      /galaxy-stable.
+      --test_data DIRECTORY           test-data directory to for specified tool(s).
+      --tool_data_table PATH          tool_data_table_conf.xml file to for specified
+                                      tool(s).
+      --dependency_resolvers_config_file PATH
+                                      Dependency resolver configuration for Galaxy
+                                      to target.
+      --brew_dependency_resolution    Configure Galaxy to use plain brew dependency
+                                      resolution.
+      --shed_dependency_resolution    Configure Galaxy to use brewed Tool Shed
+                                      dependency resolution.
+      --no_dependency_resolution      Configure Galaxy with no dependency resolvers.
+      --conda_prefix DIRECTORY        Conda prefix to use for conda dependency
+                                      commands.
+      --conda_exec PATH               Location of conda executable.
+      --conda_debug                   Enable more verbose conda logging.
+      --conda_channels, --conda_ensure_channels TEXT
+                                      Ensure conda is configured with specified
+                                      comma separated list of channels.
+      --conda_use_local               Use locally built packages while building
+                                      Conda environments.
+      --conda_dependency_resolution   Configure Galaxy to use only conda for
+                                      dependency resolution.
+      --conda_copy_dependencies       Conda dependency resolution for Galaxy will
+                                      copy dependencies instead of attempting to
+                                      link them.
+      --conda_auto_install / --no_conda_auto_install
+                                      Conda dependency resolution for Galaxy will
+                                      attempt to install requested but missing
+                                      packages.
+      --conda_auto_init / --no_conda_auto_init
+                                      Conda dependency resolution for Galaxy will
+                                      auto install conda itself using miniconda if
+                                      not availabe on conda_prefix.
+      --profile TEXT                  Name of profile (created with the
+                                      profile_create command) to use with this
+                                      command.
+      --postgres                      Use postgres database type.
+      --database_type [postgres|postgres_docker|sqlite|auto]
+                                      Type of database to use for profile - 'auto',
+                                      'sqlite', 'postgres', and 'postgres_docker'
+                                      are available options. Use postgres to use an
+                                      existing postgres server you user can access
+                                      without a password via the psql command. Use
+                                      postgres_docker to have Planemo manage a
+                                      docker container running postgres. Data with
+                                      postgres_docker is not yet persisted past when
+                                      you restart the docker container launched by
+                                      Planemo so be careful with this option.
+      --postgres_psql_path TEXT       Name or or path to postgres client binary
+                                      (psql).
+      --postgres_database_user TEXT   Postgres username for managed development
+                                      databases.
+      --postgres_database_host TEXT   Postgres host name for managed development
+                                      databases.
+      --postgres_database_port TEXT   Postgres port for managed development
+                                      databases.
+      --file_path DIRECTORY           Location for files created by Galaxy (e.g.
+                                      database/files).
+      --database_connection TEXT      Database connection string to use for Galaxy.
+      --shed_tool_conf TEXT           Location of shed tools conf file for Galaxy.
+      --shed_tool_path TEXT           Location of shed tools directory for Galaxy.
+      --daemon                        Serve Galaxy process as a daemon.
+      --pid_file PATH                 Location of pid file is executed with
+                                      --daemon.
+      --help                          Show this message and exit.
+    

--- a/docs/planemo.commands.rst
+++ b/docs/planemo.commands.rst
@@ -452,6 +452,14 @@ planemo\.commands\.cmd\_virtualenv module
     :undoc-members:
     :show-inheritance:
 
+planemo\.commands\.cmd\_workflow\_convert module
+------------------------------------------------
+
+.. automodule:: planemo.commands.cmd_workflow_convert
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------


### PR DESCRIPTION
- Drop mention of Brew, brew-based tool development is probably a dead end at this point.
- Drop mention of the Travis support - per tool repositories never took off in favor of mega-repositories. Travis support should be upgraded to reflect this and not referenced until it is.
- Include less dated information in the readme and link out to the more well maintained RTDs for Conda and Docker.