### PR TITLE
Improve test report handling for JSON generated via galaxy-lib testing script.

### DIFF
--- a/planemo/commands/cmd_test_reports.py
+++ b/planemo/commands/cmd_test_reports.py
@@ -24,4 +24,5 @@ def cli(ctx, path, **kwds):
         return 1
 
     test_data = StructuredData(path)
+    test_data.calculate_summary_data_if_needed()
     handle_reports(ctx, test_data.structured_data, kwds)

--- a/planemo/reports/custom.js
+++ b/planemo/reports/custom.js
@@ -112,7 +112,12 @@ var TestResult = function(data) {
 		splitParts = rSplit(testMethod, "_", 1);
 	}
 	var toolName = splitParts[0];
-	var testIndex = splitParts[1];
+	var testIndex;
+	if(data["data"]["test_index"] !== null) {
+		testIndex = data["data"]["test_index"];
+	} else {
+		testIndex = splitParts[1];
+	}
 	this.toolName = toolName;
 	this.testIndex = parseInt(testIndex);
 	console.log(data);

--- a/planemo/test/results.py
+++ b/planemo/test/results.py
@@ -52,6 +52,10 @@ class StructuredData(object):
         """Set the exit_code for the this test."""
         self.structured_data["exit_code"] = exit_code
 
+    def calculate_summary_data_if_needed(self):
+        if "summary" not in self.structured_data:
+            self.calculate_summary_data()
+
     def calculate_summary_data(self):
         """Use full details on individual test data to update structured data with summary info."""
         num_tests = 0


### PR DESCRIPTION
Should work nicely with reports from the external tool testing script enhanced in galaxy-lib with https://github.com/galaxyproject/galaxy-lib/pull/103.

