### PR TITLE
Move most tests to Python 3.7. Updates for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,22 @@ matrix:
   include:
     - python: 2.7
       env: TOX_ENV=py27-lint
+    - python: 3.7
+      env: TOX_ENV=py37-lint_readme
+    - python: 3.7
+      env: TOX_ENV=py37-lint_docs
+    - python: 3.7
+      env: TOX_ENV=py37-lint_docstrings
+    - python: 3.7
+      env: TOX_ENV=py37-lint
+    - python: 3.7
+      env: TOX_ENV=py37-quick
     - python: 2.7
-      env: TOX_ENV=py27-lint-readme
-    - python: 2.7
-      env: TOX_ENV=py27-lint-docs
-    - python: 2.7
-      env: TOX_ENV=py27-lint-docstrings
-    - python: 3.6
-      env: TOX_ENV=py36-lint
-    - python: 3.6
-      env: TOX_ENV=py36-quick
-    - python: 2.7
-      env: TOX_ENV=py27
-    - python: 3.6
-      env: TOX_ENV=py36
+      env: TOX_ENV=py27-unit
+    - python: 3.7
+      env: TOX_ENV=py37-unit
   allow_failures:
-    - env: TOX_ENV=py27-lint-docstrings
+    - env: TOX_ENV=py37-lint_docstrings
 
 install:
   - pip install tox coveralls

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-2. The pull request should work for Python 2.7 and 3.4. Check
+2. The pull request should work for Python 2.7 and 3.7. Check
    https://travis-ci.org/galaxyproject/planemo/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
@@ -115,15 +115,15 @@ Tips
 
 To run a subset of tests::
 
-    % make tox ENV=py27 ARGS='--tests tests/test_shed_upload.py'
+    % make tox ENV=py37-unit ARGS='--tests tests/test_shed_upload.py'
 
-This will use Tox_ to run the specified tests using Python 2.7. ``ENV`` here
+This will use Tox_ to run the specified tests using Python 3.7. ``ENV`` here
 can be used to specify different Python version (e.g. ``py27`` and
-``py34``). Python 3.4 is a work in progress. 
+``py37``).
 
 Even more granularity is also possible by specifying specific test methods.::
 
-    make tox ENV=py27 ARGS='--tests tests/test_shed_upload.py:ShedUploadTestCase.test_tar_from_git'
+    make tox ENV=py37-unit ARGS='--tests tests/test_shed_upload.py:ShedUploadTestCase.test_tar_from_git'
 
 
 ``tox`` can be used to run tests directly also (use ``. .venv/bin/activate``
@@ -131,7 +131,7 @@ to ensure it is on your ``PATH``).
 
 ::
 
-    tox -e py27 -- --tests tests/test_shed_upload.py
+    tox -e py37-unit -- --tests tests/test_shed_upload.py
 
 Tox_ itself is configured to wrap nose_. One can skip Tox_ and run
 ``nosetests`` directly.
@@ -150,18 +150,18 @@ testing environment. Planemo defines the following environments:
 ``py27-lint``
     Lint the planemo code using Python 2.7.
 
-``py34-lint``
+``py37-lint``
     Lint the planemo code using Python 3.4 (also ensures valid Python 3
     syntax).
 
-``py27-lint-readme``
+``py37-lint_readme``
     Lint the README reStructuredText.
 
-``py27``
+``py27-unit``
     Run planemo tests in Python 2.7.
 
-``py34``
-    Run planemo tests in Python 3.4 (not currently working).
+``py37-unit``
+    Run planemo tests in Python 3.7.
 
 
 Pre-commit Hooks

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ flake8: ## check style using flake8 for current Python (faster than lint)
 	$(IN_VENV) flake8 $(SOURCE_DIR)  $(TEST_DIR)
 
 lint: ## check style using tox and flake8 for Python 2 and Python 3
-	$(IN_VENV) tox -e py27-lint && tox -e py34-lint
+	$(IN_VENV) tox -e py27-lint && tox -e py37-lint
 
 lint-readme: ## check README formatting for PyPI
 	$(IN_VENV) python setup.py check -r -s

--- a/docs/planemo.bioconda_scripts.rst
+++ b/docs/planemo.bioconda_scripts.rst
@@ -8,15 +8,15 @@ planemo.bioconda\_scripts.bioconductor\_skeleton module
 -------------------------------------------------------
 
 .. automodule:: planemo.bioconda_scripts.bioconductor_skeleton
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.bioconda_scripts
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.commands.rst
+++ b/docs/planemo.commands.rst
@@ -8,495 +8,495 @@ planemo.commands.cmd\_bioc\_conda\_recipe\_init module
 ------------------------------------------------------
 
 .. automodule:: planemo.commands.cmd_bioc_conda_recipe_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_bioc\_tool\_init module
 ---------------------------------------------
 
 .. automodule:: planemo.commands.cmd_bioc_tool_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_brew module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_brew
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_brew\_env module
 --------------------------------------
 
 .. automodule:: planemo.commands.cmd_brew_env
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_brew\_init module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_brew_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_ci\_find\_repos module
 --------------------------------------------
 
 .. automodule:: planemo.commands.cmd_ci_find_repos
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_ci\_find\_tools module
 --------------------------------------------
 
 .. automodule:: planemo.commands.cmd_ci_find_tools
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_clone module
 ----------------------------------
 
 .. automodule:: planemo.commands.cmd_clone
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_conda\_build module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_conda_build
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_conda\_env module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_conda_env
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_conda\_init module
 ----------------------------------------
 
 .. automodule:: planemo.commands.cmd_conda_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_conda\_install module
 -------------------------------------------
 
 .. automodule:: planemo.commands.cmd_conda_install
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_conda\_lint module
 ----------------------------------------
 
 .. automodule:: planemo.commands.cmd_conda_lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_conda\_search module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_conda_search
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_config\_init module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_config_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_container\_register module
 ------------------------------------------------
 
 .. automodule:: planemo.commands.cmd_container_register
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_create\_gist module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_create_gist
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_cwl\_script module
 ----------------------------------------
 
 .. automodule:: planemo.commands.cmd_cwl_script
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_database\_create module
 ---------------------------------------------
 
 .. automodule:: planemo.commands.cmd_database_create
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_database\_delete module
 ---------------------------------------------
 
 .. automodule:: planemo.commands.cmd_database_delete
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_database\_list module
 -------------------------------------------
 
 .. automodule:: planemo.commands.cmd_database_list
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_dependency\_script module
 -----------------------------------------------
 
 .. automodule:: planemo.commands.cmd_dependency_script
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_docker\_build module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_docker_build
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_docker\_shell module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_docker_shell
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_docs module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_docs
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_lint module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_mull module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_mull
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_mulled\_init module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_mulled_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_normalize module
 --------------------------------------
 
 .. automodule:: planemo.commands.cmd_normalize
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_open module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_open
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_profile\_create module
 --------------------------------------------
 
 .. automodule:: planemo.commands.cmd_profile_create
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_profile\_delete module
 --------------------------------------------
 
 .. automodule:: planemo.commands.cmd_profile_delete
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_profile\_list module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_profile_list
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_project\_init module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_project_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_pull\_request module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_pull_request
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_run module
 --------------------------------
 
 .. automodule:: planemo.commands.cmd_run
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_serve module
 ----------------------------------
 
 .. automodule:: planemo.commands.cmd_serve
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_share\_test module
 ----------------------------------------
 
 .. automodule:: planemo.commands.cmd_share_test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_build module
 ----------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_build
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_create module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_create
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_diff module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_diff
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_download module
 -------------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_download
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_init module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_lint module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_serve module
 ----------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_serve
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_test module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_update module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_update
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_shed\_upload module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_shed_upload
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_syntax module
 -----------------------------------
 
 .. automodule:: planemo.commands.cmd_syntax
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_test module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_test\_reports module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_test_reports
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_tool\_factory module
 ------------------------------------------
 
 .. automodule:: planemo.commands.cmd_tool_factory
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_tool\_init module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_tool_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_training\_fill\_data\_library module
 ----------------------------------------------------------
 
 .. automodule:: planemo.commands.cmd_training_fill_data_library
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_training\_generate\_from\_wf module
 ---------------------------------------------------------
 
 .. automodule:: planemo.commands.cmd_training_generate_from_wf
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_training\_init module
 -------------------------------------------
 
 .. automodule:: planemo.commands.cmd_training_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_travis\_before\_install module
 ----------------------------------------------------
 
 .. automodule:: planemo.commands.cmd_travis_before_install
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_travis\_init module
 -----------------------------------------
 
 .. automodule:: planemo.commands.cmd_travis_init
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_virtualenv module
 ---------------------------------------
 
 .. automodule:: planemo.commands.cmd_virtualenv
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_workflow\_convert module
 ----------------------------------------------
 
 .. automodule:: planemo.commands.cmd_workflow_convert
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.commands.cmd\_workflow\_edit module
 -------------------------------------------
 
 .. automodule:: planemo.commands.cmd_workflow_edit
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.commands
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.conda_verify.rst
+++ b/docs/planemo.conda_verify.rst
@@ -8,31 +8,31 @@ planemo.conda\_verify.const module
 ----------------------------------
 
 .. automodule:: planemo.conda_verify.const
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.conda\_verify.recipe module
 -----------------------------------
 
 .. automodule:: planemo.conda_verify.recipe
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.conda\_verify.utils module
 ----------------------------------
 
 .. automodule:: planemo.conda_verify.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.conda_verify
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.cwl.rst
+++ b/docs/planemo.cwl.rst
@@ -8,31 +8,31 @@ planemo.cwl.run module
 ----------------------
 
 .. automodule:: planemo.cwl.run
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.cwl.script module
 -------------------------
 
 .. automodule:: planemo.cwl.script
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.cwl.toil module
 -----------------------
 
 .. automodule:: planemo.cwl.toil
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.cwl
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.database.rst
+++ b/docs/planemo.database.rst
@@ -8,39 +8,39 @@ planemo.database.factory module
 -------------------------------
 
 .. automodule:: planemo.database.factory
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.database.interface module
 ---------------------------------
 
 .. automodule:: planemo.database.interface
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.database.postgres module
 --------------------------------
 
 .. automodule:: planemo.database.postgres
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.database.postgres\_docker module
 ----------------------------------------
 
 .. automodule:: planemo.database.postgres_docker
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.database
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.engine.rst
+++ b/docs/planemo.engine.rst
@@ -8,47 +8,47 @@ planemo.engine.cwltool module
 -----------------------------
 
 .. automodule:: planemo.engine.cwltool
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.engine.factory module
 -----------------------------
 
 .. automodule:: planemo.engine.factory
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.engine.galaxy module
 ----------------------------
 
 .. automodule:: planemo.engine.galaxy
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.engine.interface module
 -------------------------------
 
 .. automodule:: planemo.engine.interface
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.engine.toil module
 --------------------------
 
 .. automodule:: planemo.engine.toil
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.engine
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.galaxy.rst
+++ b/docs/planemo.galaxy.rst
@@ -6,7 +6,7 @@ Subpackages
 
 .. toctree::
 
-    planemo.galaxy.test
+   planemo.galaxy.test
 
 Submodules
 ----------
@@ -15,79 +15,79 @@ planemo.galaxy.activity module
 ------------------------------
 
 .. automodule:: planemo.galaxy.activity
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.api module
 -------------------------
 
 .. automodule:: planemo.galaxy.api
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.config module
 ----------------------------
 
 .. automodule:: planemo.galaxy.config
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.distro\_tools module
 -----------------------------------
 
 .. automodule:: planemo.galaxy.distro_tools
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.ephemeris\_sleep module
 --------------------------------------
 
 .. automodule:: planemo.galaxy.ephemeris_sleep
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.profiles module
 ------------------------------
 
 .. automodule:: planemo.galaxy.profiles
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.run module
 -------------------------
 
 .. automodule:: planemo.galaxy.run
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.serve module
 ---------------------------
 
 .. automodule:: planemo.galaxy.serve
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.workflows module
 -------------------------------
 
 .. automodule:: planemo.galaxy.workflows
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.galaxy
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.galaxy.test.rst
+++ b/docs/planemo.galaxy.test.rst
@@ -8,23 +8,23 @@ planemo.galaxy.test.actions module
 ----------------------------------
 
 .. automodule:: planemo.galaxy.test.actions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.galaxy.test.structures module
 -------------------------------------
 
 .. automodule:: planemo.galaxy.test.structures
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.galaxy.test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.linters.rst
+++ b/docs/planemo.linters.rst
@@ -8,47 +8,47 @@ planemo.linters.biocontainer\_registered module
 -----------------------------------------------
 
 .. automodule:: planemo.linters.biocontainer_registered
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.linters.conda\_requirements module
 ------------------------------------------
 
 .. automodule:: planemo.linters.conda_requirements
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.linters.doi module
 --------------------------
 
 .. automodule:: planemo.linters.doi
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.linters.urls module
 ---------------------------
 
 .. automodule:: planemo.linters.urls
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.linters.xsd module
 --------------------------
 
 .. automodule:: planemo.linters.xsd
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.linters
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.reports.rst
+++ b/docs/planemo.reports.rst
@@ -8,23 +8,23 @@ planemo.reports.build\_report module
 ------------------------------------
 
 .. automodule:: planemo.reports.build_report
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.reports.xunit\_handler module
 -------------------------------------
 
 .. automodule:: planemo.reports.xunit_handler
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.reports
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.rst
+++ b/docs/planemo.rst
@@ -6,20 +6,20 @@ Subpackages
 
 .. toctree::
 
-    planemo.bioconda_scripts
-    planemo.commands
-    planemo.conda_verify
-    planemo.cwl
-    planemo.database
-    planemo.engine
-    planemo.galaxy
-    planemo.linters
-    planemo.reports
-    planemo.shed
-    planemo.shed2tap
-    planemo.test
-    planemo.training
-    planemo.xml
+   planemo.bioconda_scripts
+   planemo.commands
+   planemo.conda_verify
+   planemo.cwl
+   planemo.database
+   planemo.engine
+   planemo.galaxy
+   planemo.linters
+   planemo.reports
+   planemo.shed
+   planemo.shed2tap
+   planemo.test
+   planemo.training
+   planemo.xml
 
 Submodules
 ----------
@@ -28,223 +28,223 @@ planemo.bioblend module
 -----------------------
 
 .. automodule:: planemo.bioblend
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.bioc\_tool\_builder module
 ----------------------------------
 
 .. automodule:: planemo.bioc_tool_builder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.ci module
 -----------------
 
 .. automodule:: planemo.ci
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.cli module
 ------------------
 
 .. automodule:: planemo.cli
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.conda module
 --------------------
 
 .. automodule:: planemo.conda
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.conda\_lint module
 --------------------------
 
 .. automodule:: planemo.conda_lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.conda\_recipes module
 -----------------------------
 
 .. automodule:: planemo.conda_recipes
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.config module
 ---------------------
 
 .. automodule:: planemo.config
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.deps module
 -------------------
 
 .. automodule:: planemo.deps
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.docker module
 ---------------------
 
 .. automodule:: planemo.docker
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.exit\_codes module
 --------------------------
 
 .. automodule:: planemo.exit_codes
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.git module
 ------------------
 
 .. automodule:: planemo.git
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.github\_util module
 ---------------------------
 
 .. automodule:: planemo.github_util
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.glob module
 -------------------
 
 .. automodule:: planemo.glob
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.io module
 -----------------
 
 .. automodule:: planemo.io
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.lint module
 -------------------
 
 .. automodule:: planemo.lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.mulled module
 ---------------------
 
 .. automodule:: planemo.mulled
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.network\_util module
 ----------------------------
 
 .. automodule:: planemo.network_util
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.options module
 ----------------------
 
 .. automodule:: planemo.options
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.rscript\_parse module
 -----------------------------
 
 .. automodule:: planemo.rscript_parse
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.runnable module
 -----------------------
 
 .. automodule:: planemo.runnable
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.shed\_lint module
 -------------------------
 
 .. automodule:: planemo.shed_lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.templates module
 ------------------------
 
 .. automodule:: planemo.templates
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.tool\_builder module
 ----------------------------
 
 .. automodule:: planemo.tool_builder
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.tool\_lint module
 -------------------------
 
 .. automodule:: planemo.tool_lint
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.tools module
 --------------------
 
 .. automodule:: planemo.tools
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.virtualenv module
 -------------------------
 
 .. automodule:: planemo.virtualenv
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.shed.rst
+++ b/docs/planemo.shed.rst
@@ -8,23 +8,23 @@ planemo.shed.diff module
 ------------------------
 
 .. automodule:: planemo.shed.diff
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.shed.interface module
 -----------------------------
 
 .. automodule:: planemo.shed.interface
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.shed
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.shed2tap.rst
+++ b/docs/planemo.shed2tap.rst
@@ -8,15 +8,15 @@ planemo.shed2tap.base module
 ----------------------------
 
 .. automodule:: planemo.shed2tap.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.shed2tap
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.test.rst
+++ b/docs/planemo.test.rst
@@ -8,23 +8,23 @@ planemo.test.data module
 ------------------------
 
 .. automodule:: planemo.test.data
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.test.results module
 ---------------------------
 
 .. automodule:: planemo.test.results
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.training.rst
+++ b/docs/planemo.training.rst
@@ -8,39 +8,39 @@ planemo.training.tool\_input module
 -----------------------------------
 
 .. automodule:: planemo.training.tool_input
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.training.topic module
 -----------------------------
 
 .. automodule:: planemo.training.topic
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.training.tutorial module
 --------------------------------
 
 .. automodule:: planemo.training.tutorial
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.training.utils module
 -----------------------------
 
 .. automodule:: planemo.training.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.training
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo.xml.rst
+++ b/docs/planemo.xml.rst
@@ -8,23 +8,23 @@ planemo.xml.diff module
 -----------------------
 
 .. automodule:: planemo.xml.diff
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 planemo.xml.validation module
 -----------------------------
 
 .. automodule:: planemo.xml.validation
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: planemo.xml
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/planemo_ext.rst
+++ b/docs/planemo_ext.rst
@@ -5,6 +5,6 @@ Module contents
 ---------------
 
 .. automodule:: planemo_ext
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/planemo/conda_verify/recipe.py
+++ b/planemo/conda_verify/recipe.py
@@ -1,16 +1,35 @@
-from __future__ import print_function, division, absolute_import
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+)
 
 import os
 import re
-from os.path import basename, isfile, getsize, join
+from os.path import (
+    basename,
+    getsize,
+    isfile,
+    join,
+)
 
 import yaml
 
-from planemo.conda_verify.const import LICENSE_FAMILIES, FIELDS
-from planemo.conda_verify.utils import all_ascii, get_bad_seq, memoized
-
+from planemo.conda_verify.const import (
+    FIELDS,
+    LICENSE_FAMILIES,
+)
+from planemo.conda_verify.utils import (
+    all_ascii,
+    get_bad_seq,
+    memoized,
+)
 
 PEDANTIC = True
+sel_pat = re.compile(r'(.+?)\s*\[(.+)\]$')
+name_pat = re.compile(r'[a-z0-9_][a-z0-9_\-\.]*$')
+version_pat = re.compile(r'[\w\.]+$')
+url_pat = re.compile(r'(ftp|http(s)?)://')
 
 
 class RecipeError(Exception):
@@ -24,34 +43,33 @@ def ns_cfg(cfg):
     for x in py, np:
         assert isinstance(x, int), x
     return dict(
-        nomkl = False,
-        debug = False,
-        linux = plat.startswith('linux-'),
-        linux32 = bool(plat == 'linux-32'),
-        linux64 = bool(plat == 'linux-64'),
-        armv7l = False,
-        arm = False,
-        ppc64le = False,
-        osx = plat.startswith('osx-'),
-        unix = plat.startswith(('linux-', 'osx-')),
-        win = plat.startswith('win-'),
-        win32 = bool(plat == 'win-32'),
-        win64 = bool(plat == 'win-64'),
-        x86 = plat.endswith(('-32', '-64')),
-        x86_64 = plat.endswith('-64'),
-        py = py,
-        py3k = bool(30 <= py < 40),
-        py2k = bool(20 <= py < 30),
-        py26 = bool(py == 26),
-        py27 = bool(py == 27),
-        py33 = bool(py == 33),
-        py34 = bool(py == 34),
-        py35 = bool(py == 35),
-        np = np,
+        nomkl=False,
+        debug=False,
+        linux=plat.startswith('linux-'),
+        linux32=bool(plat == 'linux-32'),
+        linux64=bool(plat == 'linux-64'),
+        armv7l=False,
+        arm=False,
+        ppc64le=False,
+        osx=plat.startswith('osx-'),
+        unix=plat.startswith(('linux-', 'osx-')),
+        win=plat.startswith('win-'),
+        win32=bool(plat == 'win-32'),
+        win64=bool(plat == 'win-64'),
+        x86=plat.endswith(('-32', '-64')),
+        x86_64=plat.endswith('-64'),
+        py=py,
+        py3k=bool(30 <= py < 40),
+        py2k=bool(20 <= py < 30),
+        py26=bool(py == 26),
+        py27=bool(py == 27),
+        py33=bool(py == 33),
+        py34=bool(py == 34),
+        py35=bool(py == 35),
+        np=np,
     )
 
 
-sel_pat = re.compile(r'(.+?)\s*\[(.+)\]$')
 def select_lines(data, namespace):
     lines = []
     for line in data.splitlines():
@@ -98,7 +116,6 @@ def get_field(meta, field, default=None):
     return res
 
 
-name_pat = re.compile(r'[a-z0-9_][a-z0-9_\-\.]*$')
 def check_name(name):
     if name:
         name = str(name)
@@ -112,7 +129,6 @@ def check_name(name):
                           "package name: '%s'" % (seq, name))
 
 
-version_pat = re.compile(r'[\w\.]+$')
 def check_version(ver):
     if ver:
         ver = str(ver)
@@ -155,7 +171,6 @@ Allowed license families are:""" % lf)
         raise RecipeError("wrong license family")
 
 
-url_pat = re.compile(r'(ftp|http(s)?)://')
 def check_url(url):
     if not url_pat.match(url):
         raise RecipeError("not a valid URL: %s" % url)
@@ -182,6 +197,8 @@ def check_about(meta):
 hash_pat = {'md5': re.compile(r'[a-f0-9]{32}$'),
             'sha1': re.compile(r'[a-f0-9]{40}$'),
             'sha256': re.compile(r'[a-f0-9]{64}$')}
+
+
 def check_source(meta):
     src = meta.get('source')
     if not src:
@@ -231,7 +248,7 @@ def validate_files(recipe_dir, meta):
                 raise RecipeError("path outsite recipe: %s" % fn)
             path = join(recipe_dir, fn)
             if isfile(path):
-               continue
+                continue
             raise RecipeError("no such file '%s'" % path)
 
 
@@ -261,8 +278,7 @@ def check_dir_content(recipe_dir):
                     print("Warning: found: %s" % fn)
             path = join(root, fn)
             # only allow small archives for testing
-            if (PEDANTIC and fn_lower.endswith(('.bz2', '.gz')) and
-                         getsize(path) > 512):
+            if (PEDANTIC and fn_lower.endswith(('.bz2', '.gz')) and getsize(path) > 512):
                 raise RecipeError("found: %s (too large)" % fn)
 
     if basename(recipe_dir) == 'icu':

--- a/planemo/conda_verify/utils.py
+++ b/planemo/conda_verify/utils.py
@@ -1,8 +1,10 @@
-import sys
 import collections
+import sys
 
-from planemo.conda_verify.const import MAGIC_HEADERS, DLL_TYPES
-
+from planemo.conda_verify.const import (
+    DLL_TYPES,
+    MAGIC_HEADERS,
+)
 
 
 def get_object_type(data):
@@ -32,9 +34,9 @@ def get_bad_seq(s):
 
 
 def all_ascii(data, allow_CR=False):
-    newline = [10] # LF
+    newline = [10]  # LF
     if allow_CR:
-        newline.append(13) # CF
+        newline.append(13)  # CF
     for c in data:
         n = ord(c) if sys.version_info[0] == 2 else c
         if not (n in newline or 32 <= n < 127):
@@ -50,6 +52,7 @@ class memoized(object):
     def __init__(self, func):
         self.func = func
         self.cache = {}
+
     def __call__(self, *args):
         if not isinstance(args, collections.Hashable):
             # uncacheable. a list, for instance.

--- a/planemo/xml/xsd/tool/galaxy.xsd
+++ b/planemo/xml/xsd/tool/galaxy.xsd
@@ -47,7 +47,9 @@ A ``data_source`` tool contains a few more relevant attributes.
         <xs:element name="macros" type="Macros" minOccurs="0"/>
         <xs:element name="edam_topics" type="EdamTopics" minOccurs="0"/>
         <xs:element name="edam_operations" type="EdamOperations" minOccurs="0"/>
+        <xs:element name="xrefs" type="xrefs" minOccurs="0" />
         <xs:element name="requirements" type="Requirements" minOccurs="0"/>
+        <xs:element name="entry_points" type="EntryPoints" minOccurs="0" maxOccurs="1" />
         <xs:element name="description" type="xs:string" minOccurs="0">
           <xs:annotation gxdocs:best_practices="tool-descriptions">
             <xs:documentation xml:lang="en"><![CDATA[The value is displayed in
@@ -222,6 +224,74 @@ For more information, see https://planemo.readthedocs.io/en/latest/writing_advan
       <xs:element name="token" type="xs:anyType" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="xml" type="xs:anyType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EntryPoints">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+
+This is a container tag set for the ``entry_point`` tag that contains ``port`` and ``url`` tags
+described in greater detail below. ``entry_point``s describe InteractiveTool entry points
+to a tool.
+
+]]></xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="entry_point" type="EntryPoint" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="EntryPoint" mixed="true">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+
+This tag set is contained within the ``<entry_point>`` tag set. Access to entry point
+ports and urls are included in this tag set. These are used by InteractiveTools
+to provide access to graphical tools in real-time.
+
+```xml
+<entry_points>
+  <entry_point name="Example name">
+    <port>80</port>
+    <url>landing/${template_enabled}/index.html</url>
+  </entry_point>
+</entry_points>
+```
+
+]]></xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="port" type="EntryPointPort" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="url" type="EntryPointURL" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">This value defines the name of the entry point.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="requires_domain" type="PermissiveBoolean" default="false">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">This value declares if domain-based proxying is required. Default is False. Currently only works when True.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="EntryPointPort" mixed="true">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+
+This tag set is contained within the ``<entry_point>`` tag set. It contains the entry port.
+
+]]></xs:documentation>
+    </xs:annotation>
+  </xs:complexType>
+  <xs:complexType name="EntryPointURL" mixed="true">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+
+This tag set is contained within the ``<entry_point>`` tag set. It contains the entry URL.
+
+]]></xs:documentation>
+    </xs:annotation>
   </xs:complexType>
 
   <xs:complexType name="ToolAction">
@@ -715,6 +785,7 @@ specified and instead a series of assertions is made about the output.
             <!-- &#009; is XML escape code for tab -->
             <has_line line="chr7&#009;127471195&#009;127489808" />
             <has_n_columns n="3" />
+            <has_n_lines n="3" />
         </assert_contents>
     </output>
 </test>
@@ -1566,7 +1637,7 @@ many of the default assertion tags that come with Galaxy and examples of each
 can be found below.
 
 The implementation of these tags are simply Python functions defined in the
-[/lib/galaxy/tools/verify/asserts](https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/tools/verify/asserts)
+[/lib/galaxy/tool_util/verify/asserts](https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/tool_util/verify/asserts)
 module.
 ]]>
       </xs:documentation>
@@ -1598,6 +1669,12 @@ module.
       <xs:element name="has_line" type="xs:anyType">
         <xs:annotation>
           <xs:documentation><![CDATA[Asserts a line matching the specified string (``line``) appears in the output (e.g. ``<has_line line="A full example line." />``).]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="has_n_lines" type="xs:anyType">
+        <xs:annotation>
+          <xs:documentation><![CDATA[Asserts that an output contains ``n`` lines, e.g. ``<has_n_lines n="3" />``.]]>
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -1787,7 +1864,7 @@ statement. A good example tool that demonstrates many conditional parameters is
     </param>
     <when value="tsv">
         <param name="input_table" type="data" format="tabular" label="Tabular File" argument="--input-fp"/>
-        <param name="process_obs_metadata" type="select" label="Process metadata associated with observations when converting" argument="--process-obs-metadata">
+        <param argument="--process-obs-metadata" type="select" label="Process metadata associated with observations when converting">
             <option value="" selected="true">Do Not process metadata</option>
             <option value="taxonomy">taxonomy</option>
             <option value="naive">naive</option>
@@ -2352,9 +2429,10 @@ rendered as a one line text box (if ``false``, the default) or a multi-line text
 
 If the parameter reflects just one command line argument of a certain tool, this
 tag should be set to that particular argument. It is rendered in parenthesis
-after the help section, and it will create the name attribute from the argument
-attribute by stripping the dashes (e.g. if ``argument="--sensitive"`` then
-``name="sensitive"`` is implicit).
+after the help section, and it will create the name attribute (if not given explicitly)
+from the argument attribute by stripping leading dashes and replacing all remaining
+dashes by underscores (e.g. if ``argument="--long-parameter"`` then
+``name="long_parameter"`` is implicit).
 
 ]]></xs:documentation>
           </xs:annotation>
@@ -3495,7 +3573,7 @@ is the ``none`` preset.</xs:documentation>
   <xs:complexType name="Filter">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[Optionally contained within an
-``<options>`` tag set - filter out values obtained from a locally stored file (e.g.
+``<options>`` tag set - modify (e.g. remove, add, sort, ...) the list of values obtained from a locally stored file (e.g.
 a tool data table) or a dataset in the current history.
 
 ### Examples
@@ -3598,19 +3676,39 @@ demonstrates splitting up strings into multiple values.
     <xs:attribute name="type" type="FilterType" use="required">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
+Currently the following filters are defined:
+
+* ``static_value`` filter options for which the entry in a given ``column`` of the referenced file based on equality to the ``value`` attribute of the filter. 
+* ``regexp`` similar to the ``static_value`` filter, but checks if the regular expression given by ``value`` matches the entry.
+* ``param_value`` filter options for which the entry in a given ``column`` of the referenced file based on properties of another input parameter specified by ``ref``. This property is by default the value of the parameter, but also the values of another attribute (``ref_attribute``) of the parameter can be used, e.g. the extension of a data input.
+* ``data_meta`` If a ``column`` is given options are filtered for which the entry in this column ``column`` is equal to metadata of another input parameter specified by ``ref``. 
+If no ``column`` is given the metadata value of the referenced input is added to the options list (in this case the corresponding ``options`` tag must not have the ``from_data_table`` or ``from_dataset`` attributes). 
+In both cases the desired metadata is selected by ``key``.
+
+The above filters can be inverted by setting ``keep`` to true.
+
+* ``add_value``: add an option with a given ``name`` and ``value`` to the options. By default the new option is appended, with ``index`` the insertion position can be specified.
+* ``remove_value``: remove a value from the options. Either specified explicitly with ``value``, the value of another input specifified with ``ref``, or the metatdata ``key`` of another input ``meta_ref``.
+* ``unique_value``: remove options that have duplicate entries in the given ``column``.
+* ``sort_by``: sort options by the entries of a given ``column``.
+* ``multiple_splitter``: split the entries of the specified ``column``(s) in the referenced file using a ``separator``. Thereby the number of columns is increased. 
+
+Note that filters that are applyed after one of the latter two filters must not refer to 
+
 These values are defined in the module
 [/lib/galaxy/tools/parameters/dynamic_options.py](https://github.com/galaxyproject/galaxy/blob/master/lib/galaxy/tools/parameters/dynamic_options.py)
-in the ``filter_types`` dictionary. Currently defined values are: ``data_meta``,
-``param_value``, ``static_value``, ``unique_value``, ``multiple_splitter``,
-``attribute_value_splitter``, ``add_value``, ``remove_value``, and
-``sort_by``]]></xs:documentation>
+in the ``filter_types`` dictionary. 
+
+Deprecated filter types:
+
+* ``attribute_value_splitter`` 
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="column" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Column targeted by this filter - this
-attribute is unused and invalid if ``type`` is ``add_value`` or ``remove_value``.
-This can be a column index or a column name.</xs:documentation>
+        <xs:documentation xml:lang="en">Column targeted by this filter given as column index or a column name. Invalid if ``type`` is ``add_value`` or ``remove_value``.
+</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="name" type="xs:string">
@@ -3652,7 +3750,7 @@ only used if ``multiple`` is set to ``true``.]]></xs:documentation>
       <xs:annotation>
         <xs:documentation xml:lang="en">If ``true``, keep columns matching the
 value, if ``false`` discard columns matching the value. Used when ``type`` is
-either ``static_value`` or ``param_value``.</xs:documentation>
+either ``static_value``, ``regexp`` or ``param_value``.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="value" type="xs:string">
@@ -3660,7 +3758,7 @@ either ``static_value`` or ``param_value``.</xs:documentation>
         <xs:documentation xml:lang="en">Target value of the operations - has
 slightly different meanings depending on ``type``. For instance when ``type`` is
 ``add_value`` it is the value to add to the list and when ``type`` is
-``static_value`` it is the value compared against.</xs:documentation>
+``static_value`` or ``regexp`` it is the value compared against.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="ref_attribute" type="xs:string">
@@ -4582,6 +4680,11 @@ variable instead of shell variable.
 define.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="strip" type="PermissiveBoolean" default="false">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Whether to strip leading and trailing whitespace from the calculated value before exporting the environment variable.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -5352,6 +5455,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="data_source"/>
       <xs:enumeration value="manage_data"/>
+      <xs:enumeration value="interactive"/>
       <xs:enumeration value="expression"/>
     </xs:restriction>
   </xs:simpleType>
@@ -5432,6 +5536,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:enumeration value="data_meta"/>
       <xs:enumeration value="param_value"/>
       <xs:enumeration value="static_value"/>
+      <xs:enumeration value="regexp"/>
       <xs:enumeration value="unique_value"/>
       <xs:enumeration value="multiple_splitter"/>
       <xs:enumeration value="add_value"/>
@@ -5491,6 +5596,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:enumeration value="fatal"/>
       <xs:enumeration value="warning"/>
       <xs:enumeration value="log"/>
+      <xs:enumeration value="qc"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="RangeType">
@@ -5581,14 +5687,60 @@ A tool can have any number of EDAM operation references.
 ]]></xs:documentation>
     </xs:annotation>
     <xs:sequence>
-        <xs:element name="edam_operation" minOccurs="0" maxOccurs="unbounded">
-          <xs:simpleType>
-            <xs:restriction base="xs:string">
-              <xs:pattern value="operation_[0-9]{4}"></xs:pattern>
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:element>
-      </xs:sequence>
-    </xs:complexType>
+      <xs:element name="edam_operation" minOccurs="0" maxOccurs="unbounded">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="operation_[0-9]{4}"></xs:pattern>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="xrefs">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+Container tag set for the ``<xref>`` tags.
+A tool can refer multiple reference IDs.
+	
+```xml
+   <!-- Example: this tool is seqtk -->
+   <xrefs>
+	<xref type="bio.tools">seqtk</xref>
+   </xrefs>
+   <!-- https://bio.tools/seqtk -->
+```
+
+]]></xs:documentation>
+    </xs:annotation>
+      <xs:sequence>
+        <xs:element name="xref" type="xref" minOccurs="0" maxOccurs="unbounded">
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="xref">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">The ``xref`` element specifies reference
+information according to a catalog.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="type" type="xrefType" use="required">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Type of reference - currently ``bio.tools``
+is the only supported options.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="xrefType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Type of Reference.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="bio.tools"/>
+      <!--xs:enumeration value="whatelse"/-->
+    </xs:restriction>
+  </xs:simpleType>
 
 </xs:schema>

--- a/scripts/lint_sphinx_output.py
+++ b/scripts/lint_sphinx_output.py
@@ -24,7 +24,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv
     sphinx_output = sys.stdin.read()
-    warning_lines = filter(warning_line, sphinx_output.splitlines())
+    warning_lines = [_ for _ in sphinx_output.splitlines() if warning_line(_)]
     for line in warning_lines:
         print(line)
     sys.exit(1 if warning_lines else 0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,6 @@ logging-level=INFO
 [flake8]
 max-line-length = 150
 max-complexity = 13
-exclude=.eggs,.git,.tox,.venv,.venv3,build,docs/conf.py,docs/standards,planemo/cwl/cwl2script,planemo/conda_verify,planemo_ext/tool_factory_2/rgToolFactory2.py
+exclude=.eggs,.git,.tox,.venv,.venv3,build,docs/conf.py,docs/standards,planemo/cwl/cwl2script,planemo_ext/tool_factory_2/rgToolFactory2.py
 import-order-style = smarkets
 application-import-names = planemo,test

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,36 @@
 [tox]
-envlist = py{27,34,35,36}-lint, py{27,34,35,36}-quick, py27-lint-docstrings, py27-lint-readme, py27-lint-docs, py{27,34,35,36}, py{27,34,35,36}-gx-{master,dev,1805,1801,1709,1705}, doc-test
+envlist = py{27,37}-lint, py37-quick, py37-lint_docstrings, py37-lint_readme, py37-lint_docs, py{27,37}-unit
 source_dir = planemo
 test_dir = tests
 
 [testenv]
-commands = nosetests
+commands =
+    lint: flake8
+    lint_docs: make lint-docs
+    lint_docstrings: flake8 {[tox]source_dir} {[tox]test_dir}
+    lint_readme: make lint-readme
+    quick,unit: nosetests []
 passenv = 
     PLANEMO_*
     NOSE_*
     HOME
     DOCS
 deps =
-    -rrequirements.txt
-    nose
-    coverage
-    flask
+    lint: flake8-import-order
+    lint,lint_docstrings: flake8
+    lint_docs: -rdev-requirements.txt
+    lint_docs,quick,unit: -rrequirements.txt
+    lint_docstrings: flake8_docstrings
+    lint_readme: readme
+    quick,unit: nose
+    quick,unit: coverage
+    quick,unit: flask
 setenv =
     quick: PLANEMO_SKIP_SLOW_TESTS=1
     quick: PLANEMO_SKIP_GALAXY_TESTS=1
-    py27: PLANEMO_SKIP_PYTHON3=1
-    py36: PLANEMO_SKIP_PYTHON2=1
-    py36: PLANEMO_DEFAULT_PYTHON_VERSION=3
+    py27-unit: PLANEMO_SKIP_PYTHON3=1
+    !py27-unit: PLANEMO_SKIP_PYTHON2=1
+    !py27-unit: PLANEMO_DEFAULT_PYTHON_VERSION=3
     gx: NOSE_ATTR=tests_galaxy_branch
     master: PLANEMO_TEST_GALAXY_BRANCH=master
     dev: PLANEMO_TEST_GALAXY_BRANCH=dev
@@ -28,47 +38,13 @@ setenv =
     1801: PLANEMO_TEST_GALAXY_BRANCH=release_18.01
     1709: PLANEMO_TEST_GALAXY_BRANCH=release_17.09
     1705: PLANEMO_TEST_GALAXY_BRANCH=release_17.05
+skip_install =
+    doc_test,lint,lint_docs,lint_docstrings,lint_readme: True
+whitelist_externals =
+    lint_docs,lint_readme: make
 
-[testenv:py27-lint]
-commands = flake8
-skip_install = True
-deps =
-     flake8
-     flake8-import-order
-
-[testenv:py27-lint-docstrings]
-commands = flake8 {[tox]source_dir} {[tox]test_dir}
-skip_install = True
-deps =
-    flake8
-    flake8_docstrings
-
-[testenv:py36-lint]
-commands = flake8
-skip_install = True
-deps =
-     flake8
-     flake8-import-order
-
-[testenv:py27-lint-readme]
-commands = make lint-readme
-skip_install = True
-whitelist_externals = make
-deps =
-    readme
-
-[testenv:py27-lint-docs]
-commands = make lint-docs
-skip_install = True
-whitelist_externals = make
-deps =
-    -rrequirements.txt
-    -rdev-requirements.txt
-
-[testenv:doc-test]
+[testenv:doc_test]
 commands = bash scripts/run_doc_test.sh
-skip_install = True
 skipsdist = True
 whitelist_externals = bash
 deps = 
-


### PR DESCRIPTION
- Drop Python 3.4.
- Refactor `tox.ini`
- Add Python3 support to some files
- Update docs
- Update `galaxy.xsd` from upstream