### PR TITLE
added documentation for GALAXY_MEMORY_MB

### DIFF
--- a/docs/_writing_clusters.rst
+++ b/docs/_writing_clusters.rst
@@ -1,9 +1,9 @@
 Cluster Usage
 ==============================
 
---------------------------------------------
-Developing for Clusters - ``GALAXY_SLOTS``
---------------------------------------------
+-----------------------------------------------------------------------------------------------------
+Developing for Clusters - ``GALAXY_SLOTS``, ``GALAXY_MEMORY_MB``, and ``GALAXY_MEMORY_MB_PER_SLOT``
+-----------------------------------------------------------------------------------------------------
 
 ``GALAXY_SLOTS`` is a special environment variable that is set in a Galaxy
 tool's runtime environment. If the tool you are working on allows configuring
@@ -29,6 +29,14 @@ tool should be allowed to use.
 For information on how server administrators can configure this value for
 a particular tool, check out `the Galaxy wiki
 <https://wiki.galaxyproject.org/Admin/Config/GALAXY_SLOTS>`__.
+
+Analogously ``GALAXY_MEMORY_MB`` and ``GALAXY_MEMORY_MB_PER_SLOT`` are special 
+environment variables in a Galaxy tool's runtime environment that can be used
+to specify the amount of memory that a tool can use overall and per slot, 
+respectively. 
+
+For an example see the samtools sort tool (`here https://github.com/galaxyproject/tools-iuc/blob/master/tool_collections/samtools/samtools_sort/samtools_sort.xml`__) which allows to specify the 
+total memory with the -m parameter. 
 
 -----------------------------------------------
 Test Against Clusters - ``--job_config_file``


### PR DESCRIPTION
There are two new variables that can be used in tools -- see https://github.com/galaxyproject/galaxy/pull/5625. I will also update the cluster documentation. As suggested by @natefoo the link might change. I hope that I can fix this soon.
