### PR TITLE
Pass the tool file name when linting so that errors can reference it

### DIFF
--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -109,11 +109,11 @@ def is_doi(publication_id, lint_ctx):
 
 def lint_xsd(lint_ctx, schema_path, path):
     """Lint XML at specified path with supplied schema."""
-    name = os.path.basename(path)
+    name = lint_ctx.object_name or os.path.basename(path)
     validator = validation.get_validator(require=True)
     validation_result = validator.validate(schema_path, path)
     if not validation_result.passed:
-        msg = "Invalid %s found. Errors [%s]"
+        msg = "Invalid XML found in file: %s. Errors [%s]"
         msg = msg % (name, validation_result.output)
         lint_ctx.error(msg)
     else:

--- a/planemo/tool_lint.py
+++ b/planemo/tool_lint.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from os.path import basename
+
 from galaxy.tools.lint import lint_tool_source
 
 from planemo.exit_codes import (
@@ -28,7 +30,7 @@ def lint_tools_on_path(ctx, paths, lint_args, **kwds):
             exit_codes.append(EXIT_CODE_GENERIC_FAILURE)
             continue
         info("Linting tool %s" % tool_path)
-        if not lint_tool_source(tool_xml, **lint_args):
+        if not lint_tool_source(tool_xml, name=basename(tool_path), **lint_args):
             error("Failed linting")
             exit_codes.append(EXIT_CODE_GENERIC_FAILURE)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ virtualenv
 lxml
 gxformat2>=0.2.0
 ephemeris>=0.8
-galaxy-lib>=18.5.13
+galaxy-lib>=18.5.14
 html5lib>=0.9999999,!=0.99999999,!=0.999999999,!=1.0b10,!=1.0b09
 cwltool==1.0.20180508202931


### PR DESCRIPTION
Before:

```
Applying linter tool_xsd... FAIL
.. ERROR: Invalid tmpfNqQF8 found. Errors [/var/folders/ct/z_jrb3314w73ktpxwg_bwx_c0000gn/T/tmpfNqQF8:4:0:ERROR:SCHEMASV:SCHEMAV_CVC_COMPLEX_TYPE_4: Element 'requirement': The attribute 'type' is required but missing.]
```

After:

```
Applying linter tool_xsd... FAIL
.. ERROR: Invalid XML found in file: pear.xml. Errors [/var/folders/ct/z_jrb3314w73ktpxwg_bwx_c0000gn/T/tmpMBoCs8:4:0:ERROR:SCHEMASV:SCHEMAV_CVC_COMPLEX_TYPE_4: Element 'requirement': The attribute 'type' is required but missing.]
```

Requires the changes in galaxyproject/galaxy-lib#121 so tests will fail until there's a new galaxy-lib release with those changes.