### PR TITLE
Redo testing.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: Python CI
 on: [push, pull_request]
 env:
-  PLANEMO_SKIP_REDUNDANT_TESTS: 1
   PLANEMO_ENABLE_POSTGRES_TESTS: 1
   PLANEMO_SKIP_GALAXY_CWL_TESTS: 1
   PLANEMO_TEST_WORKFLOW_RUN_PROFILE: 1
@@ -10,6 +9,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -17,8 +17,18 @@ jobs:
         tox-action:
           - lint
           - lint_docs
-          - quick
-          - unit
+          - unit-quick
+          #- unit-diagnostic-servebasic
+          #- unit-diagnostic-servebasic-gx-2005
+          #- unit-diagnostic-servebasic-gx-master
+          - unit-diagnostic-servebasic-gx-dev
+          #- unit-diagnostic-servetraining
+          #- unit-diagnostic-servecmd
+          #- unit-diagnostic-trainingwfcmd
+          - unit-nonredundant-noclientbuild-noshed-gx-2005
+          - unit-nonredundant-noclientbuild-noshed-gx-dev
+          - unit-nonredundant-noclientbuild-noshed
+          - unit-diagnostic-serveclientcmd
     services:
       postgres:
         image: postgres:10.8
@@ -45,6 +55,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox coveralls
+      - name: Checkout system space
+        run: |
+          df
       - name: Test with tox
         run: |
           TOXENV=$(echo $TOXENV | sed 's/\.//') tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,19 @@ matrix:
   include:
     - python: 3.7
       env: TOX_ENV=py37-lint_docstrings
+    - python: 3.7
+      env: TOX_ENV=py37-unit-diagnostic-serveshed
+    - python: 3.7
+      env: TOX_ENV=py37-unit-quick
+    - python: 3.7
+      env: TOX_ENV=py37-unit-nonredundant-noclientbuild-noshed-gx-2005
+    - python: 3.7
+      env: TOX_ENV=py37-unit-nonredundant-noclientbuild-noshed-gx-master
+    - python: 3.7
+      env: TOX_ENV=py37-unit-diagnostic-serveshedcmd-gx-master
   allow_failures:
     - env: TOX_ENV=py37-lint_docstrings
+    - env: TOX_ENV=py37-unit-diagnostic-serveshedcmd-gx-master
 
 install:
   - pip install tox

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Default tests run with make test and make quick-tests
-NOSE_TESTS?=tests planemo
+TESTS?=tests planemo
 # Default environment for make tox
 ENV?=py27
 # Extra arguments supplied to tox command
@@ -74,13 +74,13 @@ flake8: ## check style using flake8 for current Python (faster than lint)
 	$(IN_VENV) flake8 $(SOURCE_DIR) $(TEST_DIR)
 
 lint: ## check style using tox and flake8 for Python 2 and Python 3
-	$(IN_VENV) tox -e py27-lint && tox -e py37-lint
+	$(IN_VENV) tox -e py36-lint
 
 test: ## run tests with the default Python (faster than tox)
-	$(IN_VENV) nosetests $(NOSE_TESTS)
+	$(IN_VENV) pytest $(TESTS)
 
 quick-test: ## run quickest tests with the default Python
-	$(IN_VENV) PLANEMO_SKIP_SLOW_TESTS=1 PLANEMO_SKIP_GALAXY_TESTS=1 nosetests $(NOSE_TESTS)
+	$(IN_VENV) PLANEMO_SKIP_SLOW_TESTS=1 PLANEMO_SKIP_GALAXY_TESTS=1 pytest $(TESTS)
 
 tox: ## run tests with tox in the specified ENV, defaults to py27
 	$(IN_VENV) tox -e $(ENV) -- $(ARGS)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ Werkzeug
 
 # For testing
 tox
-nose
+pytest
 coverage
 
 #Building Docs

--- a/planemo/bioblend.py
+++ b/planemo/bioblend.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-
+"""Planemo layer for ensuring bioblend available."""
 try:
     from bioblend import toolshed
     from bioblend import galaxy
@@ -13,5 +12,6 @@ BIOBLEND_UNAVAILABLE = ("This functionality requires the bioblend library "
 
 
 def ensure_module():
+    """Throw an exception if bioblend is not available to Planemo."""
     if toolshed is None:
         raise Exception(BIOBLEND_UNAVAILABLE)

--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -39,5 +39,5 @@ def cli(ctx, uris, **kwds):
     """
     paths = uris_to_paths(ctx, uris)
     runnables = for_paths(paths)
-    kwds['galaxy_skip_client_build'] = False
+    kwds['galaxy_skip_client_build'] = kwds.pop("skip_client_build", False)
     galaxy_serve(ctx, runnables, **kwds)

--- a/planemo/commands/cmd_shed_serve.py
+++ b/planemo/commands/cmd_shed_serve.py
@@ -11,10 +11,7 @@ from planemo.galaxy.serve import sleep_for_serve
 
 @click.command("shed_serve")
 @options.shed_read_options()
-@options.galaxy_run_options()
-@options.galaxy_config_options()
-@options.pid_file_option()
-@options.daemon_option()
+@options.galaxy_serve_options()
 @click.option(
     "--skip_dependencies",
     is_flag=True,
@@ -30,7 +27,7 @@ def cli(ctx, paths, **kwds):
     install these artifacts, and serve a Galaxy instances that can be
     logged into and explored interactively.
     """
-    kwds['galaxy_skip_client_build'] = False
+    kwds['galaxy_skip_client_build'] = kwds.pop("skip_client_build", False)
     install_args_list = shed.install_arg_lists(ctx, paths, **kwds)
     with shed_serve(ctx, install_args_list, **kwds) as config:
         io.info("Galaxy running with tools installed at %s" % config.galaxy_url)

--- a/planemo/commands/cmd_training_generate_from_wf.py
+++ b/planemo/commands/cmd_training_generate_from_wf.py
@@ -15,5 +15,8 @@ from planemo.training import Training
 def cli(ctx, uris, **kwds):
     """Create tutorial skeleton from workflow."""
     kwds["no_dependency_resolution"] = True
+    # Ugh rather than override this - it just needs to not be in the serve options
+    # for this command.
+    kwds["skip_client_build"] = True
     training = Training(kwds)
     training.generate_tuto_from_wf(ctx)

--- a/planemo/conda_recipes.py
+++ b/planemo/conda_recipes.py
@@ -1,7 +1,4 @@
-"""Planemo specific utilities for dealing with conda recipe generation.
-"""
-
-from __future__ import absolute_import
+"""Planemo specific utilities for dealing with conda recipe generation."""
 
 import os
 

--- a/planemo/deps.py
+++ b/planemo/deps.py
@@ -1,3 +1,4 @@
+"""Abstractions for building dependency resolution configurations."""
 import tempfile
 from string import Template
 

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -7,7 +7,7 @@ import json
 import os
 import shutil
 
-from galaxy.tool_util.deps.commands import which
+from galaxy.util.commands import which
 
 from planemo.config import (
     OptionSource,

--- a/planemo/galaxy/run.py
+++ b/planemo/galaxy/run.py
@@ -66,8 +66,7 @@ def locate_galaxy_virtualenv(ctx, kwds):
         galaxy_branch = kwds.get("galaxy_branch") or "master"
         shared_venv_path = os.path.join(workspace, "gx_venv")
         galaxy_python_version = kwds.get('galaxy_python_version') or DEFAULT_PYTHON_VERSION
-        if galaxy_python_version != DEFAULT_PYTHON_VERSION:
-            shared_venv_path = "%s_%s" % (shared_venv_path, galaxy_python_version)
+        shared_venv_path = "%s_%s" % (shared_venv_path, galaxy_python_version)
         if galaxy_branch != "master":
             shared_venv_path = "%s_%s" % (shared_venv_path, galaxy_branch)
         venv_command = CACHED_VIRTUAL_ENV_COMMAND % shlex_quote(shared_venv_path)

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -1,3 +1,4 @@
+"""Planemo I/O abstractions and utilities."""
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -14,8 +14,8 @@ from sys import platform as _platform
 from xml.sax.saxutils import escape
 
 import click
-from galaxy.tool_util.deps import commands
-from galaxy.tool_util.deps.commands import download_command
+from galaxy.util import commands
+from galaxy.util.commands import download_command
 from six import (
     string_types,
     StringIO
@@ -218,7 +218,9 @@ def kill_posix(pid):
     if _check_pid():
         for sig in [15, 9]:
             try:
-                os.kill(pid, sig)
+                # gunicorn (unlike paste), seem to require killing process
+                # group
+                os.killpg(os.getpgid(pid), sig)
             except OSError:
                 return
             time.sleep(1)

--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -59,7 +59,7 @@ def _lint_extra_modules(**kwds):
 
 
 def setup_lint(ctx, **kwds):
-    """Setup lint_args and lint_ctx to begin linting a target."""
+    """Prepare lint_args and lint_ctx to begin linting a target."""
     lint_args = build_lint_args(ctx, **kwds)
     lint_ctx = LintContext(lint_args["level"])
     return lint_args, lint_ctx

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -12,6 +12,7 @@ from .config import planemo_option
 
 
 def force_option(what="files"):
+    """Annotate click command as consume the -f/--force option."""
     return planemo_option(
         "-f",
         "--force",
@@ -21,6 +22,7 @@ def force_option(what="files"):
 
 
 def skip_venv_option():
+    """Annotate click command as consume the --skip_venv option."""
     return planemo_option(
         "--skip_venv",
         is_flag=True,
@@ -30,7 +32,18 @@ def skip_venv_option():
     )
 
 
+def skip_client_build_option():
+    """Annotate click command as consume the --skip_client_build option."""
+    return planemo_option(
+        "--skip_client_build",
+        is_flag=True,
+        default=False,
+        help=("Do not build Galaxy client when serving Galaxy.")
+    )
+
+
 def run_engine_option():
+    """Annotate click command as consume the --engine option."""
     return planemo_option(
         "--engine",
         type=click.Choice(["galaxy", "docker_galaxy", "cwltool", "toil", "external_galaxy"]),
@@ -44,6 +57,7 @@ def run_engine_option():
 
 
 def non_strict_cwl_option():
+    """Annotate click command as consume the --non_strict_cwl option."""
     return planemo_option(
         "--non_strict_cwl",
         default=False,
@@ -53,6 +67,11 @@ def non_strict_cwl_option():
 
 
 def serve_engine_option():
+    """Annotate click command as consume the --engine option.
+
+    This variant of the engine command is restricted to engines that can serve Galaxy
+    servers.
+    """
     return planemo_option(
         "--engine",
         type=click.Choice(["galaxy", "docker_galaxy", "external_galaxy"]),
@@ -66,6 +85,7 @@ def serve_engine_option():
 
 
 def ignore_dependency_problems_option():
+    """Annotate click command as consume the --ignore_dependency_problems option."""
     return planemo_option(
         "--ignore_dependency_problems",
         is_flag=True,
@@ -78,6 +98,10 @@ def ignore_dependency_problems_option():
 
 
 def cwltool_no_container_option():
+    """Annotate click command as consume the --no_container option.
+
+    This option is for the CWL CLI runner interface.
+    """
     return planemo_option(
         "--no-container",
         "--no_container",
@@ -89,6 +113,7 @@ def cwltool_no_container_option():
 
 
 def test_data_option():
+    """Annotate click command as consume the --test_data option."""
     return planemo_option(
         "--test_data",
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
@@ -1145,6 +1170,7 @@ def galaxy_serve_options():
         daemon_option(),
         pid_file_option(),
         ignore_dependency_problems_option(),
+        skip_client_build_option(),
         shed_install_option()
     )
 

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -67,9 +67,11 @@ _Runnable = collections.namedtuple("Runnable", ["path", "type"])
 
 
 class Runnable(_Runnable):
+    """Abstraction describing tools and workflows."""
 
     @property
     def test_data_search_path(self):
+        """During testing, path to search for test data files."""
         if self.type.name in ['galaxy_datamanager']:
             return os.path.join(os.path.dirname(self.path), os.path.pardir)
         else:
@@ -77,19 +79,26 @@ class Runnable(_Runnable):
 
     @property
     def tool_data_search_path(self):
+        """During testing, path to search for Galaxy tool data tables."""
         return self.test_data_search_path
 
     @property
     def data_manager_conf_path(self):
+        """Path of a Galaxy data manager configuration for runnable or None."""
         if self.type.name in ['galaxy_datamanager']:
             return os.path.join(os.path.dirname(self.path), os.pardir, 'data_manager_conf.xml')
 
     @property
     def has_tools(self):
+        """Boolean indicating if this runnable corresponds to one or more tools."""
         return _runnable_delegate_attribute('has_tools')
 
     @property
     def is_single_artifact(self):
+        """Boolean indicating if this runnable is a single artifact.
+
+        Currently only directories are considered not a single artifact.
+        """
         return _runnable_delegate_attribute('is_single_artifact')
 
 
@@ -215,8 +224,7 @@ def cases(runnable):
 
 @add_metaclass(abc.ABCMeta)
 class AbstractTestCase(object):
-    """Description of a test case for a runnable.
-    """
+    """Description of a test case for a runnable."""
 
     def structured_test_data(self, run_response):
         """Result of executing this test case - a "structured_data" dict.
@@ -262,8 +270,7 @@ class TestCase(AbstractTestCase):
             (self.doc, self.runnable, self.job, self.output_expectations, self.tests_directory, self.index)
 
     def structured_test_data(self, run_response):
-        """Check a test case against outputs dictionary.
-        """
+        """Check a test case against outputs dictionary."""
         output_problems = []
         if run_response.was_successful:
             outputs_dict = run_response.outputs_dict
@@ -353,8 +360,7 @@ class TestCase(AbstractTestCase):
 
 
 class ExternalGalaxyToolTestCase(AbstractTestCase):
-    """Special class of AbstractCase that doesn't use job_path but uses test data from a Galaxy server.
-    """
+    """Special class of AbstractCase that doesn't use job_path but uses test data from a Galaxy server."""
 
     def __init__(self, runnable, tool_id, tool_version, test_index, test_dict):
         """Construct TestCase object from required attributes."""
@@ -365,8 +371,7 @@ class ExternalGalaxyToolTestCase(AbstractTestCase):
         self.test_dict = test_dict
 
     def structured_test_data(self, run_response):
-        """Just return the structured_test_data generated from galaxy-tool-util for this test variant.
-        """
+        """Just return the structured_test_data generated from galaxy-tool-util for this test variant."""
         return run_response
 
 
@@ -416,6 +421,7 @@ class RunnableOutput(object):
 
 
 class ToolOutput(RunnableOutput):
+    """Implementation of RunnableOutput corresponding to Galaxy tool outputs."""
 
     def __init__(self, tool_output):
         self._tool_output = tool_output
@@ -425,6 +431,7 @@ class ToolOutput(RunnableOutput):
 
 
 class GalaxyWorkflowOutput(RunnableOutput):
+    """Implementation of RunnableOutput corresponding to Galaxy workflow outputs."""
 
     def __init__(self, workflow_output):
         self._workflow_output = workflow_output
@@ -438,6 +445,7 @@ class GalaxyWorkflowOutput(RunnableOutput):
 
 
 class CwlWorkflowOutput(RunnableOutput):
+    """Implementation of RunnableOutput corresponding to CWL outputs."""
 
     def __init__(self, label):
         self._label = label
@@ -452,7 +460,7 @@ class RunResponse(object):
 
     @abc.abstractproperty
     def was_successful(self):
-        """Indicate whether an error was encountered while executing this runnble.
+        """Indicate whether an error was encountered while executing this runnable.
 
         If successful, response should conform to the SuccessfulRunResponse interface,
         otherwise it will conform to the ErrorRunResponse interface.

--- a/planemo/templates.py
+++ b/planemo/templates.py
@@ -1,3 +1,4 @@
+"""Templating abstraction around jinja2 for Planemo."""
 try:
     from jinja2 import Template
 except ImportError:
@@ -8,8 +9,7 @@ NO_JINJA2_MESSAGE = ("This functionality requires Jinja2 but this library is "
 
 
 def render(template_str, **kwds):
-    """ Use jinja2 to render a template
-    """
+    """Use jinja2 to render specified template."""
     if Template is None:
         raise Exception(NO_JINJA2_MESSAGE)
     template = Template(template_str)

--- a/planemo/tool_builder.py
+++ b/planemo/tool_builder.py
@@ -457,7 +457,7 @@ class CommandIO(object):
         for position, (prefix, value) in enumerate(prefixed_parts):
             if value in self.example_input_names():
                 input_count += 1
-                input = CwlInput(
+                input = _CwlInput(
                     "input%d" % input_count,
                     position,
                     prefix,
@@ -466,7 +466,7 @@ class CommandIO(object):
                 parse_list.append(input)
             elif value in self.example_output_names():
                 output_count += 1
-                output = CwlOutput(
+                output = _CwlOutput(
                     "output%d" % output_count,
                     position,
                     prefix,
@@ -476,7 +476,7 @@ class CommandIO(object):
             elif prefix:
                 param_id = prefix.prefix.lower().rstrip("=")
                 type_ = param_type(value)
-                input = CwlInput(
+                input = _CwlInput(
                     param_id,
                     position,
                     prefix,
@@ -485,7 +485,7 @@ class CommandIO(object):
                 )
                 parse_list.append(input)
             else:
-                part = CwlCommandPart(value, position, prefix)
+                part = _CwlCommandPart(value, position, prefix)
                 parse_list.append(part)
         return parse_list
 
@@ -500,7 +500,7 @@ class CommandIO(object):
         index = 0
         while index < len(lex_list):
             token = lex_list[index]
-            if isinstance(token, CwlCommandPart):
+            if isinstance(token, _CwlCommandPart):
                 base_command.append(token.value)
             else:
                 break
@@ -511,11 +511,11 @@ class CommandIO(object):
             if token.is_token(">"):
                 break
             token.position = index - len(base_command) + 1
-            if isinstance(token, CwlCommandPart):
+            if isinstance(token, _CwlCommandPart):
                 arguments.append(token)
-            elif isinstance(token, CwlInput):
+            elif isinstance(token, _CwlInput):
                 inputs.append(token)
-            elif isinstance(token, CwlOutput):
+            elif isinstance(token, _CwlOutput):
                 token.glob = "$(inputs.%s)" % token.id
                 outputs.append(token)
 
@@ -526,8 +526,8 @@ class CommandIO(object):
             token = lex_list[index]
             if token.is_token(">") and (index + 1) < len(lex_list):
                 output_token = lex_list[index + 1]
-                if not isinstance(output_token, CwlOutput):
-                    output_token = CwlOutput("std_out", None)
+                if not isinstance(output_token, _CwlOutput):
+                    output_token = _CwlOutput("std_out", None)
 
                 output_token.glob = "out"
                 output_token.require_filename = False
@@ -572,7 +572,7 @@ def _looks_like_start_of_prefix(index, parts):
 Prefix = namedtuple("Prefix", ["prefix", "separated"])
 
 
-class CwlCommandPart(object):
+class _CwlCommandPart(object):
 
     def __init__(self, value, position, prefix):
         self.value = value
@@ -583,7 +583,7 @@ class CwlCommandPart(object):
         return self.value == value
 
 
-class CwlInput(object):
+class _CwlInput(object):
 
     def __init__(self, id, position, prefix, example_value, type_="File"):
         self.id = id
@@ -596,7 +596,7 @@ class CwlInput(object):
         return False
 
 
-class CwlOutput(object):
+class _CwlOutput(object):
 
     def __init__(self, id, position, prefix, example_value):
         self.id = id
@@ -611,15 +611,14 @@ class CwlOutput(object):
 
 
 def _render(kwds, template_str=TOOL_TEMPLATE):
-    """ Apply supplied template variables to TOOL_TEMPLATE to generate
-    the final tool.
-    """
+    """Render template variables to generate the final tool."""
     return templates.render(template_str, **kwds)
 
 
 def _replace_file_in_command(command, specified_file, name):
-    """ Replace example file with cheetah variable name in supplied command
-    or command template. Be sure to single quote the name.
+    """Replace example file with cheetah variable name.
+
+    Be sure to single quote the name.
     """
     # TODO: check if the supplied variant was single quoted already.
     if '"%s"' % specified_file in command:
@@ -634,7 +633,8 @@ def _replace_file_in_command(command, specified_file, name):
 
 
 def _handle_help(kwds):
-    """ Convert supplied help parameters into a help variable for template.
+    """Convert supplied help parameters into a help variable for template.
+
     If help_text is supplied, use as is. If help is specified from a command,
     run the command and use that help text.
     """
@@ -658,7 +658,9 @@ def _handle_help(kwds):
 
 
 def _handle_tests(kwds, test_case):
-    """ Given state built up from handling rest of arguments (test_case) and
+    """Build tool test abstractions.
+
+    Given state built up from handling rest of arguments (test_case) and
     supplied kwds - build tests for template and corresponding test files.
     """
     test_files = []
@@ -672,7 +674,9 @@ def _handle_tests(kwds, test_case):
 
 
 def _handle_requirements(kwds):
-    """ Convert requirements and containers specified from the command-line
+    """Build tool requirement abstractions.
+
+    Convert requirements and containers specified from the command-line
     into abstract format for consumption by the template.
     """
     requirements = kwds["requirement"]
@@ -688,7 +692,7 @@ def _handle_requirements(kwds):
 
 
 def _find_command(kwds):
-    """Find base command from supplied arguments or just return None.
+    """Find base command from supplied arguments or just return `None`.
 
     If no such command was supplied (template will just replace this
     with a TODO item).
@@ -702,6 +706,7 @@ def _find_command(kwds):
 
 
 class UrlCitation(object):
+    """Describe citation for tool."""
 
     def __init__(self, url):
         self.url = url

--- a/planemo/tools.py
+++ b/planemo/tools.py
@@ -17,11 +17,13 @@ LOAD_ERROR_MESSAGE = "Error loading tool with path %s"
 
 
 def uri_to_path(ctx, uri):
+    """Fetch URI to a local path."""
     fetcher = ToolLocationFetcher()
     return fetcher.to_tool_path(uri)
 
 
 def uris_to_paths(ctx, uris):
+    """Fetch multiple URIs to a local path."""
     fetcher = ToolLocationFetcher()
     paths = []
     for uri in uris:
@@ -31,6 +33,7 @@ def uris_to_paths(ctx, uris):
 
 
 def yield_tool_sources_on_paths(ctx, paths, recursive=False, yield_load_errors=True, exclude_deprecated=False):
+    """Walk paths and yield ToolSource objects discovered."""
     for path in paths:
         for (tool_path, tool_source) in yield_tool_sources(ctx, path, recursive, yield_load_errors):
             if exclude_deprecated and 'deprecated' in tool_path:
@@ -39,6 +42,7 @@ def yield_tool_sources_on_paths(ctx, paths, recursive=False, yield_load_errors=T
 
 
 def yield_tool_sources(ctx, path, recursive=False, yield_load_errors=True):
+    """Walk single path and yield ToolSource objects discovered."""
     tools = load_tool_sources_from_path(
         path,
         recursive,
@@ -58,7 +62,7 @@ def yield_tool_sources(ctx, path, recursive=False, yield_load_errors=True):
 
 
 def load_tool_sources_from_path(path, recursive, register_load_errors=False):
-    """Generator for tool sources on a path."""
+    """Generate a list for tool sources found down specified path."""
     return loader_directory.load_tool_sources_from_path(
         path,
         _load_exception_handler,

--- a/planemo/virtualenv.py
+++ b/planemo/virtualenv.py
@@ -6,10 +6,10 @@ import os
 import sys
 
 import virtualenv
-from galaxy.tool_util.deps.commands import which
+from galaxy.util.commands import which
 
 
-DEFAULT_PYTHON_VERSION = os.environ.get("PLANEMO_DEFAULT_PYTHON_VERSION", "3.6")
+DEFAULT_PYTHON_VERSION = os.environ.get("PLANEMO_DEFAULT_PYTHON_VERSION", "3")
 
 
 def create_and_exit(virtualenv_path, **kwds):

--- a/tests/test_cmd_serve.py
+++ b/tests/test_cmd_serve.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import time
 import uuid
@@ -15,6 +14,8 @@ from .test_utils import (
     launch_and_wait_for_galaxy,
     mark,
     PROJECT_TEMPLATES_DIR,
+    run_verbosely,
+    safe_rmtree,
     skip_if_environ,
     skip_unless_environ,
     skip_unless_executable,
@@ -24,6 +25,7 @@ from .test_utils import (
 )
 
 TEST_HISTORY_NAME = "Cool History 42"
+SERVE_TEST_VERBOSE = True
 
 
 class ServeTestCase(CliTestCase):
@@ -34,7 +36,7 @@ class ServeTestCase(CliTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.galaxy_root)
+        safe_rmtree(cls.galaxy_root)
 
     def setUp(self):
         super(ServeTestCase, self).setUp()
@@ -46,17 +48,24 @@ class ServeTestCase(CliTestCase):
     @skip_if_environ("PLANEMO_SKIP_PYTHON2")
     @mark.tests_galaxy_branch
     def test_serve(self):
-        self._launch_thread_and_wait(self._run)
+        extra_args = [
+            "--skip_client_build",
+        ]
+        self._launch_thread_and_wait(self._run, extra_args)
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     @skip_if_environ("PLANEMO_SKIP_PYTHON3")
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_CLIENT_TESTS")
     @skip_unless_executable("python3")
-    def test_serve_python3(self):
+    def test_serve_client_python3(self):
         extra_args = [
-            "--galaxy_python_version", "3"]
-        self._launch_thread_and_wait(self._run, extra_args)
+            "--galaxy_python_version", "3"
+        ]
+        # Given the client build - give this more time.
+        timeout_multiplier = 3
+        self._launch_thread_and_wait(self._run, extra_args, timeout_multiplier=timeout_multiplier)
         # Check that the client was correctly built
-        url = "http://localhost:%d/static/scripts/bundled/analysis.bundled.js" % int(self._port)
+        url = "http://localhost:%d/static/dist/analysis.bundled.js" % int(self._port)
         r = requests.get(url)
         assert r.status_code == 200
 
@@ -65,6 +74,7 @@ class ServeTestCase(CliTestCase):
     def test_serve_daemon(self):
         extra_args = [
             "--daemon",
+            "--skip_client_build",
             "--pid_file", self._pid_file]
         self._launch_thread_and_wait(self._run, extra_args)
         user_gi = self._user_gi
@@ -80,6 +90,7 @@ class ServeTestCase(CliTestCase):
         self._serve_artifact = os.path.join(TEST_DATA_DIR, "wf1.gxwf.yml")
         extra_args = [
             "--daemon",
+            "--skip_client_build",
             "--pid_file", self._pid_file,
             "--extra_tools", random_lines,
             "--extra_tools", cat,
@@ -93,10 +104,12 @@ class ServeTestCase(CliTestCase):
         assert len(user_gi.workflows.get_workflows()) == 1
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    @skip_if_environ("PLANEMO_SKIP_SHED_TESTS")
     @mark.tests_galaxy_branch
     def test_shed_serve(self):
         extra_args = [
             "--daemon",
+            "--skip_client_build",
             "--pid_file", self._pid_file,
             "--shed_target", "toolshed"]
         fastqc_path = os.path.join(TEST_REPOS_DIR, "fastqc")
@@ -129,6 +142,7 @@ class ServeTestCase(CliTestCase):
         new_profile = "planemo_test_profile_%s" % uuid.uuid4()
         extra_args = [
             "--daemon",
+            "--skip_client_build",
             "--pid_file", self._pid_file,
             "--profile", new_profile,
         ]
@@ -149,25 +163,28 @@ class ServeTestCase(CliTestCase):
         user_gi = api.gi(self._port, key=user_api_key)
         return user_gi
 
-    def _launch_thread_and_wait(self, func, args=[]):
-        t = launch_and_wait_for_galaxy(self._port, func, [args])
-        self._threads.append(t)
+    def _launch_thread_and_wait(self, func, args=[], **kwd):
+        future = launch_and_wait_for_galaxy(self._port, func, [args], **kwd)
+        self._futures.append(future)
 
     def _run_shed(self, serve_args=[]):
         return self._run(serve_args=serve_args, serve_cmd="shed_serve")
 
     def _run(self, serve_args=[], serve_cmd="serve"):
         serve_cmd = self._serve_command_list(serve_args, serve_cmd)
+        if run_verbosely():
+            print("Running command for test [%s]" % serve_cmd)
         self._check_exit_code(serve_cmd)
 
     def _serve_command_list(self, serve_args=[], serve_cmd="serve"):
-        test_cmd = [
+        test_cmd = ["--verbose"] if run_verbosely() else []
+        test_cmd.extend([
             serve_cmd,
             "--galaxy_root", self.galaxy_root,
             "--galaxy_branch", target_galaxy_branch(),
             "--no_dependency_resolution",
             "--port", str(self._port),
             self._serve_artifact,
-        ]
+        ])
         test_cmd.extend(serve_args)
         return test_cmd

--- a/tests/test_database_commands.py
+++ b/tests/test_database_commands.py
@@ -25,6 +25,7 @@ class DatabaseCommandsTestCase(CliTestCase):
     def test_database_commands(self):
         self._database_commands()
 
+    @skip_unless_environ("PLANEMO_ENABLE_POSTGRES_TESTS")
     @skip_unless_executable("docker")
     def test_database_commands_docker(self):
         try:

--- a/tests/test_shed_test.py
+++ b/tests/test_shed_test.py
@@ -14,11 +14,13 @@ class ShedTestTestCase(CliTestCase):
 
     @skip  # Skip for now since toolshed has invalid test data for 0.11.4
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    @skip_if_environ("PLANEMO_SKIP_SHED_TESTS")
     def test_shed_test_fastqc(self):
         self.__run_shed_test("fastqc")
 
     @skip  # Skip for now since toolshed has problem with op column.
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    @skip_if_environ("PLANEMO_SKIP_SHED_TESTS")
     def test_shed_test_datamash(self):
         self.__run_shed_test("datamash")
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -3,12 +3,11 @@ import json
 import os
 import shutil
 
-from nose.tools import assert_raises_regexp
-
 from planemo import cli
 from planemo.runnable import for_path
 from planemo.training import Training
 from .test_utils import (
+    assert_raises_regexp,
     skip_if_environ,
     TEST_DATA_DIR,
 )
@@ -95,6 +94,7 @@ KWDS = {
     'shed_install': True,
     'shed_tool_conf': None,
     'shed_tool_path': None,
+    'skip_client_build': True,
     'skip_venv': False,
     'test_data': None,
     'tool_data_table': None,

--- a/tests/test_training_tool_input.py
+++ b/tests/test_training_tool_input.py
@@ -2,8 +2,6 @@
 import json
 import os
 
-from nose.tools import assert_raises_regexp
-
 from planemo.training.tool_input import (
     get_empty_input,
     get_empty_param,
@@ -15,6 +13,7 @@ from .test_training import (
     wf_param_values
 )
 from .test_utils import (
+    assert_raises_regexp,
     TEST_DATA_DIR
 )
 

--- a/tests/test_training_tutorial.py
+++ b/tests/test_training_tutorial.py
@@ -2,9 +2,6 @@
 import os
 import shutil
 
-from nose.tools import assert_raises_regexp
-
-
 from planemo.engine import (
     engine_context,
     is_galaxy_engine,
@@ -36,6 +33,7 @@ from .test_training import (
     zenodo_link
 )
 from .test_utils import (
+    assert_raises_regexp,
     skip_if_environ,
 )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,40 +4,32 @@ from __future__ import print_function
 import contextlib
 import functools
 import os
+import re
 import shutil
 import signal
-import threading
 import traceback
+from concurrent.futures import as_completed, ThreadPoolExecutor
 from sys import version_info
 from tempfile import mkdtemp
+from unittest import skip, TestCase
 
 import psutil
+import py.code
+import pytest
 from click.testing import CliRunner
-from galaxy.tool_util.deps.commands import which
-from galaxy.util import unicodify
+from galaxy.util import asbool, unicodify, which
 
 from planemo import cli
 from planemo import io
 from planemo import shed
 from planemo.config import PLANEMO_CONFIG_ENV_PROP
-from planemo.galaxy.ephemeris_sleep import sleep
+from planemo.galaxy.ephemeris_sleep import sleep, SleepCondition
 from .shed_app_test_utils import (
     mock_shed,
     setup_mock_shed,
 )
 
-try:
-    import pytest
-except ImportError:
-    pytest = None
-    from nose.plugins.attrib import attr
-
-if version_info < (2, 7):
-    from unittest2 import TestCase, skip
-    PRE_PYTHON_27 = True
-else:
-    from unittest import TestCase, skip
-    PRE_PYTHON_27 = False
+PRE_PYTHON_27 = False
 if version_info[0] == 2 and version_info[1] >= 7:
     PYTHON_27 = True
 else:
@@ -58,10 +50,7 @@ NON_ZERO_EXIT_CODE = object()
 class MarkGenerator(object):
 
     def __getattr__(self, name):
-        if pytest:
-            return getattr(pytest.mark, name)
-        else:
-            return attr(name)
+        return getattr(pytest.mark, name)
 
 
 mark = MarkGenerator()
@@ -76,20 +65,24 @@ class CliTestCase(TestCase):
         self._runner = CliRunner()
         self._home = mkdtemp()
         self._old_config = os.environ.get(PLANEMO_CONFIG_ENV_PROP, None)
-        self._threads = []
+        self._futures = []
         self._port = None
         os.environ[PLANEMO_CONFIG_ENV_PROP] = self.planemo_yaml_path
 
     def tearDown(self):  # noqa
-        for t in self._threads:
-            t.join(timeout=10)
+        for future in self._futures:
+            future.cancel()
+            try:
+                future.result(timeout=10)
+            except Exception as e:
+                print("Failed to dispose of future driven resource [%s]" % e)
         if self._port:
             kill_process_on_port(self._port)
         if self._old_config:
             os.environ[PLANEMO_CONFIG_ENV_PROP] = self._old_config
         else:
             del os.environ[PLANEMO_CONFIG_ENV_PROP]
-        shutil.rmtree(self._home)
+        safe_rmtree(self._home)
 
     @property
     def planemo_yaml_path(self):
@@ -177,7 +170,7 @@ class TempDirectoryTestCase(TestCase):
         self.temp_directory = mkdtemp()
 
     def tearDown(self):  # noqa
-        shutil.rmtree(self.temp_directory)
+        safe_rmtree(self.temp_directory)
 
 
 class TempDirectoryContext(object):
@@ -188,7 +181,7 @@ class TempDirectoryContext(object):
         return self
 
     def __exit__(self, type, value, tb):
-        shutil.rmtree(self.temp_directory)
+        safe_rmtree(self.temp_directory)
 
 
 def skip_unless_environ(var):
@@ -256,9 +249,14 @@ def modify_environ(values, remove=[]):
             del os.environ[key]
 
 
+def run_verbosely():
+    return asbool(os.environ.get("PLANEMO_TEST_VERBOSE", "false"))
+
+
 def test_context():
     context = cli.Context()
     context.planemo_directory = "/tmp/planemo-test-workspace"
+    context.verbose = run_verbosely()
     return context
 
 
@@ -328,13 +326,13 @@ def kill_process_on_port(port):
 
 @contextlib.contextmanager
 def cli_daemon_galaxy(runner, pid_file, port, command_list, exit_code=0):
-    t = launch_and_wait_for_galaxy(port, check_exit_code, args=[runner, command_list, exit_code])
+    future = launch_and_wait_for_galaxy(port, check_exit_code, args=[runner, command_list, exit_code])
     yield
     io.kill_pid_file(pid_file)
-    t.join(timeout=60)
+    _wait_on_future_suppress_exception(future)
 
 
-def launch_and_wait_for_galaxy(port, func, args=[]):
+def launch_and_wait_for_galaxy(port, func, args=[], timeout=600, timeout_multiplier=1):
     """Run func(args) in a thread and wait on port for service.
 
     Service should remain up so check network a few times, this prevents
@@ -342,12 +340,86 @@ def launch_and_wait_for_galaxy(port, func, args=[]):
     detecting that the port is bound to.
     """
     target = functools.partial(func, *args)
-    t = threading.Thread(target=target)
-    t.daemon = True
-    t.start()
-    if not sleep("http://localhost:%d" % port, timeout=600):
-        raise Exception('Galaxy failed to start')
-    return t
+
+    wait_sleep_condition = SleepCondition()
+
+    def wait():
+        effective_timeout = timeout * timeout_multiplier
+        if not sleep("http://localhost:%d" % port, verbose=True, timeout=effective_timeout, sleep_condition=wait_sleep_condition):
+            raise Exception('Galaxy failed to start on port %d' % port)
+
+    executor = ThreadPoolExecutor(max_workers=2)
+    try:
+        target_future = executor.submit(target)
+        wait_future = executor.submit(wait)
+        for first in as_completed([target_future, wait_future]):
+            break
+
+        if target_future.running():
+            # If wait timed out re-throw.
+            wait_future.result()
+            return target_future
+        else:
+            if target_future.exception() is not None:
+                wait_future.cancel()
+                wait_sleep_condition.cancel()
+                _wait_on_future_suppress_exception(wait_future)
+                # If the target threw an exception, rethrow.
+                target_future.result()
+            else:
+                # Otherwise, daemon started properly. Just wait on wait.
+                wait_future.result()
+    finally:
+        executor.shutdown(wait=False)
+
+
+def _wait_on_future_suppress_exception(future):
+    try:
+        future.result(timeout=30)
+    except Exception as e:
+        print("Problem waiting on future %s" % e)
+
+
+# From pytest-raisesregexp
+class assert_raises_regexp(object):
+    def __init__(self, expected_exception, regexp, *args, **kwargs):
+        __tracebackhide__ = True
+        self.exception = expected_exception
+        self.regexp = regexp
+        self.excinfo = None
+
+        if args:
+            with self:
+                args[0](*args[1:], **kwargs)
+
+    def __enter__(self):
+        self.excinfo = object.__new__(py.code.ExceptionInfo)
+        return self.excinfo
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        __tracebackhide__ = True
+
+        if exc_type is None:
+            pytest.fail('DID NOT RAISE {0}'.format(self.exception))
+
+        self.excinfo.__init__((exc_type, exc_val, exc_tb))
+
+        if not issubclass(exc_type, self.exception):
+            pytest.fail('{0} RAISED instead of {1}\n{2!r}'
+                        .format(exc_type, self.exception, exc_val))
+
+        if not re.search(self.regexp, str(exc_val)):
+            pytest.fail('Pattern "{0}" not found in "{1!s}"'
+                        .format(self.regexp, exc_val))
+
+        return True
+
+
+def safe_rmtree(path):
+    try:
+        shutil.rmtree(path)
+    except Exception as e:
+        print("Failed to cleanup test directory [%s]: [%s]" % (path, e))
 
 
 # TODO: everything should be considered "exported".

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ test_dir = tests
 commands =
     lint: flake8
     lint_docs: make lint-docs
-    lint_docstrings: flake8 {[tox]source_dir} {[tox]test_dir}
+    lint_docstrings: flake8 --ignore='D107,D401,D105' {[tox]source_dir}
     unit: pytest {env:PYTEST_CAPTURE:} -m {env:PYTEST_MARK:""} {env:PYTEST_TARGET:{[tox]test_dir}} {posargs}
 
 passenv = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,37}-lint, py37-quick, py37-lint_docstrings, py37-lint_docs, py{27,37}-unit
+envlist = py{36}-lint, py36-unit-quick, py36-lint_docstrings, py36-lint_docs, py{36,37}-unit
 source_dir = planemo
 test_dir = tests
 
@@ -8,11 +8,11 @@ commands =
     lint: flake8
     lint_docs: make lint-docs
     lint_docstrings: flake8 {[tox]source_dir} {[tox]test_dir}
-    quick,unit: nosetests []
+    unit: pytest {env:PYTEST_CAPTURE:} -m {env:PYTEST_MARK:""} {env:PYTEST_TARGET:{[tox]test_dir}} {posargs}
+
 passenv = 
     PLANEMO_*
     PG*
-    NOSE_*
     HOME
     DOCS
 deps =
@@ -21,22 +21,37 @@ deps =
     lint_docs: -rdev-requirements.txt
     lint_docs,quick,unit: -rrequirements.txt
     lint_docstrings: flake8_docstrings
-    quick,unit: nose
-    quick,unit: coverage
-    quick,unit: flask
+    unit: pytest 
+    # unit: pytest-timeout
+    unit: coverage
+    unit: flask
 setenv =
+    gx: PYTEST_MARK="tests_galaxy_branch"
+    diagnostic: PLANEMO_TEST_VERBOSE=1
+    diagnostic: PYTEST_CAPTURE="--capture=no"
+    servecmd: PYTEST_TARGET="tests/test_cmd_serve.py::ServeTestCase::test_serve_daemon"
+    serveshedcmd: PYTEST_TARGET="tests/test_cmd_serve.py::ServeTestCase::test_shed_serve"
+    serveclientcmd: PYTEST_TARGET="tests/test_cmd_serve.py::ServeTestCase::test_serve_client_python3"
+    servebasic: PYTEST_TARGET="tests/test_galaxy_serve.py::GalaxyServeTestCase::test_serve_daemon"
+    serveshed: PYTEST_TARGET="tests/test_galaxy_serve.py::GalaxyServeTestCase::test_shed_serve_daemon"
+    servewkfl: PYTEST_TARGET="tests/test_galaxy_serve.py::GalaxyServeTestCase::test_serve_workflow"
+    servetraining: PYTEST_TARGET="tests/test_training_tutorial.py::test_get_hands_on_boxes_from_local_galaxy"
+    initandtest: PYTEST_TARGET="tests/test_init_and_test.py"
+    trainingwfcmd: PYTEST_TARGET="tests/test_cmd_training_generate_from_wf.py"
+    runcmd: PYTEST_TARGET="tests/test_run.py::RunTestCase::test_run_gxtool_randomlines"
+    condatest: PYTEST_TARGET="tests/test_cmd_test_conda.py::CmdTestCondaTestCase::test_conda_dependencies_by_default"
+    nonredundant: PLANEMO_SKIP_REDUNDANT_TESTS=1
+    noclientbuild: PLANEMO_SKIP_GALAXY_CLIENT_TESTS=1
+    noshed: PLANEMO_SKIP_SHED_TESTS=1
     quick: PLANEMO_SKIP_SLOW_TESTS=1
     quick: PLANEMO_SKIP_GALAXY_TESTS=1
     py27-unit: PLANEMO_SKIP_PYTHON3=1
     !py27-unit: PLANEMO_SKIP_PYTHON2=1
     !py27-unit: PLANEMO_DEFAULT_PYTHON_VERSION=3
-    gx: NOSE_ATTR=tests_galaxy_branch
     master: PLANEMO_TEST_GALAXY_BRANCH=master
     dev: PLANEMO_TEST_GALAXY_BRANCH=dev
-    1805: PLANEMO_TEST_GALAXY_BRANCH=release_18.05
-    1801: PLANEMO_TEST_GALAXY_BRANCH=release_18.01
-    1709: PLANEMO_TEST_GALAXY_BRANCH=release_17.09
-    1705: PLANEMO_TEST_GALAXY_BRANCH=release_17.05
+    2005: PLANEMO_TEST_GALAXY_BRANCH=release_20.05
+    2001: PLANEMO_TEST_GALAXY_BRANCH=release_20.01
 skip_install =
     doc_test,lint,lint_docs,lint_docstrings: True
 whitelist_externals =


### PR DESCRIPTION
Fix https://github.com/galaxyproject/planemo/issues/945 .

Redo testing.

- Use pytest.
- Rework tox to add more bells and whistles (more docs for this in the drop Python 2 branch)
- Slice and dice the tests in different ways to hopefully make it clearer what is failing in the future.
- Add a bunch of tests back to Travis - different combinations of Pythons, Galaxy versions, and tests than Github actions though.
- Skip more client building when not needed - slows down the tests a lot it seems.
- More debugging in various places - in tests and in app.
- Fix options in shed_serve.
- Various gunicorn fixes.
- Rework some testing framework to use concurrent.futures.


Also change directory for gx_venv because it doesn't default to Python 2 anymore.
