### PR TITLE
Fixes for CLI when external_galaxy is used as the engine

### DIFF
--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -35,7 +35,12 @@ def cli(ctx, uri, job_path, **kwds):
     is_cwl = path.endswith(".cwl")
     kwds["cwl"] = is_cwl
     if kwds.get("engine", None) is None:
-        kwds["engine"] = "galaxy" if not is_cwl else "cwltool"
+        if is_cwl:
+            kwds["engine"] = "cwltool"
+        elif kwds.get('galaxy_url', None):
+            kwds["engine"] = "external_galaxy"
+        else:
+            kwds["engine"] = "galaxy"
 
     with engine_context(ctx, **kwds) as engine:
         run_result = engine.run(path, job_path)

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -73,8 +73,13 @@ def cli(ctx, paths, **kwds):
         # Create temp dir(s) outside of temp, docker can't mount $TEMPDIR on OSX
         runnables = for_paths(paths, temp_path=temp_path)
         is_cwl = all(r.type in {RunnableType.cwl_tool, RunnableType.cwl_workflow} for r in runnables)
-        if kwds.get("engine") is None:
-            kwds["engine"] = "galaxy" if not is_cwl else "cwltool"
+        if kwds.get("engine", None) is None:
+            if is_cwl:
+                kwds["engine"] = "cwltool"
+            elif kwds.get('galaxy_url', None):
+                kwds["engine"] = "external_galaxy"
+            else:
+                kwds["engine"] = "galaxy"
 
         return_value = test_runnables(ctx, runnables, original_paths=paths, **kwds)
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -761,7 +761,7 @@ class BaseGalaxyConfig(GalaxyInterface):
                 self._install_workflow(runnable)
 
     def _install_workflow(self, runnable):
-        if self._kwds.get("shed_install") and self._kwds.get("engine") != "external_galaxy":
+        if self._kwds.get("shed_install") and (self._kwds.get("engine") != "external_galaxy" or self._kwds.get("galaxy_admin_key")):
             install_shed_repos(runnable,
                                self.gi,
                                self._kwds.get("ignore_dependency_problems", False),

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -761,7 +761,7 @@ class BaseGalaxyConfig(GalaxyInterface):
                 self._install_workflow(runnable)
 
     def _install_workflow(self, runnable):
-        if self._kwds.get("shed_install"):
+        if self._kwds.get("shed_install") and self._kwds.get("engine") != "external_galaxy":
             install_shed_repos(runnable,
                                self.gi,
                                self._kwds.get("ignore_dependency_problems", False),


### PR DESCRIPTION
Two minor changes:
* when `--galaxy_url` is specified, the engine should be `external_galaxy` by default without this having to be additionally specified.
* when tools/workflows are run on an external galaxy, planemo should not attempt to install shed repositories (at the very least, not by default). See #1071.