### PR TITLE
Depend on any cwltool

### DIFF
--- a/planemo/cwl/script.py
+++ b/planemo/cwl/script.py
@@ -13,7 +13,7 @@ except (ImportError, SyntaxError):
     cwltool = None
 
 try:
-    from cwltool.main import load_tool
+    from cwltool.load_tool import load_tool
 except (ImportError, SyntaxError):
     load_tool = None
 
@@ -46,7 +46,7 @@ def to_script(ctx, path, job_path, **kwds):
 
     job, _ = loader.resolve_ref(uri)
 
-    t = load_tool(path, False, False, cwltool.workflow.defaultMakeTool, True)
+    t = load_tool(path)
 
     if type(t) == int:
         return t

--- a/planemo/cwl/script.py
+++ b/planemo/cwl/script.py
@@ -4,7 +4,6 @@ import os
 try:
     import schema_salad
 except (ImportError, SyntaxError):
-    # TODO: implement support for Python 2.6 and 3.X
     schema_salad = None
 
 try:
@@ -30,10 +29,10 @@ except (ImportError, SyntaxError):
 
 def to_script(ctx, path, job_path, **kwds):
     if schema_salad is None:
-        raise Exception("This functionality requires schema_salad and Python 2.7.")
+        raise Exception("This functionality requires schema_salad.")
 
     if cwltool is None:
-        raise Exception("This functionality requires cwltool and Python 2.7.")
+        raise Exception("This functionality requires cwltool.")
 
     uri = "file://" + os.path.abspath(job_path)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ BeautifulSoup4
 bioblend>=0.13.0
 Click
 configparser
-cwltool==1.0.20191225192155 
+cwltool>=1.0.20191225192155
 docutils
 ephemeris>=0.10.3
 galaxy-containers


### PR DESCRIPTION
I'm unsure how important the CWL to shell script feature is, since it depends on Python 2. But in any case, I've modernized the `load_tool` invocation so that I can install a more recent `cwltool`. The motivation for this is #1033. I believe the `cwtool` CLI which is used elsewhere is stable so I don't think that will pose a problem.