### PR TITLE
Fix command run by `planemo test --skip_venv`

### DIFF
--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -75,9 +75,9 @@ def run_in_config(ctx, config, run=run_galaxy_command, **kwds):
     setup_common_startup_args = ""
     if kwds.get("skip_venv", False):
         setup_common_startup_args = shell_join(
-            'COMMON_STARTUP_ARGS=--skip-venv'
-            'export COMMON_STARTUP_ARGS'
-            'echo "Set COMMON_STARTUP_ARGS to ${COMMON_STARTUP_ARGS}"'
+            'COMMON_STARTUP_ARGS=--skip-venv',
+            'export COMMON_STARTUP_ARGS',
+            'echo "Set COMMON_STARTUP_ARGS to ${COMMON_STARTUP_ARGS}"',
         )
     setup_venv_command = setup_venv(ctx, kwds)
     cmd = shell_join(


### PR DESCRIPTION
Fix the following issue found in https://travis-ci.org/peterjc/galaxy_blast/jobs/474815361 :
```
$ planemo test --no_conda_auto_install --galaxy_root ${TRAVIS_BUILD_DIR}/galaxy-${GALAXY_BRANCH} --skip_venv tools/
Testing using galaxy_root /home/travis/build/peterjc/galaxy_blast/galaxy-master
Testing tools with command [cd /home/travis/build/peterjc/galaxy_blast/galaxy-master && COMMON_STARTUP_ARGS=--skip-venvexport COMMON_STARTUP_ARGSecho "Set COMMON_STARTUP_ARGS to ${COMMON_STARTUP_ARGS}" && sh run_tests.sh $COMMON_STARTUP_ARGS --report_file /home/travis/build/peterjc/galaxy_blast/tool_test_output.html --xunit_report_file /tmp/tmp0dVdsD/xunit.xml --structured_data_report_file /home/travis/build/peterjc/galaxy_blast/tool_test_output.json functional.test_toolbox]
/bin/sh: 1: COMMON_STARTUP_ARGSecho: not found
```

Introduced in commit 434099e81314b41c4d9f5bd89dcc78f6513e9141 .