### PR TITLE
Sync galaxy.xsd from galaxy repo

### DIFF
--- a/planemo/xml/xsd/tool/galaxy.xsd
+++ b/planemo/xml/xsd/tool/galaxy.xsd
@@ -248,12 +248,12 @@ complete descriptions of the runtime of a tool.
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 
-This tag set is contained within the ``requirements`` tag set. Third party
+This tag set is contained within the ``<requirements>`` tag set. Third party
 programs or modules that the tool depends upon are included in this tag set.
 
 When a tool runs, Galaxy attempts to *resolve* these requirements (also called
 dependencies). ``requirement``s are meant to be abstract and resolvable by
-multiple different systems (e.g. [conda](http://conda.pydata.org/docs/), the
+multiple different systems (e.g. [conda](https://conda.io/), the
 [Galaxy Tool Shed dependency management system](https://galaxyproject.org/toolshed/tool-features/#Automatic_third-party_tool_dependency_installation_and_compilation_with_installed_repositories),
 or [environment modules](http://modules.sourceforge.net/)).
 
@@ -297,12 +297,12 @@ resolver.
       <xs:extension base="xs:string">
         <xs:attribute name="type" type="RequirementType" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> This value defines the which type of the 3rd party module required by this tool. </xs:documentation>
+            <xs:documentation xml:lang="en">This value defines the type of the 3rd party module required by this tool.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="version" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> For package type requirements this value defines a specific version of the tool dependency. </xs:documentation>
+            <xs:documentation xml:lang="en">For requirements of type ``package`` this value defines a specific version of the tool dependency.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -311,7 +311,6 @@ resolver.
   <xs:complexType name="Container">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
-
 This tag set is contained within the 'requirements' tag set. Galaxy can be
 configured to run tools within [Docker](https://www.docker.com/) containers -
 this tag allows the tool to suggest possible valid Docker containers for this
@@ -319,14 +318,13 @@ tool.
 
 Read more about configuring Galaxy to run Docker jobs
 [here](https://galaxyproject.org/admin/tools/docker/).
-
 ]]></xs:documentation>
     </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="type" type="ContainerType" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> This value describes the type of container that the tool may be executed in and currently must be ``docker``. </xs:documentation>
+            <xs:documentation xml:lang="en">This value describes the type of container that the tool may be executed in and currently must be ``docker``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -371,7 +369,7 @@ Read more about configuring Galaxy to run Docker jobs
   <xs:complexType name="Code">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
-**Deprecated** Do not use this unless absolutely necessary.
+*Deprecated*. Do not use this unless absolutely necessary.
 
 The extensions described here can cause problems using your tool with certain components
 of Galaxy (like the workflow system). It is highly recommended to avoid these constructs
@@ -549,7 +547,7 @@ The content of ``stdout`` and ``stderr`` are strings containing the output of th
   </xs:complexType>
   <xs:complexType name="CodeHook">
     <xs:annotation>
-      <xs:documentation xml:lang="en">**Deprecated** Map a hook to a function defined in the code file.</xs:documentation>
+      <xs:documentation xml:lang="en">*Deprecated*. Map a hook to a function defined in the code file.</xs:documentation>
     </xs:annotation>
     <xs:attribute name="exec_after_process" type="xs:string">
       <xs:annotation>
@@ -572,9 +570,9 @@ The content of ``stdout`` and ``stderr`` are strings containing the output of th
     <xs:annotation>
       <xs:documentation xml:lang="en">This directive is used to specify some rarely modified options.</xs:documentation>
     </xs:annotation>
-    <xs:attribute name="refresh" type="PermissiveBoolean">
+    <xs:attribute name="refresh" type="PermissiveBoolean" gxdocs:deprecated="true">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Deprecated, likely unused attribute.</xs:documentation>
+        <xs:documentation xml:lang="en">*Deprecated*. Unused attribute.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="sanitize" type="PermissiveBoolean" default="true">
@@ -613,8 +611,8 @@ The content of ``stdout`` and ``stderr`` are strings containing the output of th
     <xs:annotation gxdocs:best_practices="tests">
       <xs:documentation xml:lang="en"><![CDATA[
 
-Container tag set to specify tests via the <test> tag sets. Any number of tests can be included,
-and each test is wrapped within separate <test> tag sets. Functional tests are
+Container tag set to specify tests via the ``<test>`` tag sets. Any number of tests can be included,
+and each test is wrapped within separate ``<test>`` tag sets. Functional tests are
 executed via [Planemo](https://planemo.readthedocs.io/) or the
 [run_tests.sh](https://github.com/galaxyproject/galaxy/blob/dev/run_tests.sh)
 shell script distributed with Galaxy.
@@ -1340,6 +1338,11 @@ The functional test tool
 provides a demonstration of using this tag.
 
 ```xml
+<outputs>
+    <data format="tabular" name="sample">
+      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" ext="tabular" visible="true" assign_primary_output="true" />
+    </data>
+</outputs>
 <test>
   <param name="num_param" value="7" />
   <param name="input" ftype="txt" value="simple_line.txt"/>
@@ -1358,6 +1361,7 @@ provides a demonstration of using this tag.
 </test>
 ```
 
+Note that this tool uses ``assign_primary_output="true"`` for ``<discover_data_sets>``. Hence, the content of the first discovered dataset (which is the first in the alphabetically sorted list of discovered designations) is checked directly in the ``<output>`` tag of the test.
 ]]></xs:documentation>
     </xs:annotation>
     <xs:complexContent>
@@ -1750,7 +1754,7 @@ managed by the Galaxy admins (for instance via
 [data managers](https://galaxyproject.org/admin/tools/data-managers/)
 ) and
 history files. A good example tool that demonstrates this is
-the [Bowtie 2](https://github.com/galaxyproject/tools-devteam/blob/master/tools/bowtie2/bowtie2_wrapper.xml) wrapper.
+the [Bowtie 2](https://github.com/galaxyproject/tools-iuc/blob/master/tools/bowtie2/bowtie2_wrapper.xml) wrapper.
 
 ```xml
 <conditional name="reference_genome">
@@ -1870,7 +1874,7 @@ This part is contained in the ``<inputs>`` tag set.
 This Cheetah code can be used in the ``<command>`` tag set or the
 ``<configfile>`` tag set.
 
-```xml
+```
 #for $i, $s in enumerate($series)
     rank_of_series=$i
     input_path='${s.input}'
@@ -1901,7 +1905,7 @@ This is an example test case with multiple repeat elements for the example above
 
 See the documentation on the [repeat test directive](#tool-tests-test-repeat).
 
-An older way to specify repeats in a test is by instances that are created by referring to names with a special format: "<repeat name>_<repeat index>|<param name>"
+An older way to specify repeats in a test is by instances that are created by referring to names with a special format: ``<repeat name>_<repeat index>|<param name>``
 
 ```xml
 <test>
@@ -1932,22 +1936,22 @@ demonstrates both testing strategies.
         </xs:attribute>
         <xs:attribute name="title" type="xs:string" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> The title of the repeat section, which will be displayed on the tool form. </xs:documentation>
+            <xs:documentation xml:lang="en">The title of the repeat section, which will be displayed on the tool form.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="min" type="xs:integer">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> The minimum number of repeat units. </xs:documentation>
+            <xs:documentation xml:lang="en">The minimum number of repeat units.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="max" type="xs:integer">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> The maximum number of repeat units. </xs:documentation>
+            <xs:documentation xml:lang="en">The maximum number of repeat units.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="default" type="xs:integer" default="1">
           <xs:annotation>
-            <xs:documentation xml:lang="en"> The default number of repeat units. </xs:documentation>
+            <xs:documentation xml:lang="en">The default number of repeat units.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="help" type="xs:string">
@@ -2077,7 +2081,7 @@ These parameters represent whole number and real numbers, respectively.
 
 ##### Example
 
-```
+```xml
 <param name="region_size" size="4" type="integer" value="1" label="flanking regions of size" />
 ```
 
@@ -2092,6 +2096,11 @@ $attribute_list:checked,truevalue,falsevalue:5
 #### ``data``
 
 A dataset from the current history. Multiple types might be used for the param form.
+
+#### ``group_tag``
+
+$attribute_list:multiple,date_ref:5
+
 
 ##### Examples
 
@@ -2298,7 +2307,7 @@ parameter.</xs:documentation>
         </xs:attribute>
         <xs:attribute name="default_value" type="xs:string" gxdocs:deprecated="true">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Deprecated way to specify default value for column parameters (use ``value`` instead).</xs:documentation>
+            <xs:documentation xml:lang="en">*Deprecated*. Specify default value for column parameters (use ``value`` instead).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="optional" type="xs:string" default="false">
@@ -2350,10 +2359,10 @@ as a comma separated list.
           <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
 
-Only valid if ``type`` attribute value is ``select`` or ``data_column``. Used
-with select lists whose options are dynamically generated based on certain
-metadata attributes of the dataset upon which this parameter depends (usually
-but not always the tool's input dataset).
+Only valid if ``type`` attribute value is ``select``, ``data_column``, or
+``group_tag``. Used with select lists whose options are dynamically generated
+based on certain metadata attributes of the dataset or collection upon which
+this parameter depends (usually but not always the tool's input dataset).
 
             ]]></xs:documentation>
           </xs:annotation>
@@ -2370,7 +2379,7 @@ but not always the tool's input dataset).
         </xs:attribute>
         <xs:attribute name="force_select" type="PermissiveBoolean" gxdocs:deprecated="true">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Used only if the ``type`` attribute
+            <xs:documentation xml:lang="en">*Deprecated*. Used only if the ``type`` attribute
 value is ``data_column``, this is deprecated and the inverse of ``optional``.
 Set to ``false`` to not force user to select an option in the list.</xs:documentation>
           </xs:annotation>
@@ -2503,6 +2512,7 @@ allow access to Python code to generate options for a select list. See
       <xs:enumeration value="file"/>
       <xs:enumeration value="data"/>
       <xs:enumeration value="drill_down"/>
+      <xs:enumeration value="group_tag"/>
       <xs:enumeration value="data_collection"/>
     </xs:restriction>
   </xs:simpleType>
@@ -2525,7 +2535,9 @@ to the interpreter specified in the corresponding attribute (if any).
 The following uses a compiled executable ([bedtools](https://bedtools.readthedocs.io/en/latest/)).
 
 ```xml
-<command>bed12ToBed6 -i '$input' > '$output'</command>
+<command><![CDATA[
+bed12ToBed6 -i '$input' > '$output'
+]]]]><![CDATA[></command>
 ```
 
 A few things to note about even this simple example:
@@ -2547,26 +2559,26 @@ tool.
 ```xml
 <command><![CDATA[
 bedtools annotate
-        -i "${inputA}"
-        #if $names.names_select == 'yes':
-            -files
-            #for $bed in $names.beds:
-                '${bed.input}'
-            #end for
-            -names
-            #for $bed in $names.beds:
-                '${bed.inputName}'
-            #end for
-        #else:
-            #set files = '" "'.join([str($file) for $file in $names.beds])
-            -files '${files}'
-            #set names = '" "'.join([str($name.display_name) for $name in $names.beds])
-            -names '${names}'
-        #end if
-        $strand
-        $counts
-        $both
-        > "${output}"
+-i '${inputA}'
+#if $names.names_select == 'yes':
+    -files
+    #for $bed in $names.beds:
+        '${bed.input}'
+    #end for
+    -names
+    #for $bed in $names.beds:
+        '${bed.inputName}'
+    #end for
+#else:
+    #set files = '" "'.join([str($file) for $file in $names.beds])
+    -files '${files}'
+    #set names = '" "'.join([str($name.display_name) for $name in $names.beds])
+    -names '${names}'
+#end if
+$strand
+$counts
+$both
+> '${output}'
 ]]]]><![CDATA[></command>
 ```
 
@@ -2663,15 +2675,13 @@ Name | Description
 See the [Planemo docs](https://planemo.readthedocs.io/en/latest/writing_advanced.html#cluster-usage)
 on the topic of ``GALAXY_SLOTS`` for more information and examples.
 
-### Attributes
+### Error detection
 
-#### ``detect_errors``
+The ``detect_errors`` attribute of ``command``, if present, can be one of:
 
-If present on the ``command`` tag, this attribute can be one of:
-
-* ``default`` no-op fallback to ``stdio`` tags and erroring on standard error output (for legacy tools).
-* ``exit_code`` error if tool exit code is not 0. (The @jmchilton recommendation).
-* ``aggressive`` error if tool exit code is not 0 or ``Exception:``, ``Error:``, or
+* ``default``: no-op fallback to ``stdio`` tags and erroring on standard error output (for legacy tools).
+* ``exit_code``: error if tool exit code is not 0. (The @jmchilton recommendation).
+* ``aggressive``: error if tool exit code is not 0 or ``Exception:``, ``Error:``, or
   various messages related to being out of memory appear in the standard error or output.
   (The @bgruening recommendation).
 
@@ -2681,46 +2691,33 @@ produces any standard error output).
 
 See [pull request 117](https://github.com/galaxyproject/galaxy/pull/117) for more implementation
 information and discussion on the ``detect_errors`` attribute.
-
-#### ``strict``
-
-This boolean forces the ``#set -e`` directive on in shell scripts - so that in a
-multi-part command if any part fails the job exits with a non-zero exit code.
-This is enabled by default for tools with ``profile>=16.04`` and disabled on
-legacy tools.
-
-#### ``interpreter``
-
-Older tools may define an ``intepreter`` attribute on the command, but this is
-deprecated and using the ``$__tool_directory__`` variable is superior.
-
 ]]></xs:documentation>
     </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="detect_errors" type="xs:string">
           <xs:annotation>
-            <xs:documentation></xs:documentation>
+            <xs:documentation>One of ``default``, ``exit_code``, ``aggressive``. See "Error detection" above for details.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="oom_exit_code" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Only used if ``detect_errors="exit_code", tells Galaxy the specified exit code indicates an out of memory error. Galaxy instances may be configured to retry such jobs on resources with more memory.</xs:documentation>
+            <xs:documentation>Only used if ``detect_errors="exit_code"``, tells Galaxy the specified exit code indicates an out of memory error. Galaxy instances may be configured to retry such jobs on resources with more memory.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="use_shared_home" type="xs:string">
           <xs:annotation>
-            <xs:documentation>When running a job for this tool, do not isolate its $HOME directory within the job's directory - use either the shared_home_dir setting in Galaxy or the default $HOME specified in the job's default environment.</xs:documentation>
+            <xs:documentation>When running a job for this tool, do not isolate its ``$HOME`` directory within the job's directory - use either the ``shared_home_dir`` setting in Galaxy or the default ``$HOME`` specified in the job's default environment.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="interpreter" type="xs:string" gxdocs:deprecated="true">
           <xs:annotation>
-            <xs:documentation xml:lang="en">This attribute defines the programming language in which the tool's executable file is written. Any language can be used (tools can be written in Python, C, Perl, Java, etc.). The executable file must be in the same directory of the XML file. If instead this attribute is not specified, the tag content should be a Bash command calling executable(s) available in the $PATH. </xs:documentation>
+            <xs:documentation xml:lang="en"><![CDATA[*Deprecated*. This will prefix the command with the value of this attribute (e.g. ``python`` or ``perl``) and the tool directory, in order to run an executable file shipped with the tool. It is recommended to instead use ``<interpreter> '$__tool_directory__/<executable_name>'`` in the tag content. If this attribute is not specified, the tag should contain a Bash command calling executable(s) available in the ``$PATH``, as modified after loading the requirements.]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="strict" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en"></xs:documentation>
+            <xs:documentation xml:lang="en">This boolean forces the ``#set -e`` directive on in shell scripts - so that in a multi-part command if any part fails the job exits with a non-zero exit code. This is enabled by default for tools with ``profile>=16.04`` and disabled on legacy tools.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -3061,7 +3058,7 @@ target file.</xs:documentation>
 See the
 [annotation_profiler](https://github.com/galaxyproject/tools-devteam/blob/master/tools/annotation_profiler/annotation_profiler.xml)
 tool for an example of how to use this tag set. This tag set is contained within
-the <param> tag set - it applies a validator to the containing parameter.
+the ``<param>`` tag set - it applies a validator to the containing parameter.
 
 ### Examples
 
@@ -3130,7 +3127,7 @@ Valid values include: ``expression``, ``regex``, ``in_range``, ``length``,
         <xs:attribute name="message" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">
-The error message displayed on the tool form if validation fails. </xs:documentation>
+The error message displayed on the tool form if validation fails.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="check" type="xs:string">
@@ -3232,7 +3229,7 @@ contained within the ``<param>`` tag set - it contains a set of ``<valid>`` and
 ### Character presets
 
 The following presets can be used when specifying the valid characters: the
-[constants from the ``string`` Python3 module](https://docs.python.org/3/library/string.html#string-constants),
+[constants](https://docs.python.org/3/library/string.html#string-constants) from the ``string`` Python3 module,
 plus ``default`` (equal to ``string.ascii_letters + string.digits + " -=_.()/+*^,:?!"``)
 and ``none`` (empty set).
 The ``string.letters``, ``string.lowercase`` and ``string.uppercase`` Python2
@@ -3247,10 +3244,12 @@ of the default ``X``, so invalid characters are effectively dropped instead of
 replaced with ``X``) and indicates that the only valid characters for this input
 are ASCII letters, digits, and ``_``.
 
-```
+```xml
 <param name="mystring" type="text" label="Say something interesting">
     <sanitizer invalid_char="">
-        <valid initial="string.ascii_letters,string.digits"><add value="_" /> </valid>
+        <valid initial="string.ascii_letters,string.digits">
+            <add value="_" />
+        </valid>
     </sanitizer>
 </param>
 ```
@@ -3258,13 +3257,13 @@ are ASCII letters, digits, and ``_``.
 This example allows many more valid characters and specifies that ``&`` will just
 be dropped from the input.
 
-```
+```xml
 <sanitizer>
     <valid initial="string.printable">
-        <remove value="&apos;"/>
+        <remove value="&amp;"/>
     </valid>
     <mapping initial="none">
-        <add source="&apos;" target=""/>
+        <add source="&amp;" target=""/>
     </mapping>
 </sanitizer>
 ```
@@ -3317,7 +3316,8 @@ valid input for the mapping to occur.</xs:documentation>
     </xs:annotation>
     <xs:attribute name="preset" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Add the characters contained in the specified character preset (as defined above) to the list of valid characters.</xs:documentation>
+        <xs:documentation xml:lang="en">Add the characters contained in the specified character preset (as defined above) to the list of valid characters. The default
+is the ``none`` preset.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="value" type="xs:string">
@@ -3330,12 +3330,12 @@ valid input for the mapping to occur.</xs:documentation>
     <xs:annotation>
       <xs:documentation xml:lang="en">This directive is used to remove
 individual characters or preset lists of characters.
-Character must not be allowed as a valid input for the mapping to occur.
-Preset lists include default and none as well as those available from string.* (e.g. ``string.printable``).</xs:documentation>
+Character must not be allowed as a valid input for the mapping to occur.</xs:documentation>
     </xs:annotation>
     <xs:attribute name="preset" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Remove the characters contained in the specified character preset (as defined above) from the list of valid characters.</xs:documentation>
+        <xs:documentation xml:lang="en">Remove the characters contained in the specified character preset (as defined above) from the list of valid characters. The default
+is the ``none`` preset.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="value" type="xs:string">
@@ -3352,7 +3352,7 @@ Preset lists include default and none as well as those available from string.* (
   </xs:group>
   <xs:complexType name="SanitizerMapping">
     <xs:annotation>
-      <xs:documentation xml:lang="en"><![CDATA[Contained within the <sanitizer> tag set. Used to specify a mapping of disallowed character to replacement string. Contains <add> and <remove> tags.]]></xs:documentation>
+      <xs:documentation xml:lang="en"><![CDATA[Contained within the ``<sanitizer>`` tag set. Used to specify a mapping of disallowed character to replacement string. Contains ``<add>`` and ``<remove>`` tags.]]></xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:group ref="SanitizerMappingElement" minOccurs="0" maxOccurs="unbounded"/>
@@ -3604,24 +3604,24 @@ the ``<inputs>`` documentation.
     <xs:attribute name="provided_metadata_style" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-          Style used for tool provided metadata file (i.e.
-          [galaxy.json](http://planemo.readthedocs.io/en/latest/writing_advanced.html#tool-provided-metadata))
-          - this can be either "legacy" or "default". The default of tools with
-          a profile of 17.09 or newer are "default", and "legacy" for older and
-          tools and tools without a specified profile. A discussion of the
-          differences between the styles can be found at
-          https://github.com/galaxyproject/galaxy/pull/4437.
+Style used for tool provided metadata file (i.e.
+[galaxy.json](https://planemo.readthedocs.io/en/latest/writing_advanced.html#tool-provided-metadata))
+- this can be either "legacy" or "default". The default of tools with a profile
+of 17.09 or newer are "default", and "legacy" for older and tools and tools
+without a specified profile. A discussion of the differences between the styles
+can be found at https://github.com/galaxyproject/galaxy/pull/4437 .
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="provided_metadata_file" type="xs:string" default="galaxy.json">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-          Path relative to tool's working directory to load tool provided
-          metadata from. This metadata can describe dynamic datasets to load,
-          dynamic collection contents, as well as simple metadata (e.g. name, dbkey, etc...) and datatype specific metadata for declared outputs.
-          More information can be found [here](http://planemo.readthedocs.io/en/latest/writing_advanced.html#tool-provided-metadata). The
-          default is galaxy.json.
+Path relative to tool's working directory to load tool provided metadata from.
+This metadata can describe dynamic datasets to load, dynamic collection
+contents, as well as simple metadata (e.g. name, dbkey, etc...) and
+datatype-specific metadata for declared outputs. More information can be found
+[here](https://planemo.readthedocs.io/en/latest/writing_advanced.html#tool-provided-metadata).
+The default is ``galaxy.json``.
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
@@ -3648,7 +3648,7 @@ This tag set is contained within the ``<outputs>`` tag set, and it defines the
 output data description for the files resulting from the tool's execution. The
 value of the attribute ``label`` can be acquired from input parameters or metadata
 in the same way that the command line parameters are (discussed in the
-<command> tag set section above).
+``<command>`` tag set section above).
 
 ### Examples
 
@@ -3762,7 +3762,7 @@ The valid values for format can be found in
     <xs:attribute name="default_identifier_source" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Sets the source of element identifier to the specified input.
-This only applies to collections that are mapped over a non-collection input and that have equivalent structures.</xs:documentation>
+This only applies to collections that are mapped over a non-collection input and that have equivalent structures. If this references input elements in conditionals, this value should be qualified (e.g. ``cond|input`` instead of ``input`` if ``input`` is in a conditional with ``name="cond"``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="metadata_source" type="xs:string">
@@ -3818,7 +3818,7 @@ metadata in the same way that the command line parameters are (discussed in the
 [command](#tool-command) directive).
 
 Creating collections in tools is covered in-depth in
-[planemo's documentation](https://planemo.readthedocs.io/en/latest/writing_advanced.html#creating-collections).
+[Planemo's documentation](https://planemo.readthedocs.io/en/latest/writing_advanced.html#creating-collections).
 
 ]]></xs:documentation>
     </xs:annotation>
@@ -3867,7 +3867,9 @@ derive collection's type (e.g. ``collection_type``) from.</xs:documentation>
         <xs:documentation xml:lang="en">This is the name of input collection or
 dataset to derive "structure" of the output from (output element count and
 identifiers). For instance, if the referenced input has three ordered items with
-identifiers ``sample1``, ``sample2``,  and ``sample3``</xs:documentation>
+identifiers ``sample1``, ``sample2``,  and ``sample3``. If this references input
+elements in conditionals, this value should be qualified (e.g. ``cond|input`` instead
+of ``input`` if ``input`` is in a conditional with ``name="cond"``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="inherit_format" type="xs:boolean">
@@ -3900,12 +3902,12 @@ conditionals are accessed using a hash named after the conditional.
           <option selected="true" value="defaults">Use default options</option>
           <option value="advanced">Use advanced options</option>
         </param>
-        <when value="defaults"> </when>
+        <when value="defaults" />
         <when value="advanced">
           <param name="vcf_output" type="boolean" checked="false" label="VCF output"
             truevalue="--vcf" falsevalue="" />
         </when>
-      <conditional>
+      </conditional>
     </inputs>
     <outputs>
       <data format="txt" label="Alignment report on ${on_string}" name="output_txt" />
@@ -4046,7 +4048,7 @@ The ``<actions>`` in the Bowtie 2 wrapper is used in lieu of the deprecated
 ``<code>`` tag to set the ``dbkey`` of the output dataset. In
 [bowtie2_wrapper.xml](https://github.com/galaxyproject/tools-devteam/blob/master/tools/bowtie2/bowtie2_wrapper.xml)
 (see below), according to the first action block, if the
-```reference_genome.source`` is ``indexed`` (not ``history``), then it will assign
+``reference_genome.source`` is ``indexed`` (not ``history``), then it will assign
 the ``dbkey`` of the output file to be the same as that of the reference file. It
 does this by looking at through the data table and finding the entry that has the
 value that's been selected in the index dropdown box as column 1 of the loc file
@@ -4163,7 +4165,7 @@ In addition to demonstrating this lower-level direct access of .loc files, it
 demonstrates an unconditional action. The second block would not be needed for
 most cases - it was required in this tool to handle the specific case of a small
 reference file used for functional testing. It says that if the dbkey has been
-set to ``equCab2chrM`` (which is what the ```<filter type="metadata_value"...
+set to ``equCab2chrM`` (which is what the ``<filter type="metadata_value"...
 column="1" />`` tag does), then it should be changed to ``equCab2`` (which is the
 ``<option type="from_param" ... column="0" ...>`` tag does).
 
@@ -4545,8 +4547,8 @@ the path to the file created with this directive.</xs:documentation>
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 
-This tag set is contained within the <configfiles> tag set. It tells Galaxy to
-write out a JSON representation of the tool parameters .
+This tag set is contained within the ``<configfiles>`` tag set. It tells Galaxy to
+write out a JSON representation of the tool parameters.
 
 *Example*
 
@@ -4570,6 +4572,9 @@ the specified name (i.e. ``inputs.json``).
 
 A contrived example of a tool that uses this is the test tool
 [inputs_as_json.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/inputs_as_json.xml).
+
+By default this file will not contain paths for data or collection inputs. To include simple
+paths for data parameters set the ``data_style`` attribute to ``paths`` (see [inputs_as_json_with_paths.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/inputs_as_json_with_paths.xml) for an example).
 ]]></xs:documentation>
     </xs:annotation>
     <xs:simpleContent>
@@ -4585,6 +4590,11 @@ response to this directive.
         <xs:attribute name="filename" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Path relative to the working directory of the tool for the inputs JSON file created in response to this directive.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="data_style" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Set to 'paths' to include dataset paths in the resulting file.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -4630,7 +4640,7 @@ Examples are included in the test tools directory including:
       <xs:extension base="xs:string">
         <xs:attribute name="interpreter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en"><![CDATA[*Deprecated*: Prefix the version command with an interpreter and the tool directory in order to execute a script shipped with the tool. It is better to just use ``<interpreter> '$__tool_directory__/<script_name>'``.]]></xs:documentation>
+            <xs:documentation xml:lang="en"><![CDATA[*Deprecated*. This will prefix the version command with the value of this attribute (e.g. ``python`` or ``perl``) and the tool directory, in order to to run an executable file shipped with the tool. It is recommended to instead use ``<interpreter> '$__tool_directory__/<executable_name>'`` in the tag content. If this attribute is not specified, the tag should contain a Bash command calling executable(s) available in the ``$PATH``, as modified after loading the requirements.]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -4809,7 +4819,7 @@ The target value (e.g. for setting data format: the list of supported data forma
 Legacy tools (ones with ``profile`` unspecified or a ``profile`` of less than
 16.04) will default to checking stderr for errors as described above. Newer
 tools will instead treat an exit code other than 0 as an error. The
-``detect_error`` on ``command`` can swap between these behaviors but the
+``detect_errors`` on ``command`` can swap between these behaviors but the
 ``stdio`` directive allows more options in defining error conditions (though
 these aren't always intuitive).
 
@@ -4846,33 +4856,34 @@ checked.]]></xs:documentation>
   <xs:complexType name="ExitCode">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
-Tools may use exit codes to indicate specific execution errors. Many programs use 0 to indicate success and non-zero exit codes to indicate errors. Galaxy allows each tool to specify exit codes that indicate errors. Each <exit_code> tag defines a range of exit codes, and each range can be associated with a description of the error (e.g., "Out of Memory", "Invalid Sequence File") and an error level. The description just describes the condition and can be anything. The error level is either a warning or a fatal error. A warning means that stderr will be updated with the error's description. A fatal error means that the tool's execution will be marked as having an error and the workflow will stop. Note that, if the error level is not supplied, then a fatal error is assumed to have occurred.
+Tools may use exit codes to indicate specific execution errors. Many programs use 0 to indicate success and non-zero exit codes to indicate errors. Galaxy allows each tool to specify exit codes that indicate errors. Each ``<exit_code>`` tag defines a range of exit codes, and each range can be associated with a description of the error (e.g., "Out of Memory", "Invalid Sequence File") and an error level. The description just describes the condition and can be anything. The error level is either log, warning, fatal error, or fatal_oom. A warning means that stderr will be updated with the error's description. A fatal error means that the tool's execution will be marked as having an error and the workflow will stop. A fatal_oom indicates an out of memory condition and the job might be resubmitted if Galaxy is configured appropriately. Note that, if the error level is not supplied, then a fatal error is assumed to have occurred.
 
-The exit code's range can be any consecutive group of integers. More advanced ranges, such as noncontiguous ranges, are currently not supported. Ranges can be specified in the form "m:n", where m is the start integer and n is the end integer. If ":n" is specified, then the exit code will be compared against all integers less than or equal to n. If "m:" is used, then the exit code will be compared against all integers greater than or equal to m. If the exit code matches, then the error level is applied and the error's description is added to stderr. If a tool's exit code does not match any of the supplied <exit_code> tags' ranges, then no errors are applied to the tool's execution.
+The exit code's range can be any consecutive group of integers. More advanced ranges, such as noncontiguous ranges, are currently not supported. Ranges can be specified in the form "m:n", where m is the start integer and n is the end integer. If ":n" is specified, then the exit code will be compared against all integers less than or equal to n. If "m:" is used, then the exit code will be compared against all integers greater than or equal to m. If the exit code matches, then the error level is applied and the error's description is added to stderr. If a tool's exit code does not match any of the supplied ``<exit_code>`` tags' ranges, then no errors are applied to the tool's execution.
 
 Note that most Unix and Linux variants only support positive integers 0 to 255 for exit codes. If an exit code falls out of the range 0 to 255, the usual convention is to only use the lower 8 bits for the exit code. The only known exception is if a job is broken into subtasks using the tasks runner and one of those tasks is stopped with a POSIX signal. (Note that signals should be used as a last resort for terminating processes.) In those cases, the task will receive -1 times the signal number. For example, suppose that a job uses the tasks runner and 8 tasks are created for the job. If one of the tasks hangs, then a sysadmin may choose to send the "kill" signal, SIGKILL, to the process. In that case, the task (and its job) will exit with an exit code of -9. More on POSIX signals can be found at https://en.wikipedia.org/wiki/Unix_signal as well as man pages on "signal".
 
-The <exit_code> tag's supported attributes are as follows:
+The ``<exit_code>`` tag's supported attributes are as follows:
 
 * ``range``: This indicates the range of exit codes to check. The range can be one of the following:
   * ``n``: the exit code will only be compared to n;
   * ``[m:n]``: the exit code must be greater than or equal to m and less than or equal to n;
   * ``[m:]``: the exit code must be greater than or equal to m;
   * ``[:n]``: the exit code must be less than or equal to n.
-* ``level``: This indicates the error level of the exit code. The level can have one of two values:
-  * ``warning``: If an exit code falls in the given range, then a description of the error will be added to the beginning of stderr. A warning-level error will not cause the tool to fail.
-  * ``fatal``: If an exit code falls in the given range, then a description of the error will be added to the beginning of stderr. A fatal-level error will cause the tool to fail. If no level is specified, then the fatal error level will be assumed to have occurred.
+* ``level``: This indicates the error level of the exit code. If no level is specified, then the fatal error level will be assumed to have occurred. The level can have one of following values:
+  * ``log`` and ``warning``: If an exit code falls in the given range, then a description of the error will be added to the beginning of the source, prepended with either 'Log:' or 'Warning:'. A log-level/warning-level error will not cause the tool to fail.
+  * ``fatal``: If an exit code falls in the given range, then a description of the error will be added to the beginning of stderr. A fatal-level error will cause the tool to fail.
+  * ``fatal_oom``: If an exit code falls in the given range, then a description of the error will be added to the beginning of stderr. Depending on the job configuration, a fatal_oom-level error will cause the tool to be resubmitted or fail.
 * ``description``: This is an optional description of the error that corresponds to the exit code.
 
-The following is an example of the <exit_code> tag:
+The following is an example of the ``<exit_code>`` tag:
 
 ```xml
 <stdio>
     <exit_code range="3:5" level="warning" description="Low disk space" />
-    <exit_code range="6:"  level="fatal"   description="Bad input dataset" />
+    <exit_code range="6:" level="fatal" description="Bad input dataset" />
     <!-- Catching fatal_oom allows the job runner to potentially resubmit to a resource with more
          memory if Galaxy is configured to do this. -->
-    <exit_code range="2"   level="fatal_oom"   description="Out of Memory" />
+    <exit_code range="2" level="fatal_oom" description="Out of Memory" />
 </stdio>
 ```
 
@@ -4926,10 +4937,11 @@ A regular expression includes the following attributes:
   * ``stdout``: the regular expression will be applied to stdout;
   * ``stderr``: the regular expression will be applied to stderr;
   * ``both``: the regular expression will be applied to both stderr and stdout (which is the default case).
-* ``match``: This is the regular expression that will be used to match against stdout and/or stderr. If the <regex> tag does not contain the match attribute, then the <regex> tag will be ignored. The regular expression can be any valid Python regular expression. All regular expressions are performed case insensitively. For example, if match contains the regular expression "actg", then the regular expression will match against "actg", "ACTG", "AcTg", and so on. Also note that, if double quotes (") are to be used in the match attribute, then the value " can be used in place of double quotes. Likewise, if single quotes (') are to be used in the match attribute, then the value ' can be used if necessary.
-* ``level``: This works very similarly to the <exit_code> tag, except that, when a regular expression matches against its source, the description is added to the beginning of the source. For example, if stdout matches on a regular expression, then the regular expression's description is added to the beginning of stdout (instead of stderr). The level can be log, warning or fatal as described below.
+* ``match``: This is the regular expression that will be used to match against stdout and/or stderr. If the ``<regex>`` tag does not contain the match attribute, then the ``<regex>`` tag will be ignored. The regular expression can be any valid Python regular expression. All regular expressions are performed case insensitively. For example, if match contains the regular expression "actg", then the regular expression will match against "actg", "ACTG", "AcTg", and so on. Also note that, if double quotes (") are to be used in the match attribute, then the value " can be used in place of double quotes. Likewise, if single quotes (') are to be used in the match attribute, then the value ' can be used if necessary.
+* ``level``: This works very similarly to the ``<exit_code>`` tag, except that, when a regular expression matches against its source, the description is added to the beginning of the source. For example, if stdout matches on a regular expression, then the regular expression's description is added to the beginning of stdout (instead of stderr). If no level is specified, then the fatal error level will be assumed to have occurred. The level can have one of following values:
   * ``log`` and ``warning``: If the regular expression matches against its source input (i.e., stdout and/or stderr), then a description of the error will be added to the beginning of the source, prepended with either 'Log:' or 'Warning:'. A log-level/warning-level error will not cause the tool to fail.
-  * ``fatal``: If the regular expression matches against its source input, then a description of the error will be added to the beginning of the source. A fatal-level error will cause the tool to fail. If no level is specified, then the fatal error level will be assumed to have occurred.
+  * ``fatal``: If the regular expression matches against its source input, then a description of the error will be added to the beginning of the source. A fatal-level error will cause the tool to fail.
+  * ``fatal_oom``: In contrast to fatal the job might be resubmitted if possible according to the job configuration.
 * ``description``: Just like its ``exit_code`` counterpart, this is an optional description of the regular expression that has matched.
 
 The following is an example of regular expressions that may be used:
@@ -4972,10 +4984,14 @@ prepended with the string ``Fatal: Unknown error encountered``. Note that, if
 stderr contained ``error``, ``ERROR``, or ``ErRor`` then it would not matter -
 stderr was not being scanned.
 
-If the second regular expression did not match, then the third regular
-expression is checked. The third regular expression does not contain an error
-level, so an error level of ``fatal`` is assumed. The third regular expression
-also does not contain a source, so both stdout and stderr are checked. The third
+If the second regular expression does not match, the regular expression "out of memory"
+is checked on stdout. If found, Galaxy tries to resubmit the job with more memory
+if configured correctly, otherwise the job fails.
+
+If the previous regular expressions does not match, then the fourth regular
+expression is checked. The fourth regular expression does not contain an error
+level, so an error level of ``fatal`` is assumed. The fourth regular expression
+also does not contain a source, so both stdout and stderr are checked. The fourth
 regular expression looks for 12 consecutive "C"s or "G"s in any order and in
 uppercase or lowercase. If stdout contained ``cgccGGCCcGGcG`` or stderr
 contained ``CCCCCCgggGGG``, then the regular expression would match, the tool
@@ -4983,7 +4999,7 @@ would be marked with a fatal error, and the stream that contained the
 12-nucleotide CG island would be prepended with ``Fatal: Fatal error - CG island
 12 nts long found``.
 
-Finally, if the tool did not match any of the fatal errors, then the fourth
+Finally, if the tool did not match any of the fatal errors, then the fifth
 regular expression is checked. Since no source is specified, both stdout and
 stderr are checked. If ``Branch A`` is at the beginning of stdout or stderr, then
 a warning will be registered and the source that contained ``Branch A`` will be
@@ -4993,12 +5009,12 @@ prepended with the warning ``Warning: Branch A was taken in execution``.
     </xs:annotation>
     <xs:attribute name="source" type="SourceType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">This tells whether the regular expression should be matched against stdout, stderr, or both. If this attribute is missing or is incorrect, then both stdout and stderr will be checked. The source can be one of the follwing values: </xs:documentation>
+        <xs:documentation xml:lang="en">This tells whether the regular expression should be matched against stdout, stderr, or both. If this attribute is missing or is incorrect, then both stdout and stderr will be checked. The source can be one of the following values:</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="match" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">This is the regular expression that will be used to match against stdout and/or stderr. </xs:documentation>
+        <xs:documentation xml:lang="en">This is the regular expression that will be used to match against stdout and/or stderr.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="level" type="LevelType">
@@ -5092,12 +5108,12 @@ for a list of supported formats.</xs:documentation>
     </xs:attribute>
     <xs:attribute name="input_dataset" type="xs:string" gxdocs:deprecated="true">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Deprecated.</xs:documentation>
+        <xs:documentation xml:lang="en">*Deprecated*.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="attribute" type="xs:string" gxdocs:deprecated="true">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Deprecated.</xs:documentation>
+        <xs:documentation xml:lang="en">*Deprecated*.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -5337,6 +5353,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:documentation xml:lang="en">Documentation for LevelType</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
+      <xs:enumeration value="fatal_oom"/>
       <xs:enumeration value="fatal"/>
       <xs:enumeration value="warning"/>
       <xs:enumeration value="log"/>


### PR DESCRIPTION
We need a new Planemo release that doesn't fail the linting when `fatal_oom` is used, see e.g. https://github.com/galaxyproject/tools-devteam/pull/503 .