### PR TITLE
Build single requirement container, log if requirement not in best-pr…

### DIFF
--- a/planemo/commands/cmd_container_register.py
+++ b/planemo/commands/cmd_container_register.py
@@ -81,10 +81,9 @@ def cli(ctx, paths, **kwds):
                 ctx.log("Target [%s] is not available in best practice channels - skipping" % conda_target)
                 best_practice_requirements = False
             if not exact:
-                ctx.log("Target version [%s] for package [%s] is not available in best practice channels - skipping",
+                ctx.log("Target version [%s] for package [%s] is not available in best practice channels - please specify the full version",
                         conda_target.version,
                         conda_target.package)
-                best_practice_requirements = False
 
         if not best_practice_requirements:
             continue

--- a/planemo/commands/cmd_container_register.py
+++ b/planemo/commands/cmd_container_register.py
@@ -74,29 +74,40 @@ def cli(ctx, paths, **kwds):
         ctx.vlog("Handling conda_targets [%s]" % conda_targets)
         mulled_targets = conda_to_mulled_targets(conda_targets)
         mulled_targets_str = "- " + "\n- ".join(map(conda_build_target_str, mulled_targets))
-        if len(mulled_targets) < 2:
-            ctx.vlog("Skipping registeration, fewer than 2 targets discovered.")
-            # Skip these for now, we will want to revisit this for conda-forge dependencies and such.
-            continue
-
         best_practice_requirements = True
         for conda_target in conda_targets:
             best_hit, exact = best_practice_search(conda_target, conda_context=conda_context)
-            if not best_hit or not exact:
-                ctx.vlog("Target [%s] is not available in best practice channels - skipping" % conda_target)
+            if not best_hit:
+                ctx.log("Target [%s] is not available in best practice channels - skipping" % conda_target)
+                best_practice_requirements = False
+            if not exact:
+                ctx.log("Target version [%s] for package [%s] is not available in best practice channels - skipping",
+                        conda_target.version,
+                        conda_target.package)
                 best_practice_requirements = False
 
         if not best_practice_requirements:
             continue
 
-        name = v2_image_name(mulled_targets)
-        tag = "0"
-        name_and_tag = "%s-%s" % (name, tag)
-        target_filename = os.path.join(registry_target.output_directory, "%s.tsv" % name_and_tag)
-        ctx.vlog("Target filename for registeration is [%s]" % target_filename)
-        if os.path.exists(target_filename):
-            ctx.vlog("Target file already exists, skipping")
+        if len(mulled_targets) < 1:
+            ctx.log("Skipping registration, no targets discovered.")
             continue
+
+        name = v2_image_name(mulled_targets)
+
+        if len(mulled_targets) == 1:
+            target_filename = os.path.join(registry_target.output_directory, "hash.tsv")
+            if registry_target.targets_in_file(ctx, target_filename, mulled_targets):
+                ctx.log("'%s' already in hash.tsv, skipping" % to_target_str(mulled_targets))
+                continue
+
+        elif len(mulled_targets) > 1:
+            tag = "0"
+            name_and_tag = "%s-%s" % (name, tag)
+            target_filename = os.path.join(registry_target.output_directory, "%s.tsv" % name_and_tag)
+            if os.path.exists(target_filename):
+                ctx.log("Target file '%s' already exists, skipping" % target_filename)
+                continue
 
         namespace = kwds["mulled_namespace"]
         repo_data = quay_repository(namespace, name)
@@ -163,17 +174,29 @@ class RegistryTarget(object):
             pull_request(ctx, self.target_repository, message=message)
 
     def write_targets(self, ctx, target_filename, mulled_targets):
-        with open(target_filename, "w") as f:
-            target_strings = list()
-            for target in mulled_targets:
-                if target.version:
-                    target_str = "%s=%s" % (target.package_name, target.version)
-                else:
-                    target_str = target.package_name
-                target_strings.append(target_str)
-            contents = ",".join(target_strings)
-            f.write(contents)
-            ctx.vlog("Wrote requirements [%s] to file [%s]" % (contents, target_filename))
+        with open(target_filename, "a") as f:
+            contents = to_target_str(mulled_targets)
+            f.write("%s\n" % contents)
+            ctx.log("Wrote requirements [%s] to file [%s]" % (contents, target_filename))
+
+    def targets_in_file(self, ctx, target_filename, targets):
+        target_str = to_target_str(targets)
+        with open(target_filename) as build_tsv:
+            for line in build_tsv:
+                if line.strip() == target_str:
+                    return True
+        return False
+
+
+def to_target_str(targets):
+    target_strings = []
+    for target in targets:
+        if target.version:
+            target_str = "%s=%s" % (target.package_name, target.version)
+        else:
+            target_str = target.package_name
+        target_strings.append(target_str)
+    return ",".join(target_strings)
 
 
 def open_prs(ctx):

--- a/planemo/commands/cmd_container_register.py
+++ b/planemo/commands/cmd_container_register.py
@@ -165,7 +165,7 @@ class RegistryTarget(object):
             pull_request(ctx, self.target_repository, message=message)
 
     def write_targets(self, ctx, target_filename, mulled_targets):
-        with open(target_filename, "a") as f:
+        with open(target_filename, "w") as f:
             contents = to_target_str(mulled_targets)
             f.write("%s\n" % contents)
             ctx.log("Wrote requirements [%s] to file [%s]" % (contents, target_filename))

--- a/planemo/commands/cmd_container_register.py
+++ b/planemo/commands/cmd_container_register.py
@@ -93,20 +93,12 @@ def cli(ctx, paths, **kwds):
             continue
 
         name = v2_image_name(mulled_targets)
-
-        if len(mulled_targets) == 1:
-            target_filename = os.path.join(registry_target.output_directory, "hash.tsv")
-            if registry_target.targets_in_file(ctx, target_filename, mulled_targets):
-                ctx.log("'%s' already in hash.tsv, skipping" % to_target_str(mulled_targets))
-                continue
-
-        elif len(mulled_targets) > 1:
-            tag = "0"
-            name_and_tag = "%s-%s" % (name, tag)
-            target_filename = os.path.join(registry_target.output_directory, "%s.tsv" % name_and_tag)
-            if os.path.exists(target_filename):
-                ctx.log("Target file '%s' already exists, skipping" % target_filename)
-                continue
+        tag = "0"
+        name_and_tag = "%s-%s" % (name, tag)
+        target_filename = os.path.join(registry_target.output_directory, "%s.tsv" % name_and_tag)
+        if os.path.exists(target_filename):
+            ctx.log("Target file '%s' already exists, skipping" % target_filename)
+            continue
 
         namespace = kwds["mulled_namespace"]
         repo_data = quay_repository(namespace, name)
@@ -177,14 +169,6 @@ class RegistryTarget(object):
             contents = to_target_str(mulled_targets)
             f.write("%s\n" % contents)
             ctx.log("Wrote requirements [%s] to file [%s]" % (contents, target_filename))
-
-    def targets_in_file(self, ctx, target_filename, targets):
-        target_str = to_target_str(targets)
-        with open(target_filename) as build_tsv:
-            for line in build_tsv:
-                if line.strip() == target_str:
-                    return True
-        return False
 
 
 def to_target_str(targets):

--- a/planemo/github_util.py
+++ b/planemo/github_util.py
@@ -116,6 +116,8 @@ def _get_raw_github_config(ctx):
                 "username": os.environ["GITHUB_USER"],
                 "password": os.environ["GITHUB_PASSWORD"],
             }
+    if "github" not in ctx.global_config:
+        raise Exception("github account not found in planemo config and GITHUB_USER / GITHUB_PASSWORD environment variables unset")
     return ctx.global_config["github"]
 
 


### PR DESCRIPTION
…actice channels

This also revealed quite a headache: We frequently don't specify exact versions in tool requirements (e.g `<requirement type="package" version="3.7">conda</requirement>`) instead of the full 3.7.1. This is very widespread in Galaxy tools. A single requirement like this will prevent building a container :(.