### PR TITLE
Fix deprecated ``getchildren()``

### DIFF
--- a/planemo/shed/diff.py
+++ b/planemo/shed/diff.py
@@ -51,10 +51,8 @@ def _shed_diff(file_a, file_b, f=sys.stdout):
 def _strip_shed_attributes(xml_element):
     if xml_element.tag == "repository":
         _remove_attribs(xml_element)
-    children = xml_element.getchildren()
-    if len(children) > 0:
-        for child in children:
-            _strip_shed_attributes(child)
+    for child in xml_element:
+        _strip_shed_attributes(child)
 
 
 def _remove_attribs(xml_element):

--- a/planemo/xml/diff.py
+++ b/planemo/xml/diff.py
@@ -37,8 +37,8 @@ def xml_compare(x1, x2, reporter=None):
 
 
 def _compare_children(x1, x2, reporter):
-    cl1 = x1.getchildren()
-    cl2 = x2.getchildren()
+    cl1 = list(x1)
+    cl2 = list(x2)
     if len(cl1) != len(cl2):
         reporter('children length differs, %i != %i\n'
                  % (len(cl1), len(cl2)))

--- a/tests/shed_app.py
+++ b/tests/shed_app.py
@@ -173,10 +173,8 @@ def _modify_attributes(xml_element):
         xml_element.attrib["toolshed"] = "localhost:9012"
         xml_element.attrib["changeset_revision"] = "12345"
 
-    children = xml_element.getchildren()
-    if len(children) > 0:
-        for child in children:
-            _modify_attributes(child)
+    for child in xml_element:
+        _modify_attributes(child)
 
 
 def _shutdown_server():


### PR DESCRIPTION
See https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren