### PR TITLE
Add icon for repeat parameters in training

### DIFF
--- a/planemo/training/tool_input.py
+++ b/planemo/training/tool_input.py
@@ -17,7 +17,7 @@ INPUT_SECTION = """
 """
 
 INPUT_ADD_REPEAT = """
->{{space}}- Click on *"Insert {{repeat_label}}"*:
+>{{space}}- {{ '{%' }} icon param-repeat {{ '%}' }} *"Insert {{repeat_label}}"*
 """
 
 SPACE = '    '
@@ -142,10 +142,6 @@ class ToolInput():
                 repeat_paramlist += templates.render(INPUT_ADD_REPEAT, **{
                     'space': SPACE * (self.level),
                     'repeat_label': self.tool_inp_desc['title']})
-                # add description of parameters in the repeat
-                repeat_paramlist += templates.render(INPUT_SECTION, **{
-                    'space': SPACE * (self.level),
-                    'section_label': "%s: %s" % (ind + 1, self.tool_inp_desc['title'])})
                 repeat_paramlist += paramlist_in_repeat
             self.level = cur_level
         self.wf_param_values = tmp_wf_param_values

--- a/tests/test_training_tool_input.py
+++ b/tests/test_training_tool_input.py
@@ -176,10 +176,8 @@ def test_ToolInput_get_formatted_repeat_desc():
         force_default=False)
     repeat_desc = tool_input.get_formatted_repeat_desc()
     assert '>    - In *"' in repeat_desc
-    assert '>        - Click on' in repeat_desc
-    assert '>        - In *"1:' in repeat_desc
+    assert '>        - {% icon param-repeat %} *"Insert' in repeat_desc
     assert '>            -' in repeat_desc
-    assert '>        - In *"2:' in repeat_desc
 
 
 def test_ToolInput_get_formatted_other_param_desc():


### PR DESCRIPTION
A new icon has been added to manage repeat parameters in training hands-on: https://github.com/galaxyproject/training-material/pull/1125

This PR updates the formatting of the repeat to use the icon in the skeleton generated from a workflow