### PR TITLE
 add filetype support to the workflow-job.yml test script

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -193,7 +193,7 @@ def stage_in(ctx, runnable, config, user_gi, history_id, job_path, **kwds):
             file_path = upload_target.path
             upload_payload = user_gi.tools._upload_payload(
                 history_id,
-                file_type= upload_target.properties.get('filetype', None) or "auto",
+                file_type=upload_target.properties.get('filetype', None) or "auto",
             )
             name = os.path.basename(file_path)
             upload_payload["inputs"]["files_0|auto_decompress"] = False

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -193,7 +193,7 @@ def stage_in(ctx, runnable, config, user_gi, history_id, job_path, **kwds):
             file_path = upload_target.path
             upload_payload = user_gi.tools._upload_payload(
                 history_id,
-                file_type="auto",
+                file_type= upload_target.properties.get('filetype', None) or "auto",
             )
             name = os.path.basename(file_path)
             upload_payload["inputs"]["files_0|auto_decompress"] = False


### PR DESCRIPTION
needs https://github.com/galaxyproject/galaxy-lib/pull/119

This will support file like this:
```
trainset_taxonomy:
    class: File
    location: https://zenodo.org/record/815875/files/trainset16_022016.pds.tax
    filetype: mothur.seq.taxonomy
```