### PR TITLE
sort tests by id when merging

### DIFF
--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -138,6 +138,7 @@ def merge_reports(input_paths, output_path):
     tests = []
     for report in reports:
         tests.extend(report["tests"])
+    tests = sorted(tests, key=lambda k: k['id'])
     merged_report = {"tests": tests}
     with io.open(output_path, mode="w", encoding='utf-8') as out:
         out.write(unicodify(json.dumps(merged_report)))


### PR DESCRIPTION
Was a little paper cut for me when looking at larger reports (e.g. IUC CI results) that were not sorted alphabetically.