### PR TITLE
Bump minimum bioblend to 0.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aenum
 BeautifulSoup4
-bioblend>=0.13.0
+bioblend>=0.14.0
 Click
 configparser
 cwltool>=1.0.20191225192155


### PR DESCRIPTION
Otherwise workflow testing fails wih
```
'GalaxyInstance' object has no attribute '_make_url'
```