### PR TITLE
skip workflow outputs that do not have a `label` set

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -368,7 +368,6 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
             if not output_id:
                 ctx.vlog("Workflow output identified without an ID (label), skipping")
                 continue
-            output_id = runnable_output.get_id()
             output_dict_value = None
             if self._runnable.type in [RunnableType.cwl_workflow, RunnableType.cwl_tool]:
                 galaxy_output = self.to_galaxy_output(runnable_output)

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -364,6 +364,7 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
 
         ctx.vlog("collecting outputs to directory %s" % output_directory)
         for runnable_output in get_outputs(self._runnable):
+            output_id = runnable_output.get_id()
             if not output_id:
                 ctx.vlog("Workflow output identified without an ID (label), skipping")
                 continue

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -364,6 +364,9 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
 
         ctx.vlog("collecting outputs to directory %s" % output_directory)
         for runnable_output in get_outputs(self._runnable):
+            if not output_id:
+                ctx.vlog("Workflow output identified without an ID (label), skipping")
+                continue
             output_id = runnable_output.get_id()
             output_dict_value = None
             if self._runnable.type in [RunnableType.cwl_workflow, RunnableType.cwl_tool]:


### PR DESCRIPTION
This will skip `workflow_outputs` that are not set or `"label": null`