### PR TITLE
Fix display of tool ids in planemo html report

### DIFF
--- a/planemo/reports/custom.js
+++ b/planemo/reports/custom.js
@@ -109,7 +109,7 @@ var TestResult = function(index, data) {
 	if(testMethod.indexOf(".test_tool_") > -1) {
 		splitParts = testMethod.split(".test_tool_");
 	} else {
-		splitParts = rSplit(testMethod, "_", 1);
+		splitParts = rSplit(testMethod, "-", 1);
 	}
 	var toolName = splitParts[0];
 	var testIndex;


### PR DESCRIPTION
If I understand `rSplit(testMethod, "_", 1);` correctly
the purpose here is to split the test_index from the tool id.

The test index is added in `_register_job_data` by doing
`tool_id + "-" + str(test_index)`, so just splitting at
`-` should have the desired effect.