### PR TITLE
Use tojson jinja2 filter instead of json.dumps

### DIFF
--- a/planemo/reports/report_html.tpl
+++ b/planemo/reports/report_html.tpl
@@ -78,7 +78,7 @@
         .success(function(content) { renderTestResults( $.parseJSON(content) ); })
         .failure(function() { alert("Failed to load test data.")} );
       } else {
-        var test_data = {{ json.dumps(raw_data) }};
+        var test_data = {{ raw_data|tojson }};
         renderTestResults(test_data);
       }
     </script>


### PR DESCRIPTION
This handles proper escaping and is required to render the result html
for https://github.com/mvdbeek/tools-iuc/commit/632d398ea17dddaf292d92d4796e0a2c355c0956/checks?check_suite_id=331184102