### PR TITLE
More fine grained options for --shed_install

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -726,7 +726,12 @@ class BaseGalaxyConfig(GalaxyInterface):
 
     def _install_workflow(self, runnable):
         if self._kwds["shed_install"]:
-            install_shed_repos(runnable, self.gi, self._kwds.get("ignore_dependency_problems", False))
+            install_shed_repos(runnable,
+                               self.gi,
+                               self._kwds.get("ignore_dependency_problems", False),
+                               self._kwds.get("install_tool_dependencies", False),
+                               self._kwds.get("install_resolver_dependencies", True),
+                               self._kwds.get("install_repository_dependencies", True))
 
         default_from_path = self._kwds.get("workflows_from_path", False)
         # TODO: Allow serialization so this doesn't need to assume a

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -37,11 +37,18 @@ def load_shed_repos(runnable):
     return tools
 
 
-def install_shed_repos(runnable, admin_gi, ignore_dependency_problems):
+def install_shed_repos(runnable, admin_gi,
+                       ignore_dependency_problems,
+                       install_tool_dependencies=False,
+                       install_resolver_dependencies=True,
+                       install_repository_dependencies=True):
     tools_info = load_shed_repos(runnable)
     if tools_info:
         install_tool_manager = shed_tools.InstallRepositoryManager(admin_gi)
-        install_results = install_tool_manager.install_repositories(tools_info)
+        install_results = install_tool_manager.install_repositories(tools_info,
+                                                                    default_install_tool_dependencies=install_tool_dependencies,
+                                                                    default_install_resolver_dependencies=install_resolver_dependencies,
+                                                                    default_install_repository_dependencies=install_repository_dependencies)
         if install_results.errored_repositories:
             if ignore_dependency_problems:
                 warn(FAILED_REPOSITORIES_MESSAGE)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -617,6 +617,33 @@ def shed_install_option():
     )
 
 
+def install_tool_dependencies_option():
+    return planemo_option(
+        "--install_tool_dependencies/--no_install_tool_dependencies",
+        is_flag=True,
+        default=False,
+        help=("Turn on installation of tool dependencies using classic toolshed packages.")
+    )
+
+
+def install_resolver_dependencies_option():
+    return planemo_option(
+        "--install_resolver_dependencies/--no_install_resolver_dependencies",
+        is_flag=True,
+        default=True,
+        help=("Skip installing tool dependencies through resolver (e.g. conda).")
+    )
+
+
+def install_repository_dependencies_option():
+    return planemo_option(
+        "--install_repository_dependencies/--no_install_repository_dependencies",
+        is_flag=True,
+        default=True,
+        help=("Skip installing the repository dependencies.")
+    )
+
+
 def single_user_mode_option():
     return planemo_option(
         "galaxy_single_user",
@@ -1353,6 +1380,9 @@ def engine_options():
         docker_extra_volume_option(),
         ignore_dependency_problems_option(),
         shed_install_option(),
+        install_tool_dependencies_option(),
+        install_resolver_dependencies_option(),
+        install_repository_dependencies_option(),
         galaxy_url_option(),
         galaxy_admin_key_option(),
         galaxy_user_key_option(),


### PR DESCRIPTION
`--shed_install` uses the default options for installing tools from Ephemeris, resulting in automatic dependency resolution/installation on first run (see: https://github.com/galaxyproject/ephemeris/blob/6a01ac3de3f8e40145365523e3ae8807b9072282/src/ephemeris/shed_tools.py#L103). In some situations, where installing dependencies is not necessary (for example when using containers), disabling this would result in faster execution time.

With this change, the options `--install_tool_dependencies`, `--install_resolver_dependencies`, and `--install_repository_dependencies` are introduced, which enables to define tool installation using `--shed_install` more fine grained. The default options stay the same, so there should be no breaking change to existing usage.
