### PR TITLE
Do not override None with empty string

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -453,7 +453,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             watch_tools="auto",
             default_job_shell="/bin/bash",  # For conda dependency resolution
             tool_data_table_config_path=tool_data_table,
-            data_manager_config_file=",".join(data_manager_config_paths),
+            data_manager_config_file=",".join(data_manager_config_paths) or None,  # without 'or None' may raise IOError in galaxy (see #946)
             integrated_tool_panel_config=("${temp_directory}/"
                                           "integrated_tool_panel_conf.xml"),
             migrated_tools_config=empty_tool_conf,
@@ -1271,9 +1271,10 @@ def _ensure_galaxy_repository_available(ctx, kwds):
 def _build_env_for_galaxy(properties, template_args):
     env = {}
     for key, value in iteritems(properties):
-        var = "GALAXY_CONFIG_OVERRIDE_%s" % key.upper()
-        value = _sub(value, template_args)
-        env[var] = value
+        if value is not None:  # Do not override None with empty string
+            var = "GALAXY_CONFIG_OVERRIDE_%s" % key.upper()
+            value = _sub(value, template_args)
+            env[var] = value
     return env
 
 


### PR DESCRIPTION
This is a partial solution to #946; it addresses the IOError.
The cause for the error is described here: https://github.com/galaxyproject/planemo/issues/946#issuecomment-518951541

The edits prevent planemo from passing an empty string as the value of `data_manager_config_file` to the managed galaxy instance as part of kwargs. An empty string was resolved to the current directory and, due to stricter exception handling in galaxy (introduced in https://github.com/galaxyproject/galaxy/pull/921) that caused an error.

This should work correctly for both cases, when a path exists (when it's a data manager) and when it doesn't ( when it's a regular tool or a directory).

Ping @jmchilton , @natefoo . (I am not at all sure this is the optimal solution here, but it's my best guess, for now.)