### PR TITLE
Use ``yaml.safe_load()`` instead of ``load()``

### DIFF
--- a/planemo/bioc_tool_builder.py
+++ b/planemo/bioc_tool_builder.py
@@ -234,7 +234,7 @@ class Requirement(object):
                                            "r-" + name.lower(),
                                            "meta.yaml")
             with open(recipe_path, 'r') as f:
-                doc = yaml.load(f)
+                doc = yaml.safe_load(f)
                 if not version:
                     version = doc["package"]["version"]
                 package_url = doc["about"]["home"]

--- a/planemo/conda_verify/recipe.py
+++ b/planemo/conda_verify/recipe.py
@@ -73,7 +73,7 @@ def select_lines(data, namespace):
 
 @memoized
 def yamlize(data):
-    res = yaml.load(data)
+    res = yaml.safe_load(data)
     # ensure the result is a dict
     if res is None:
         res = {}

--- a/planemo/config.py
+++ b/planemo/config.py
@@ -132,7 +132,7 @@ def read_global_config(config_path):
         return DEFAULT_CONFIG
 
     with open(config_path) as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 
 
 __all__ = (

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -248,7 +248,7 @@ def stage_in(ctx, runnable, config, user_gi, history_id, job_path, **kwds):
         return dataset_collection
 
     with open(job_path, "r") as f:
-        job = yaml.load(f)
+        job = yaml.safe_load(f)
 
     # Figure out what "." should be here instead.
     job_dir = os.path.dirname(job_path)

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -24,13 +24,13 @@ def load_shed_repos(runnable):
     if path.endswith(".ga"):
         generate_tool_list_from_ga_workflow_files.generate_tool_list_from_workflow([path], "Tools from workflows", "tools.yml")
         with open("tools.yml", "r") as f:
-            tools = yaml.load(f)["tools"]
+            tools = yaml.safe_load(f)["tools"]
 
     else:
         # It'd be better to just infer this from the tool shed ID somehow than
         # require explicit annotation like this... I think?
         with open(path, "r") as f:
-            workflow = yaml.load(f)
+            workflow = yaml.safe_load(f)
 
         tools = workflow.get("tools", [])
 
@@ -81,7 +81,7 @@ def _raw_dict(path, importer=None):
         workflow_directory = os.path.dirname(path)
         workflow_directory = os.path.abspath(workflow_directory)
         with open(path, "r") as f:
-            workflow = yaml.load(f)
+            workflow = yaml.safe_load(f)
             workflow = python_to_workflow(workflow, importer, workflow_directory)
 
     return workflow

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -121,7 +121,7 @@ def cases(runnable):
         return os.path.normpath(absolute_path)
 
     with open(tests_path, "r") as f:
-        tests_def = yaml.load(f)
+        tests_def = yaml.safe_load(f)
 
     if not isinstance(tests_def, list):
         message = TEST_FILE_NOT_LIST_MESSAGE % tests_path

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -433,7 +433,7 @@ def shed_repo_config(ctx, path, name=None):
     config = {}
     if os.path.exists(shed_yaml_path):
         with open(shed_yaml_path, "r") as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
 
     if config is None:  # yaml may yield None
         config = {}

--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -290,7 +290,8 @@ def lint_shed_yaml(realized_repository, lint_ctx):
         lint_ctx.info("No .shed.yml file found, skipping.")
         return
     try:
-        yaml.load(open(shed_yaml, "r"))
+        with open(shed_yaml, "r") as fh:
+            yaml.safe_load(fh)
     except Exception as e:
         lint_ctx.warn("Failed to parse .shed.yml file [%s]" % str(e))
         return

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -262,7 +262,7 @@ class Tutorial(object):
         tuto_split_regex = re.search(regex, tuto_content)
         if not tuto_split_regex:
             raise Exception("No metadata found at the top of the tutorial")
-        metadata = yaml.load(tuto_split_regex.group("metadata"))
+        metadata = yaml.safe_load(tuto_split_regex.group("metadata"))
         self.title = metadata["title"]
         self.zenodo_link = metadata["zenodo_link"]
         self.questions = metadata["questions"]

--- a/planemo/training/utils.py
+++ b/planemo/training/utils.py
@@ -74,7 +74,7 @@ class Reference(object):
 def load_yaml(filepath):
     """Load the content of a YAML file to a dictionary."""
     with open(filepath, "r") as m_file:
-        content = yaml.load(m_file)
+        content = yaml.safe_load(m_file)
     return content
 
 

--- a/scripts/update_bioconda.bash
+++ b/scripts/update_bioconda.bash
@@ -39,7 +39,7 @@ git checkout master
 git merge --ff-only origin/master
 
 METADATA="$RECIPE/meta.yaml"
-OLD_VERSION=`python2 -c "import yaml; print yaml.load(open('$METADATA', 'r').read())['package']['version']"`
+OLD_VERSION=`python2 -c "import yaml; print yaml.safe_load(open('$METADATA', 'r').read())['package']['version']"`
 
 OLD_RECIPE="$RECIPE/$OLD_VERSION"
 mkdir "$OLD_RECIPE"

--- a/tests/test_build_and_lint.py
+++ b/tests/test_build_and_lint.py
@@ -41,7 +41,7 @@ class BuildAndLintTestCase(CliTestCase):
             self._check_lint(filename="seqtk_seq.cwl", exit_code=0)
 
             with open(os.path.join(f, "seqtk_seq.cwl")) as stream:
-                process_dict = yaml.load(stream)
+                process_dict = yaml.safe_load(stream)
             assert process_dict["id"] == "seqtk_seq"
             assert process_dict["label"] == "Convert to FASTA (seqtk)"
             assert process_dict["baseCommand"] == ["seqtk", "seq"]
@@ -55,7 +55,7 @@ class BuildAndLintTestCase(CliTestCase):
             assert process_dict["stdout"] == "out"
 
             with open(os.path.join(f, "seqtk_seq_tests.yml")) as stream:
-                test_dict = yaml.load(stream)
+                test_dict = yaml.safe_load(stream)
                 assert test_dict
 
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")

--- a/tests/test_config_init.py
+++ b/tests/test_config_init.py
@@ -14,7 +14,7 @@ class ConfigInitTestCase(CliTestCase):
             assert os.path.exists(self.planemo_yaml_path)
             with open(self.planemo_yaml_path, "r") as f:
                 # Ensure it is valid YAML
-                yaml.load(f)
+                yaml.safe_load(f)
 
     def test_config_wont_overwrite(self):
         with self._isolate():

--- a/tests/test_shed.py
+++ b/tests/test_shed.py
@@ -53,7 +53,8 @@ class ShedTestCase(CliTestCase):
                 "--shed_target", shed_url
             ]
             self._check_exit_code(init_cmd)
-            contents_dict = yaml.load(open(".shed.yml", "r"))
+            with open(".shed.yml", "r") as fh:
+                contents_dict = yaml.safe_load(fh)
             contents_dict["description"] = "Update test repository."
             io.write_file(".shed.yml", yaml.dump(contents_dict))
             update_cmd = [

--- a/tests/test_shed_init.py
+++ b/tests/test_shed_init.py
@@ -23,7 +23,8 @@ class ShedInitTestCase(CliShedTestCase):
             ])
             shed_config_path = os.path.join(f, ".shed.yml")
             assert os.path.exists(shed_config_path)
-            shed_config = yaml.load(open(shed_config_path, "r"))
+            with open(shed_config_path, "r") as fh:
+                shed_config = yaml.safe_load(fh)
             assert shed_config["name"] == "samtools_filter"
             assert shed_config["owner"] == "iuc"
             assert shed_config["description"] == "samtools_filter"
@@ -48,7 +49,8 @@ class ShedInitTestCase(CliShedTestCase):
             self._check_exit_code(init_command)
             shed_config_path = os.path.join(f, ".shed.yml")
             assert os.path.exists(shed_config_path)
-            shed_config = yaml.load(open(shed_config_path, "r"))
+            with open(shed_config_path, "r") as fh:
+                shed_config = yaml.safe_load(fh)
             assert shed_config["name"] == "samtools_filter"
             assert shed_config["owner"] == "devteam"
             assert shed_config["description"] == "A samtools repo"


### PR DESCRIPTION
Fix warnings like:

```
planemo/shed/__init__.py:436: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(f)
```