### PR TITLE
More documentation/support around running workflows.

### DIFF
--- a/docs/automating_workflows.rst
+++ b/docs/automating_workflows.rst
@@ -1,0 +1,31 @@
+Automating Galaxy Workflows
+=============================
+
+The BioBlend_ library can be used to invoke and monitor Galaxy workflows.
+Planemo provides a higher-level interfaces to working with workflows -
+both as a Python library and via the command line. Planemo can take care of
+orchestrating details such as launching and configuring a Galaxy instance,
+installing required tools for the workflow, monitoring the workflow invocation,
+and downloading the results back to a local directory.
+
+::
+
+    planemo run workflow.ga job.yml
+
+The format of the job file should be YAML or JSON and matches the job
+definition used by the workflow `test format
+<https://planemo.readthedocs.io/en/latest/test_format.html>`__.
+
+A job template for a particular workflow can be created with the
+``workflow_job_init`` command.
+
+::
+
+    planemo workflow_job_init my-workflow.ga
+
+This will create a ``my-workflow-job.yml`` file in the current directory.
+
+Planemo run and the underlying Python code when used as a library support
+a wide range of arguments for how to run a Galaxy workflow.
+
+.. _BioBlend: https://github.com/galaxyproject/bioblend

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -60,5 +60,6 @@ documentation describes these commands.
 .. include:: commands/virtualenv.rst
 .. include:: commands/workflow_convert.rst
 .. include:: commands/workflow_edit.rst
+.. include:: commands/workflow_job_init.rst
 .. include:: commands/workflow_lint.rst
 .. include:: commands/workflow_test_init.rst

--- a/docs/planemo.commands.rst
+++ b/docs/planemo.commands.rst
@@ -452,6 +452,14 @@ planemo.commands.cmd\_workflow\_edit module
    :undoc-members:
    :show-inheritance:
 
+planemo.commands.cmd\_workflow\_job\_init module
+------------------------------------------------
+
+.. automodule:: planemo.commands.cmd_workflow_job_init
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 planemo.commands.cmd\_workflow\_lint module
 -------------------------------------------
 

--- a/docs/test_example_collection_input.yml
+++ b/docs/test_example_collection_input.yml
@@ -1,0 +1,1 @@
+../tests/data/wf5-collection-input.gxwf-test.yml

--- a/docs/test_example_composite_input.yml
+++ b/docs/test_example_composite_input.yml
@@ -1,0 +1,1 @@
+../tests/data/wf6-composite-inputs.gxwf-test.yml

--- a/docs/test_example_nested_collection_input.yml
+++ b/docs/test_example_nested_collection_input.yml
@@ -1,0 +1,1 @@
+../tests/data/wf8-collection-nested-input.gxwf-test.yml

--- a/docs/test_format.rst
+++ b/docs/test_format.rst
@@ -71,24 +71,29 @@ same testing file format is used for both kinds of artifacts.
             has_n_columns:
               n: 2
 
+The above examples illustrate that each test file is broken into a list of test
+cases. Each test case should have a ``doc`` describing the test, a ``job`` description
+the describes the inputs for an execution of the target artifact, and an ``outputs``
+mapping that describes assertions about outputs to test.
 
-The above examples hopefully make it clear that each test file is broken into a list of test
-cases. Each test case should have a ``doc`` describing the test, a ``job`` description the describes
-the inputs for an execution of the target artifact, and an ``outputs`` mapping that describes assertions
-about outputs to test.
 
 ``job``
 --------
 
-The ``job`` object can be a mapping embedded right in the file or a reference to a "job" input file.
-The job input file is a proper CWL_ job document - which is fairly straight forward as demonstrated in
-the above examples. Planemo adapts the CWL_ job document to Galaxy_ workflows and tools - using input
-names for Galaxy_ tools and input node labels for workflows.
+The ``job`` object can be a mapping embedded right in the test file or a reference to a
+an external "job" input file. The job input file is a proper CWL_ job document - which
+is fairly straight forward as demonstrated in the above examples. Planemo adapts the
+CWL_ job document to Galaxy_ workflows and tools - using input names for Galaxy_ tools
+and input node labels for workflows.
 
 Input files can be specified using either ``path`` attributes (which should generally be file
 paths relative to the artifact and test directory) or ``location`` (which should be a URI). The
 examples above demonstrate using both paths relative to the tool file and test data published
 to `Zenodo <https://zenodo.org/>`__.
+
+Embedded job objects result in cleaner test suites that are simpler to read. One advantage of
+instead using external job input files is that the job object can be reused to invoke the
+runnable artifact outside the context of testing with ``planemo run``.
 
 .. note::
 
@@ -103,6 +108,44 @@ to `Zenodo <https://zenodo.org/>`__.
     CLI invocation if ``--engine=galaxy`` (for a Planemo managed Galaxy instance), ``--engine=docker_galaxy``
     (for a Docker instance of Galaxy launched by Planemo), or ``--engine=external_galaxy`` (for a running
     remote Galaxy instance).
+
+Certain Galaxy objects don't map cleanly to CWL_ job objects so Planemo attempts to extend
+the format with new constructs for running and testing Galaxy objects - such as describing 
+collections and composite inputs.
+
+Galaxy Collection Inputs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example demonstrates two ways to create input lists for Galaxy tests.
+
+.. literalinclude:: test_example_collection_input.yml
+   :language: yaml
+
+Simply specifying files in YAML lists in the input job (like vanilla CWL_
+job descriptions) will result in a simple Galaxy list. This is simple but the downside is you
+have no control of the list identifiers - which are often important in Galaxy workflows. When
+more control is desired, you may describe an explicit Galaxy collection with an input object of
+``class: Collection``. This variant (also shown in the above example) allows creating collections
+of type other than ``list`` and allows specifying element identifiers with the ``identifier``
+declaration under the list of collection ``elements``.
+
+The explicit Galaxy collection creation syntax also makes describing nested collections such as
+lists of pairs very natural. The following example is used in Planemo's test suite to illustrate
+this:
+
+.. literalinclude:: test_example_nested_collection_input.yml
+   :language: yaml
+
+Galaxy Composite Inputs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The syntax for specifying composite inputs is a little more basic still and simply must be specified
+as a list of local files (mirroring Galaxy Tool XML test syntax). While ``class`` is assumed to
+be ``File`` and URIs aren't yet tested.
+
+
+.. literalinclude:: test_example_composite_input.yml
+   :language: yaml
 
 ``outputs``
 --------------

--- a/planemo/commands/cmd_workflow_job_init.py
+++ b/planemo/commands/cmd_workflow_job_init.py
@@ -1,0 +1,34 @@
+"""Module describing the planemo ``workflow_job_init`` command."""
+import click
+import yaml
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy.workflows import job_template, new_workflow_associated_path
+from planemo.io import can_write_to_path
+
+
+@click.command('workflow_job_init')
+@options.required_workflow_arg()
+@options.force_option()
+@options.workflow_output_artifact()
+@command_function
+def cli(ctx, workflow_path, output=None, **kwds):
+    """Initialize a Galaxy workflow job description for supplied workflow.
+
+    Be sure to your lint your workflow with ``workflow_lint`` before calling this
+    to ensure inputs and outputs comply with best practices that make workflow
+    testing easier.
+
+    Jobs can be run with the planemo run command (``planemo run workflow.ga job.yml``).
+    Planemo run works with Galaxy tools and CWL artifacts (both tools and workflows)
+    as well so this command may be renamed to to job_init at something along those
+    lines at some point.
+    """
+    job = job_template(workflow_path)
+    if output is None:
+        output = new_workflow_associated_path(workflow_path, suffix="job")
+    if not can_write_to_path(output, **kwds):
+        ctx.exit(1)
+    with open(output, "w") as f_job:
+        yaml.dump(job, f_job)

--- a/planemo/commands/cmd_workflow_test_init.py
+++ b/planemo/commands/cmd_workflow_test_init.py
@@ -11,6 +11,7 @@ from planemo.galaxy.workflows import (
     new_workflow_associated_path,
     output_stubs_for_workflow,
 )
+from planemo.io import can_write_to_path
 
 
 @click.command('workflow_test_init')
@@ -18,19 +19,22 @@ from planemo.galaxy.workflows import (
 @options.force_option()
 @options.workflow_output_artifact()
 @command_function
-def cli(ctx, workflow_path, output=None, force=False, **kwds):
+def cli(ctx, workflow_path, output=None, **kwds):
     """Initialize a Galaxy workflow test description for supplied workflow.
 
     Be sure to your lint your workflow with ``workflow_lint`` before calling this
     to ensure inputs and outputs comply with best practices that make workflow
     testing easier.
     """
-    # TODO: impelement force
+    # TODO: implement force
     path_basename = os.path.basename(workflow_path)
     job = job_template(workflow_path)
     if output is None:
         output = new_workflow_associated_path(workflow_path)
     job_output = new_workflow_associated_path(workflow_path, suffix="job1")
+    if not can_write_to_path(job_output, **kwds) or not can_write_to_path(output, **kwds):
+        ctx.exit(1)
+
     test_description = [{
          'doc': 'Test outline for %s' % path_basename,
          'job': os.path.basename(job_output),

--- a/tests/data/wf6-composite-inputs.gxwf-test.yml
+++ b/tests/data/wf6-composite-inputs.gxwf-test.yml
@@ -4,10 +4,8 @@
       class: File
       filetype: imzml
       composite_data:
-        # Can use location/path keys or just specify an array of files - only
-        # order is used.
         - path: Example_Continuous.imzML
-        - Example_Continuous.ibd
+        - path: Example_Continuous.ibd
   outputs:
     wf_output_1:
-      file: Example_Continuous.imzML
+      checksum: "sha1$0d2ad51f69d7b5df0f4d2b2a47b17478f2fca509"

--- a/tests/test_cmd_workflow_job_init.py
+++ b/tests/test_cmd_workflow_job_init.py
@@ -8,18 +8,13 @@ from .test_utils import (
 )
 
 
-class CmdWorkflowTestInitTestCase(CliTestCase):
+class CmdWorkflowJobInitTestCase(CliTestCase):
 
     def test_plain_init(self):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:
-            init_cmd = ["workflow_test_init", "0_basic_native.yml"]
+            init_cmd = ["workflow_job_init", "0_basic_native.yml"]
             self._check_exit_code(init_cmd)
-            test_path = os.path.join(f, "0_basic_native_tests.yml")
-            assert os.path.exists(test_path)
-            with open(test_path, "r") as stream:
-                test_config = yaml.safe_load(stream)
-            assert isinstance(test_config, list)
-            job_path = os.path.join(f, "0_basic_native_job1.yml")
+            job_path = os.path.join(f, "0_basic_native_job.yml")
             assert os.path.exists(job_path)
             with open(job_path, "r") as stream:
                 job = yaml.safe_load(stream)
@@ -28,16 +23,20 @@ class CmdWorkflowTestInitTestCase(CliTestCase):
 
     def test_cannot_overwrite(self):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:
-            init_cmd = ["workflow_test_init", "0_basic_native.yml"]
-            test_path = os.path.join(f, "0_basic_native_tests.yml")
-            with open(test_path, "w") as f:
+            init_cmd = ["workflow_job_init", "0_basic_native.yml"]
+            job_path = os.path.join(f, "0_basic_native_job.yml")
+            with open(job_path, "w") as f:
                 f.write("already exists")
             self._check_exit_code(init_cmd, exit_code=1)
 
     def test_force(self):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:
-            init_cmd = ["workflow_test_init", "--force", "0_basic_native.yml"]
-            test_path = os.path.join(f, "0_basic_native_tests.yml")
-            with open(test_path, "w") as f:
+            init_cmd = ["workflow_job_init", "--force", "0_basic_native.yml"]
+            job_path = os.path.join(f, "0_basic_native_job.yml")
+            with open(job_path, "w") as f:
                 f.write("already exists")
-            self._check_exit_code(init_cmd)
+            self._check_exit_code(init_cmd, exit_code=0)
+            with open(job_path, "r") as stream:
+                job = yaml.safe_load(stream)
+            assert isinstance(job, dict)
+            assert "the_input" in job


### PR DESCRIPTION
Nowhere near done but I want to discuss ``planemo run`` with workflows - including from the command line and using Planemo as a library. Against running servers and with Planemo managed ones, against dockerized Galaxy, against postgres, with CVMFS, etc... To incentivize people to use ``planemo run`` I added ``planemo workflow_job_init target.ga`` to build job files.

Also fixes ``--force`` for ``workflow_test_init``.