### PR TITLE
Add --no_shed_install option.

### DIFF
--- a/docs/test_format.rst
+++ b/docs/test_format.rst
@@ -33,9 +33,9 @@ same testing file format is used for both kinds of artifacts.
       job: pear_job.yml
       outputs:
         assembled_pairs:
-          file: test-data/pear_assembled_results1.fastq
+          path: test-data/pear_assembled_results1.fastq
         unassembled_forward_reads:
-          file: test-data/pear_unassembled_forward_results1.fastq
+          path: test-data/pear_unassembled_forward_results1.fastq
 
 
 .. code-block:: yaml
@@ -50,13 +50,13 @@ same testing file format is used for both kinds of artifacts.
           path: mutant_R2.fastq
         wildtype.fna:
           class: File
-          path: wildtype.fna
+          location: https://zenodo.org/record/582600/files/wildtype.fna
         wildtype.gbk:
           class: File
-          path: wildtype.gbk
+          location: https://zenodo.org/record/582600/files/wildtype.gbk
         wildtype.gff:
           class: File
-          path: wildtype.gff
+          location: https://zenodo.org/record/582600/files/wildtype.gff
       outputs:
         jbrowse_html:
           asserts:
@@ -84,6 +84,11 @@ The ``job`` object can be a mapping embedded right in the file or a reference to
 The job input file is a proper CWL_ job document - which is fairly straight forward as demonstrated in
 the above examples. Planemo adapts the CWL_ job document to Galaxy_ workflows and tools - using input
 names for Galaxy_ tools and input node labels for workflows.
+
+Input files can be specified using either ``path`` attributes (which should generally be file
+paths relative to the aritfact and test directory) or ``location`` (which should be a URI). The 
+examples above demonstrate using both paths relative to the tool file and test data published
+to `Zenodo <https://zenodo.org/>`__.
 
 .. note::
 
@@ -241,11 +246,13 @@ option to mount test data into the testing container.
 ``external_galaxy``
 ~~~~~~~~~~~~~~~~~~~~
 
-    $ planemo test --engine external_galaxy --galaxy_admin_key <admin_key> --galaxy_user_key <user_key> --galaxy_user <url>
+    $ planemo test --engine external_galaxy --galaxy_admin_key <admin_key> --galaxy_user_key <user_key> [--no_shed_install] <url>
 
 This is primarily useful for testing workflows against already running Galaxy instances. An admin or
 master API key should be supplied to install missing tool repositories for the workflow and a user API
-key should be supplied to run the workflow using.
+key should be supplied to run the workflow using. If you wish to skip tool shed repository installation
+(this requires the tool all be present already), use the ``-no_shed_install`` option with the ``test``
+command.
 
 To run tool tests against a running Galaxy, ``galaxy-tool-test`` is a script that gets installed with 
 galaxy-lib and so may very well already be on your ``PATH``. Check out the options available with that

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -741,7 +741,9 @@ class BaseGalaxyConfig(GalaxyInterface):
                 self._install_workflow(runnable)
 
     def _install_workflow(self, runnable):
-        install_shed_repos(runnable, self.gi, self._kwds.get("ignore_dependency_problems", False))
+        if self._kwds["shed_install"]:
+            install_shed_repos(runnable, self.gi, self._kwds.get("ignore_dependency_problems", False))
+
         # TODO: Allow serialization so this doesn't need to assume a
         # shared filesystem with Galaxy server.
         from_path = runnable.type.name == "cwl_workflow"

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -607,6 +607,17 @@ def paste_test_data_paths_option():
     )
 
 
+def shed_install_option():
+    return planemo_option(
+        "--shed_install/--no_shed_install",
+        is_flag=True,
+        default=True,
+        help=("By default Planemo will attempt to install repositories needed for workflow "
+              "testing. This may not be appropriate for production servers and so this can "
+              "disabled by calling planemo with --no_shed_install.")
+    )
+
+
 def single_user_mode_option():
     return planemo_option(
         "galaxy_single_user",
@@ -1108,6 +1119,7 @@ def galaxy_serve_options():
         daemon_option(),
         pid_file_option(),
         ignore_dependency_problems_option(),
+        shed_install_option()
     )
 
 
@@ -1203,6 +1215,7 @@ def engine_options():
         docker_galaxy_image_option(),
         docker_extra_volume_option(),
         ignore_dependency_problems_option(),
+        shed_install_option(),
         galaxy_url_option(),
         galaxy_admin_key_option(),
         galaxy_user_key_option(),


### PR DESCRIPTION
@bgruening's original advice was to base this on whether ``--galaxy_admin_key`` was an actual admin key or not and just disable this functionality if not. My issue with this is that Planemo assumes a default admin key (that works with ``planemo serve`` defaults), so if the admin key is wrong and required I think it should be a hard failure not a silent behavior change. To put this another way, Planemo is tool development SDK, the correct assumption is that the target Galaxy is something it can just install tools into without worry - if that is not a correct assumption you need to change the behavior of Planemo and to do that the ``--no_shed_install`` flag makes a lot of sense I think.

I understand the critique that there are too many commands with too many options, and I have done things to make the default behaviors better (for instance none of the --conda_*** flags really need to be used for typical runs now). Rather than restricting functionality or making too clever assumptions I prefer the to go the route of documentation that focused on the actual commands to run and the relevant options for that use case. Therefore I've updated the documentation related to external Galaxy testing - and that doesn't cover twenty options - it covers only three - the most important three for external Galaxy testing including this new one.