### PR TITLE
Use ``unicodify()`` on exceptions and subprocess outputs

### DIFF
--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import json
 
 import click
+from galaxy.util import unicodify
 
 from planemo import options
 from planemo.cli import command_function
@@ -40,7 +41,7 @@ def cli(ctx, uri, job_path, **kwds):
         run_result = engine.run(path, job_path)
 
     if not run_result.was_successful:
-        warn("Run failed [%s]" % str(run_result))
+        warn("Run failed [%s]" % unicodify(run_result))
         ctx.exit(1)
 
     outputs_dict = run_result.outputs_dict

--- a/planemo/conda_lint.py
+++ b/planemo/conda_lint.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from functools import wraps
 
 from galaxy.tools.deps.conda_compat import raw_metadata
+from galaxy.util import unicodify
 
 from planemo.conda_verify.recipe import (
     check_build_number,
@@ -78,11 +79,11 @@ def wraps_recipe_error(is_error=True):
                 f(recipe_dir, lint_ctx)
             except RecipeError as e:
                 if is_error:
-                    lint_ctx.error(str(e))
+                    lint_ctx.error(unicodify(e))
                 else:
-                    lint_ctx.warn(str(e))
+                    lint_ctx.warn(unicodify(e))
             except TypeError as e:  # Errors in recipe checking code from YAML.
-                lint_ctx.error(str(e))
+                lint_ctx.error(unicodify(e))
 
         return wrapper
 

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -21,7 +21,10 @@ from galaxy.tools.cwl.util import (
     tool_response_to_output,
 )
 from galaxy.tools.parser import get_tool_source
-from galaxy.util import safe_makedirs
+from galaxy.util import (
+    safe_makedirs,
+    unicodify,
+)
 
 from planemo.galaxy.api import summarize_history
 from planemo.io import wait_on
@@ -42,7 +45,7 @@ def execute(ctx, config, runnable, job_path, **kwds):
     try:
         return _execute(ctx, config, runnable, job_path, **kwds)
     except Exception as e:
-        return ErrorRunResponse(str(e))
+        return ErrorRunResponse(unicodify(e))
 
 
 def _verified_tool_id(runnable, user_gi):

--- a/planemo/galaxy/ephemeris_sleep.py
+++ b/planemo/galaxy/ephemeris_sleep.py
@@ -12,6 +12,7 @@ import time
 from argparse import ArgumentParser
 
 import requests
+from galaxy.util import unicodify
 
 try:
     from .common_parser import get_common_args
@@ -55,7 +56,7 @@ def sleep(galaxy_url, verbose=False, timeout=0):
                     sys.stdout.flush()
         except requests.exceptions.ConnectionError as e:
             if verbose:
-                sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, str(e)[0:100]))
+                sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, unicodify(e)[:100]))
                 sys.stdout.flush()
         count += 1
 

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -17,7 +17,10 @@ from tempfile import (
 import bioblend
 import six
 import yaml
-from galaxy.util import odict
+from galaxy.util import (
+    odict,
+    unicodify,
+)
 
 from planemo import git
 from planemo import glob
@@ -1316,7 +1319,7 @@ class RealizedRepositry(object):
                 upstream_error = json.loads(e.read())
                 error(upstream_error['err_msg'])
             except Exception:
-                error(str(e))
+                error(unicodify(e))
             return None
 
     def latest_installable_revision(self, ctx, shed_context):
@@ -1354,7 +1357,7 @@ def _handle_realization_error(exception, **kwds):
     if fail_fast:
         raise exception
     else:
-        error(str(exception))
+        error(unicodify(exception))
 
 
 def _ensure_shed_description(description):

--- a/planemo/shed/interface.py
+++ b/planemo/shed/interface.py
@@ -2,6 +2,8 @@
 
 import json
 
+from galaxy.util import unicodify
+
 from planemo.bioblend import (
     ensure_module,
     toolshed,
@@ -69,7 +71,7 @@ def api_exception_to_message(e):
     """ Convert API exception to human digestable error message - parsing
     out the shed generate message if possible.
     """
-    message = str(e)
+    message = unicodify(e)
     if hasattr(e, "read"):
         message = e.read()
         try:

--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 import yaml
 from galaxy.tools.lint import lint_tool_source_with
 from galaxy.tools.linters.help import rst_invalid
+from galaxy.util import unicodify
 
 from planemo.io import info
 from planemo.lint import (
@@ -257,7 +258,7 @@ def lint_tool_dependencies_actions(realized_repository, lint_ctx):
         traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
         traceback.print_exc()
         template = "Problem parsing tool_dependenies.xml [%s]"
-        msg = template % str(e)
+        msg = template % unicodify(e)
         lint_ctx.warn(msg)
         return
 
@@ -293,7 +294,7 @@ def lint_shed_yaml(realized_repository, lint_ctx):
         with open(shed_yaml, "r") as fh:
             yaml.safe_load(fh)
     except Exception as e:
-        lint_ctx.warn("Failed to parse .shed.yml file [%s]" % str(e))
+        lint_ctx.warn("Failed to parse .shed.yml file [%s]" % unicodify(e))
         return
     lint_ctx.info(".shed.yml found and appears to be valid YAML.")
     _lint_shed_contents(lint_ctx, realized_repository)

--- a/planemo/test/_check_output.py
+++ b/planemo/test/_check_output.py
@@ -3,6 +3,7 @@
 import os
 
 from galaxy.tools.verify import verify
+from galaxy.util import unicodify
 
 
 def check_output(runnable, output_properties, test_properties, **kwds):
@@ -43,7 +44,7 @@ def check_output(runnable, output_properties, test_properties, **kwds):
             verify_extra_files=None,
         )
     except AssertionError as e:
-        problems.append(str(e))
+        problems.append(unicodify(e))
 
     return problems
 

--- a/planemo/xml/validation.py
+++ b/planemo/xml/validation.py
@@ -4,6 +4,7 @@ import subprocess
 from collections import namedtuple
 
 from galaxy.tools.deps.commands import which
+from galaxy.util import unicodify
 try:
     from lxml import etree
 except ImportError:
@@ -50,7 +51,7 @@ class LxmlValidator(XsdValidator):
             passed = xsd.validate(xml)
             return ValidationResult(passed, xsd.error_log)
         except etree.XMLSyntaxError as e:
-            return ValidationResult(False, str(e))
+            return ValidationResult(False, unicodify(e))
 
     def enabled(self):
         return etree is not None

--- a/tests/data/data_manager/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
+++ b/tests/data/data_manager/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py
@@ -3,6 +3,7 @@
 
 import bz2
 import gzip
+import json
 import optparse
 import os
 import shutil
@@ -11,7 +12,6 @@ import tarfile
 import tempfile
 import zipfile
 from ftplib import FTP
-from json import dumps, loads
 
 try:
     # For Python 3.0 and later
@@ -452,7 +452,8 @@ def main():
 
     filename = args[0]
 
-    params = loads(open(filename).read())
+    with open(filename) as fh:
+        params = json.load(fh)
     target_directory = params['output_data'][0]['extra_files_path']
     os.mkdir(target_directory)
     data_manager_dict = {}
@@ -488,7 +489,8 @@ def main():
     finally:
         cleanup_before_exit(tmp_dir)
     # save info to json file
-    open(filename, 'w').write(dumps(data_manager_dict))
+    with open(filename, 'w') as fh:
+        json.dump(data_manager_dict, fh, sort_keys=True)
 
 
 if __name__ == "__main__":

--- a/tests/data/data_manager/data_manager_fetch_genome_dbkeys_all_fasta/test-data/phiX174.data_manager_json
+++ b/tests/data/data_manager/data_manager_fetch_genome_dbkeys_all_fasta/test-data/phiX174.data_manager_json
@@ -1,1 +1,1 @@
-{"data_tables": {"__dbkeys__": [{"len_path": "phiX174.len", "value": "phiX174", "name": "phiX174"}], "all_fasta": [{"path": "phix174.fa", "dbkey": "phiX174", "name": "phiX174 sequence name", "value": "phix174"}]}}
+{"data_tables": {"__dbkeys__": [{"len_path": "phiX174.len", "name": "phiX174", "value": "phiX174"}], "all_fasta": [{"dbkey": "phiX174", "name": "phiX174 sequence name", "path": "phix174.fa", "value": "phix174"}]}}

--- a/tests/test_cmd_serve.py
+++ b/tests/test_cmd_serve.py
@@ -56,7 +56,7 @@ class ServeTestCase(CliTestCase):
             "--galaxy_python_version", "3"]
         self._launch_thread_and_wait(self._run, extra_args)
         # Check that the client was correctly built
-        url = "http://localhost:%d/static/scripts/libs/require.js" % int(self._port)
+        url = "http://localhost:%d/static/scripts/bundled/analysis.bundled.js" % int(self._port)
         r = requests.get(url)
         assert r.status_code == 200
 

--- a/tests/test_shed_upload.py
+++ b/tests/test_shed_upload.py
@@ -9,6 +9,8 @@ import shutil
 import tarfile
 from os.path import exists, join
 
+from galaxy.util import unicodify
+
 from planemo import git
 from planemo.io import shell
 from .test_utils import (
@@ -417,7 +419,7 @@ class ShedUploadTestCase(CliShedTestCase):
         except tarfile.ReadError as e:
             # Fixed in later version of Python, see
             # http://bugs.python.org/issue6123
-            assert str(e) == "empty header", e
+            assert unicodify(e) == "empty header", e
             return target  # note contained no files!
         tar.extractall(path=target)
         tar.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from tempfile import mkdtemp
 import psutil
 from click.testing import CliRunner
 from galaxy.tools.deps.commands import which
+from galaxy.util import unicodify
 
 from planemo import cli
 from planemo import io
@@ -302,7 +303,7 @@ def check_exit_code(runner, command_list, exit_code=0):
             result.output,
         )
         if result.exception:
-            message += " Exception [%s], " % str(result.exception)
+            message += " Exception [%s], " % unicodify(result.exception)
             exc_type, exc_value, exc_traceback = result.exc_info
             tb = traceback.format_exception(exc_type, exc_value,
                                             exc_traceback)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,7 @@
 import os
 
+from galaxy.util import unicodify
+
 from planemo import shed_lint
 from planemo.xml import validation
 from .test_utils import (
@@ -48,8 +50,8 @@ def _check_validator(xsd_validator):
     result = xsd_validator.validate(_path("xsd_schema_1.xsd"),
                                     _path("xml_bad_1.xml"))
     assert not result.passed
-    output = result.output
-    assert "not_command" in str(output), str(output)
+    output = unicodify(result.output)
+    assert "not_command" in output, output
 
 
 def _assert_validates(schema, target, xsd_validator=None):


### PR DESCRIPTION
Fix traceback reported in https://github.com/galaxyproject/planemo/issues/939#issuecomment-505766544 .

Also fix 2 old broken tests.