### PR TITLE
Add merge_test_reports command

### DIFF
--- a/planemo/commands/cmd_merge_test_reports.py
+++ b/planemo/commands/cmd_merge_test_reports.py
@@ -1,0 +1,22 @@
+"""Module describing the planemo ``test_reports`` command."""
+import os
+
+import click
+
+from planemo import io
+from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy.test.actions import merge_reports
+
+
+@click.command('merge_test_reports')
+@options.merge_test_json()
+@options.tool_test_json('output_path')
+@command_function
+def cli(ctx, input_paths, output_path, **kwds):
+    """Merge tool_test_output.json files from multiple runs."""
+    for input_path in input_paths:
+        if not os.path.exists(input_path):
+            io.error("Failed to tool test json file at %s" % input_path)
+            return 1
+    merge_reports(input_paths=input_paths, output_path=output_path)

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -131,6 +131,19 @@ def handle_reports_and_summary(ctx, structured_data, exit_code=None, kwds={}):
     return exit_code if exit_code is not None else summary_exit_code
 
 
+def merge_reports(input_paths, output_path):
+    reports = []
+    for path in input_paths:
+        with io.open(path, encoding='utf-8') as f:
+            reports.append(json.load(f))
+    tests = []
+    for report in reports:
+        tests.extend(report["tests"])
+    merged_report = {"tests": tests for report in reports}
+    with io.open(output_path, mode="w", encoding='utf-8') as out:
+        json.dump(merged_report, out)
+
+
 def handle_reports(ctx, structured_data, kwds):
     """Write reports based on user specified kwds."""
     exceptions = []

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -139,7 +139,7 @@ def merge_reports(input_paths, output_path):
     tests = []
     for report in reports:
         tests.extend(report["tests"])
-    merged_report = {"tests": tests for report in reports}
+    merged_report = {"tests": tests}
     with io.open(output_path, mode="w", encoding='utf-8') as out:
         json.dump(merged_report, out)
 

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -141,7 +141,7 @@ def merge_reports(input_paths, output_path):
         tests.extend(report["tests"])
     merged_report = {"tests": tests}
     with io.open(output_path, mode="w", encoding='utf-8') as out:
-        json.dump(merged_report, out)
+        out.write(unicodify(json.dumps(merged_report)))
 
 
 def handle_reports(ctx, structured_data, kwds):

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1328,14 +1328,28 @@ def recursive_option(help="Recursively perform command for subdirectories."):
     )
 
 
-def tool_test_json():
+def merge_test_json():
     target_path = click.Path(
         file_okay=True,
         dir_okay=False,
         resolve_path=True,
     )
     return click.argument(
-        'path',
+        'input_paths',
+        metavar="INPUT_PATHS",
+        type=target_path,
+        nargs=-1,
+    )
+
+
+def tool_test_json(var="path"):
+    target_path = click.Path(
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+    )
+    return click.argument(
+        var,
         metavar="FILE_PATH",
         type=target_path,
         default="tool_test_output.json",

--- a/tests/test_merge_reports.py
+++ b/tests/test_merge_reports.py
@@ -1,0 +1,11 @@
+import os
+
+from .test_utils import CliTestCase, TEST_DATA_DIR
+
+
+class TestReportsTestCase(CliTestCase):
+
+    def test_merge_reports(self):
+        with self._isolate():
+            json_path = os.path.join(TEST_DATA_DIR, "issue381.json")
+            self._check_exit_code(["merge_test_reports", json_path, json_path, json_path, "out.json"], exit_code=0)


### PR DESCRIPTION
That will be useful when running all tool tests divided up into chunks and then combining the output. Could also be done with `jq`, but couldn't quite figure out how to get this right.