### PR TITLE
Allow optional disabling of Galaxy single user mode.

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -530,7 +530,6 @@ def _shared_galaxy_properties(config_directory, kwds, for_tests):
     user_email = _user_email(kwds)
     properties = {
         'master_api_key': master_api_key,
-        'single_user': user_email,
         'admin_users': "%s,test@bx.psu.edu" % user_email,
         'expose_dataset_path': "True",
         'cleanup_job': 'never',
@@ -541,6 +540,9 @@ def _shared_galaxy_properties(config_directory, kwds, for_tests):
         'brand': kwds.get("galaxy_brand", DEFAULT_GALAXY_BRAND),
         'strict_cwl_validation': str(not kwds.get("non_strict_cwl", False)),
     }
+    if kwds.get("galaxy_single_user", True):
+        properties['single_user'] = user_email
+
     if for_tests:
         empty_dir = os.path.join(config_directory, "empty")
         _ensure_directory(empty_dir)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -607,6 +607,18 @@ def paste_test_data_paths_option():
     )
 
 
+def single_user_mode_option():
+    return planemo_option(
+        "galaxy_single_user",
+        "--galaxy_single_user/--no_galaxy_single_user",
+        is_flag=True,
+        default=True,
+        help=("By default Planemo will configure Galaxy to run in single-user mode where there "
+              "is just one user and this user is automatically logged it. Use --no_galaxy_single_user "
+              "to prevent Galaxy from running this way.")
+    )
+
+
 def required_workflow_arg():
     arg_type = click.Path(
         exists=True,
@@ -1029,6 +1041,7 @@ def galaxy_config_options():
         database_connection_option(),
         shed_tools_conf_option(),
         shed_tools_directory_option(),
+        single_user_mode_option(),
     )
 
 


### PR DESCRIPTION
Allows testing with ``planemo serve --engine docker_galaxy`` in a modality that more closely reflects "real Galaxy" servers. 