### PR TITLE
single quotes for file names

### DIFF
--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -619,15 +619,15 @@ def _render(kwds, template_str=TOOL_TEMPLATE):
 
 def _replace_file_in_command(command, specified_file, name):
     """ Replace example file with cheetah variable name in supplied command
-    or command template. Be sure to quote the name.
+    or command template. Be sure to single quote the name.
     """
     # TODO: check if the supplied variant was single quoted already.
     if '"%s"' % specified_file in command:
         # Sample command already wrapped filename in double quotes
-        command = command.replace(specified_file, '$%s' % name)
+        command = command.replace('"%s"' % specified_file, "'$%s'" % name)
     elif (" %s " % specified_file) in (" " + command + " "):
         # In case of spaces, best to wrap filename in double quotes
-        command = command.replace(specified_file, '"$%s"' % name)
+        command = command.replace(specified_file, "'$%s'" % name)
     else:
         command = command.replace(specified_file, '$%s' % name)
     return command

--- a/tests/test_command_io.py
+++ b/tests/test_command_io.py
@@ -13,7 +13,7 @@ def test_simplest_command():
 def test_example_and_quotes():
     """Test example input/output transition."""
     command_io = _example("convert 1.bed 1.bam", example_outputs=["1.bam"], example_inputs=["1.bed"])
-    assert_equal(command_io.cheetah_template, 'convert "$input1" "$output1"')
+    assert_equal(command_io.cheetah_template, "convert '$input1' '$output1'")
     assert_equal(len(command_io.outputs), 1)
     assert_equal(len(command_io.inputs), 1)
 
@@ -21,7 +21,7 @@ def test_example_and_quotes():
 def test_example_already_quoted():
     """Test example input/output transition."""
     command_io = _example('convert "1.bed" "1.bam"', example_outputs=["1.bam"], example_inputs=["1.bed"])
-    assert_equal(command_io.cheetah_template, 'convert "$input1" "$output1"')
+    assert_equal(command_io.cheetah_template, "convert '$input1' '$output1'")
 
 
 def test_example_already_quoted_single():


### PR DESCRIPTION
While giving a planemo tutorial I realized that tool_init creates double quoted file names. I guess single quotes are better. 

