### PR TITLE
Restructure serve testing code for reuse.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   allow_failures:
     - env: TOX_ENV=py27-lint-docstrings
 
-script: PLANEMO_ENABLE_POSTGRES_TESTS=1 PLANEMO_SKIP_GALAXY_CWL_TESTS=1 PLANEMO_TEST_WORKFLOW_RUN_PROFILE=travisworkflowtests tox -e $TOX_ENV
+script: PLANEMO_SKIP_REDUNDANT_TESTS=1 PLANEMO_ENABLE_POSTGRES_TESTS=1 PLANEMO_SKIP_GALAXY_CWL_TESTS=1 PLANEMO_TEST_WORKFLOW_RUN_PROFILE=travisworkflowtests tox -e $TOX_ENV
 
 after_success:
   - coveralls

--- a/tests/test_galaxy_serve.py
+++ b/tests/test_galaxy_serve.py
@@ -21,6 +21,7 @@ from .test_utils import (
 class GalaxyServeTestCase(CliTestCase):
     """Tests for planemo.galaxy.serve."""
 
+    @skip_if_environ("PLANEMO_SKIP_REDUNDANT_TESTS")  # redundant with test_cmd_serve -> test_serve_daemon
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     def test_serve_daemon(self):
         """Test serving a galaxy tool via a daemon Galaxy process."""
@@ -71,6 +72,7 @@ class GalaxyServeTestCase(CliTestCase):
         assert len(user_gi.workflows.get_workflows()) == 1
         config.kill()
 
+    @skip_if_environ("PLANEMO_SKIP_REDUNDANT_TESTS")  # redundant with test_cmd_serve -> test_shed_serve
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     def test_shed_serve_daemon(self):
         """Test serving FASTQC from the tool shed via a daemon Galaxy process."""


### PR DESCRIPTION
Want to build test cases in the external engine code that standup Galaxy with ``planemo serve`` and then test against it. This is an atomic step in that direction and that branch has grown unwieldy.
