### PR TITLE
Allow naming history from command line

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -28,6 +28,10 @@ from planemo.runnable import (
          "previously.",
     default=False,
 )
+@click.option(
+    "--history_name",
+    help="Name for history (if a history is generated as part of testing.)"
+)
 @options.galaxy_target_options()
 @options.galaxy_config_options()
 @options.test_options()


### PR DESCRIPTION
For testing of workflows specifically. Allows overriding the default "CWL Target History".

Rationale: EU is testing workflows and I considered to automatically make the history publicly available (especially in case of failure), and having these named something more distinct/appropriate would make life easier.