### PR TITLE
Make splitting job and test files optional

### DIFF
--- a/planemo/options.py
+++ b/planemo/options.py
@@ -692,6 +692,10 @@ def required_workflow_arg():
     return click.argument("workflow_path", metavar="WORKFLOW_PATH", type=arg_type)
 
 
+def split_job_and_test():
+    return click.option("--split_test/--no_split_test", default=False, help="Write workflow job and test definitions to separate files.")
+
+
 def required_job_arg():
     """Decorate click method as requiring the path to a single tool.
     """

--- a/tests/test_cmd_workflow_test_init.py
+++ b/tests/test_cmd_workflow_test_init.py
@@ -18,6 +18,17 @@ class CmdWorkflowTestInitTestCase(CliTestCase):
             assert os.path.exists(test_path)
             with open(test_path, "r") as stream:
                 test_config = yaml.safe_load(stream)
+            job = test_config[0]['job']
+            assert isinstance(job, dict)
+
+    def test_init_split_test(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:
+            init_cmd = ["workflow_test_init", "--split_test", "0_basic_native.yml"]
+            self._check_exit_code(init_cmd)
+            test_path = os.path.join(f, "0_basic_native_tests.yml")
+            assert os.path.exists(test_path)
+            with open(test_path, "r") as stream:
+                test_config = yaml.safe_load(stream)
             assert isinstance(test_config, list)
             job_path = os.path.join(f, "0_basic_native_job1.yml")
             assert os.path.exists(job_path)


### PR DESCRIPTION
I think that makes writing tests easier and I think @bgruening agrees (https://github.com/galaxyproject/training-material/pull/2021#discussion_r464233812)