### PR TITLE
Better support for different versions of Galaxy.

### DIFF
--- a/planemo/cli.py
+++ b/planemo/cli.py
@@ -2,10 +2,12 @@
 import functools
 import logging.config
 import os
+import shutil
 import sys
 import traceback
 
 import click
+from six.moves.urllib.request import urlopen
 
 from planemo import __version__
 from planemo.exit_codes import ExitCodeException
@@ -111,6 +113,21 @@ class Context(object):
         """Exit planemo with the supplied exit code."""
         self.vlog("Exiting planemo with exit code [%d]" % exit_code)
         raise ExitCodeException(exit_code)
+
+    def cache_download(self, url, destination):
+        cache = os.path.join(self.workspace, "cache")
+        if not os.path.exists(cache):
+            os.makedirs(cache)
+        filename = os.path.basename(url)
+        cache_destination = os.path.join(cache, filename)
+        if not os.path.exists(cache_destination):
+            content = urlopen(url).read()
+            if len(content) == 0:
+                raise Exception("Failed to download [%s]." % url)
+            with open(cache_destination, "wb") as f:
+                f.write(content)
+
+        shutil.copy(cache_destination, destination)
 
 
 pass_context = click.make_pass_decorator(Context, ensure=True)

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -59,14 +59,14 @@ def create_profile(ctx, profile_name, **kwds):
 
     os.makedirs(profile_directory)
     create_for_engine = _create_profile_docker if engine_type == "docker_galaxy" else _create_profile_local
-    stored_profile_options = create_for_engine(profile_directory, profile_name, kwds)
+    stored_profile_options = create_for_engine(ctx, profile_directory, profile_name, kwds)
 
     profile_options_path = _stored_profile_options_path(profile_directory)
     with open(profile_options_path, "w") as f:
         json.dump(stored_profile_options, f)
 
 
-def _create_profile_docker(profile_directory, profile_name, kwds):
+def _create_profile_docker(ctx, profile_directory, profile_name, kwds):
     export_directory = os.path.join(profile_directory, "export")
     os.makedirs(export_directory)
     return {
@@ -74,7 +74,7 @@ def _create_profile_docker(profile_directory, profile_name, kwds):
     }
 
 
-def _create_profile_local(profile_directory, profile_name, kwds):
+def _create_profile_local(ctx, profile_directory, profile_name, kwds):
     database_type = kwds.get("database_type", "auto")
     if database_type == "auto":
         if which("psql"):
@@ -93,7 +93,7 @@ def _create_profile_local(profile_directory, profile_name, kwds):
         database_connection = database_source.sqlalchemy_url(database_identifier)
     else:
         database_location = os.path.join(profile_directory, "galaxy.sqlite")
-        attempt_database_preseed(None, database_location, **kwds)
+        attempt_database_preseed(ctx, None, database_location, **kwds)
         database_connection = DATABASE_LOCATION_TEMPLATE % database_location
 
     return {

--- a/planemo/galaxy/run.py
+++ b/planemo/galaxy/run.py
@@ -53,7 +53,10 @@ def setup_venv(ctx, kwds):
 def locate_galaxy_virtualenv(ctx, kwds):
     if not kwds.get("no_cache_galaxy", False):
         workspace = ctx.workspace
+        galaxy_branch = kwds.get("galaxy_branch", "master")
         shared_venv_path = os.path.join(workspace, "gx_venv")
+        if galaxy_branch != "master":
+            shared_venv_path = "%s_%s" % (shared_venv_path, galaxy_branch)
         venv_command = CACHED_VIRTUAL_ENV_COMMAND % shared_venv_path
     else:
         venv_command = UNCACHED_VIRTUAL_ENV_COMMAND


### PR DESCRIPTION
- Do a better job grabbing the right DB version for the right Galaxy.
- Cache db versions in ~/.planemo.yml so they don't have to be refetched after the first time.
- If targetting non-master branches of Galaxy, create a virtualenv for that branch. This way you don't have repeatedly redownload all different dependencies when switching between Galaxy versions. Also would prevent bugs that may occur when having extra libraries installed for Galaxy - like the uwsgi problems from the past. (Fixes https://github.com/galaxyproject/planemo/issues/721).