### PR TITLE
Fixes to get Docker Galaxy Stable running as an --engine again.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,8 @@ History
 0.50.0.dev0
 ---------------------
 
-    
+* Fixes and small CLI tweaks to get the Docker Galaxy container working as an ``--engine`` for the
+  run, serve, and test commands.
 
 ---------------------
 0.49.2 (2018-05-09)

--- a/planemo/network_util.py
+++ b/planemo/network_util.py
@@ -1,4 +1,8 @@
 import socket
+try:
+    from http.client import BadStatusLine
+except ImportError:
+    from httplib import BadStatusLine
 from time import time as now
 
 from six.moves.urllib.error import URLError
@@ -27,6 +31,8 @@ def wait_http_service(url, timeout=None):
             kwds = {} if timeout is None else dict(timeout=next_timeout)
             urlopen(url, **kwds)
             return True
+        except BadStatusLine:
+            pass
         except URLError:
             pass
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -378,11 +378,28 @@ def install_galaxy_option():
 def docker_galaxy_image_option():
     return planemo_option(
         "--docker_galaxy_image",
-        default="bgruening/galaxy-stable",
+        default="quay.io/bgruening/galaxy",
         use_global_config=True,
         help=("Docker image identifier for docker-galaxy-flavor used if "
               "engine type is specified as ``docker-galaxy``. Defaults to "
-              "to bgruening/galaxy-stable.")
+              "to quay.io/bgruening/galaxy.")
+    )
+
+
+def docker_extra_volume_option():
+    arg_type = click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        resolve_path=True,
+    )
+    return planemo_option(
+        "--docker_extra_volume",
+        type=arg_type,
+        default=None,
+        use_global_config=True,
+        help=("Extra path to mount if --engine docker.")
     )
 
 
@@ -1062,6 +1079,7 @@ def galaxy_serve_options():
         serve_engine_option(),
         non_strict_cwl_option(),
         docker_galaxy_image_option(),
+        docker_extra_volume_option(),
         galaxy_config_options(),
         daemon_option(),
         pid_file_option(),
@@ -1159,6 +1177,7 @@ def engine_options():
         non_strict_cwl_option(),
         cwltool_no_container_option(),
         docker_galaxy_image_option(),
+        docker_extra_volume_option(),
         ignore_dependency_problems_option(),
         galaxy_url_option(),
         galaxy_admin_key_option(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ virtualenv
 lxml
 gxformat2>=0.2.0
 ephemeris>=0.8
-galaxy-lib>=18.5.5
+galaxy-lib>=18.5.10
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09
 cwltool==1.0.20170828135420


### PR DESCRIPTION
Some of this broke because of API changes over time other things seem like they may have always been broken. The broken API changes include.

- DockerVolume no longer in docker_util in galaxy-lib.
- There seem to be changes in how docker_util handles environment commands (caller needs to escape).
- There seem to be some changes in the Docker CLI related to volume arguments.
- Planemo now (at least sometimes) uploads with file paths, so adding --docker_extra_volume to allow mounting test data expected to be in the container.