### PR TITLE
Make symlinks in tool tree work for planemo test

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -1,6 +1,4 @@
 """Module describing the planemo ``test`` command."""
-from distutils.dir_util import copy_tree
-
 import click
 
 from planemo import options
@@ -96,13 +94,10 @@ def cli(ctx, paths, **kwds):
         else:
             ctx.vlog("Running traditional Galaxy tool tests using run_tests.sh in Galaxy root %s" % engine_type)
             kwds["for_tests"] = True
+            if kwds.get('update_test_data'):
+                non_copied_runnables = for_paths(paths)
+                kwds['test_data_target_dir'] = _find_test_data(non_copied_runnables, **kwds)
             with galaxy_config(ctx, runnables, **kwds) as config:
                 return_value = run_in_config(ctx, config, **kwds)
-                if kwds.get('update_test_data'):
-                    non_copied_runnables = for_paths(paths)
-                    target = _find_test_data(non_copied_runnables, **kwds)
-                    if config.test_data_dir != target:
-                        ctx.vlog("Copying %s to %s" % (config.test_data_dir, target))
-                        copy_tree(config.test_data_dir, target)
 
     ctx.exit(return_value)

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -80,12 +80,12 @@ def cli(ctx, paths, **kwds):
     with temp_directory(dir=ctx.planemo_directory) as temp_path:
         # Create temp dir(s) outside of temp, docker can't mount $TEMPDIR on OSX
         runnables = for_paths(paths, temp_path=temp_path)
-        is_cwl = all([r.type in [RunnableType.cwl_tool, RunnableType.cwl_workflow] for r in runnables])
-        if kwds.get("engine", None) is None:
+        is_cwl = all(r.type in {RunnableType.cwl_tool, RunnableType.cwl_workflow} for r in runnables)
+        if kwds.get("engine") is None:
             kwds["engine"] = "galaxy" if not is_cwl else "cwltool"
 
         engine_type = kwds["engine"]
-        test_engine_testable = (RunnableType.galaxy_tool, RunnableType.galaxy_datamanager, RunnableType.directory)
+        test_engine_testable = {RunnableType.galaxy_tool, RunnableType.galaxy_datamanager, RunnableType.directory}
         enable_test_engines = any(r.type not in test_engine_testable for r in runnables)
         enable_test_engines = enable_test_engines or engine_type != "galaxy"
         if enable_test_engines:

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -3,9 +3,9 @@
 import io
 import json
 import os
+from distutils.dir_util import copy_tree
 
 import click
-from galaxy.tool_util.deps.commands import shell
 from galaxy.util import unicodify
 
 from planemo.exit_codes import (
@@ -41,7 +41,7 @@ GENERIC_PROBLEMS_MESSAGE = ("One or more tests failed. See %s for detailed "
 GENERIC_TESTS_PASSED_MESSAGE = "No failing tests encountered."
 
 
-def run_in_config(ctx, config, run=run_galaxy_command, **kwds):
+def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None, **kwds):
     """Run Galaxy tests with the run_tests.sh command.
 
     The specified `config` object describes the context for tool
@@ -96,8 +96,7 @@ def run_in_config(ctx, config, run=run_galaxy_command, **kwds):
         action
     )
     if kwds.get('update_test_data', False):
-        update_cp_args = (job_output_files, config.test_data_dir)
-        shell('cp -r "%s"/* "%s"' % update_cp_args)
+        copy_tree(job_output_files, test_data_target_dir or config.test_data_dir)
 
     _check_test_outputs(xunit_report_file_tracker, structured_report_file_tracker)
     test_results = test_structures.GalaxyTestResults(

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -167,8 +167,14 @@ def real_io():
 
 
 @contextlib.contextmanager
-def temp_directory(prefix="planemo_tmp_"):
-    temp_dir = tempfile.mkdtemp(prefix=prefix)
+def temp_directory(prefix="planemo_tmp_", dir=None, **kwds):
+    if dir is not None:
+        try:
+            os.makedirs(dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+    temp_dir = tempfile.mkdtemp(prefix=prefix, dir=dir, **kwds)
     try:
         yield temp_dir
     finally:

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -101,7 +101,7 @@ def _runnable_delegate_attribute(attribute):
 
 def _copy_runnable_tree(path, runnable_type, temp_path):
     dir_to_copy = None
-    if runnable_type in (RunnableType.galaxy_tool, RunnableType.cwl_tool):
+    if runnable_type in {RunnableType.galaxy_tool, RunnableType.cwl_tool}:
         dir_to_copy = os.path.dirname(path)
         path = os.path.join(temp_path, os.path.basename(path))
     elif runnable_type == RunnableType.directory:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/planemo/issues/857 and https://github.com/galaxyproject/planemo/issues/865
Symlinks were problematic when the symlink pointed out of the tool
directory. This was not a problem when uploading to the tool shed,
because we'd dereference the symlinks when creating the repository
archive. So here we just copy the tool tree with shutil.copytree,
which dereferences symlinks by default.