### PR TITLE
Add support for tool versions to tutorial template generator

### DIFF
--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -59,7 +59,7 @@ HANDS_ON_TOOL_BOX_TEMPLATE = """
 
 > ### {{ '{%' }} icon hands_on {{ '%}' }} Hands-on: Task description
 >
-> 1. **{{tool_name}}** {{ '{%' }} icon tool {{ '%}' }} with the following parameters:{{inputlist}}{{paramlist}}
+> 1. {{ '{%' }} tool [{{tool_name}}]({{tool_id}}) {{ '%}' }} with the following parameters:{{inputlist}}{{paramlist}}
 >
 >    ***TODO***: *Check parameter descriptions*
 >
@@ -627,6 +627,7 @@ def format_wf_steps(wf, gi):
 
     for s in range(len(steps)):
         wf_step = steps[str(s)]
+
         # get params in workflow
         wf_param_values = {}
         if wf_step['tool_state'] and wf_step['input_connections']:
@@ -646,6 +647,7 @@ def format_wf_steps(wf, gi):
         # format the hands-on box
         body += templates.render(HANDS_ON_TOOL_BOX_TEMPLATE, **{
             "tool_name": wf_step['name'],
+            "tool_id": wf_step['tool_id'],
             "paramlist": paramlist})
     return body
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -242,7 +242,10 @@ def test_generate_tuto_from_wf():
     # with workflow
     train.kwds['workflow'] = WF_FP
     train.generate_tuto_from_wf(CTX)
-    assert_file_contains(train.tuto.tuto_fp, '{% tool [FastQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71) %} with the following parameters:')
+    assert_file_contains(
+        train.tuto.tuto_fp,
+        "{% tool [FastQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71) %} with the following parameters:",
+    )
     assert os.path.exists(train.tuto.wf_fp)
     # clean after
     shutil.rmtree(train.topics_dir)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -242,7 +242,7 @@ def test_generate_tuto_from_wf():
     # with workflow
     train.kwds['workflow'] = WF_FP
     train.generate_tuto_from_wf(CTX)
-    assert_file_contains(train.tuto.tuto_fp, '**FastQC** {% icon tool %} with the following parameters:')
+    assert_file_contains(train.tuto.tuto_fp, '{% tool [FastQC](toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71) %} with the following parameters:')
     assert os.path.exists(train.tuto.wf_fp)
     # clean after
     shutil.rmtree(train.topics_dir)


### PR DESCRIPTION
Add support for @hexylena's tool versions (xref https://github.com/galaxyproject/galaxy/pull/10024 and https://github.com/galaxyproject/training-material/pull/1989 ) to the planemo tutorial skeleton generator