### PR TITLE
Changes to update_test_data testing mode

### DIFF
--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -39,6 +39,8 @@ PROBLEM_COUNT_MESSAGE = ("There were problems with %d test(s) - out of %d "
 GENERIC_PROBLEMS_MESSAGE = ("One or more tests failed. See %s for detailed "
                             "breakdown.")
 GENERIC_TESTS_PASSED_MESSAGE = "No failing tests encountered."
+TEST_DATA_UPDATED_MESSAGE = "Test data were updated and tests were rerun."
+TEST_DATA_NOT_UPDATED_MESSAGE = "%s Therefore, no test data were updated." % ALL_TESTS_PASSED_MESSAGE
 
 
 def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None, **kwds):
@@ -95,8 +97,18 @@ def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None
         config.env,
         action
     )
-    if kwds.get('update_test_data', False):
-        copy_tree(job_output_files, test_data_target_dir or config.test_data_dir)
+    if return_code != 0 and kwds.get('update_test_data', False):
+        for test_data_dir in [config.test_data_dir, test_data_target_dir]:
+            if test_data_dir:
+                copy_tree(job_output_files, test_data_dir)
+        kwds['test_data_updated'] = True
+        info('Test data updated. Rerunning...')
+        return_code = run(
+                ctx,
+                cmd,
+                config.env,
+                action
+            )
 
     _check_test_outputs(xunit_report_file_tracker, structured_report_file_tracker)
     test_results = test_structures.GalaxyTestResults(
@@ -217,11 +229,16 @@ def _handle_summary(
         summary_exit_code = EXIT_CODE_NO_SUCH_TARGET
 
     summary_style = kwds.get("summary")
+    if kwds.get('test_data_updated'):
+        info(TEST_DATA_UPDATED_MESSAGE)
     if summary_style != "none":
         if num_tests == 0:
             warn(NO_TESTS_MESSAGE)
         elif num_problems == 0:
-            info(ALL_TESTS_PASSED_MESSAGE % num_tests)
+            if kwds.get('update_test_data') and not kwds.get('test_data_updated'):
+                info(TEST_DATA_NOT_UPDATED_MESSAGE % num_tests)
+            else:
+                info(ALL_TESTS_PASSED_MESSAGE % num_tests)
         elif num_problems:
             html_report_file = kwds.get("test_output")
             message_args = (num_problems, num_tests, html_report_file)


### PR DESCRIPTION
I tried to improve the 'update test data' mode to make it a bit more user-friendly, see https://github.com/galaxyproject/planemo/issues/1070. Ping @fubar2.

The currently behaviour is that the `--update_test_data` flag just causes the job_output_files dir to be copied back to the test dir. So the test results confusingly do not actually relate to the new updated data at all. Furthermore, if tests fail, the command needs to be rerun to check that they work with the new data.

New behaviour in this PR when the `--update_test_data` flag is used:
* if tests fail, tests are automatically rerun after the test data has been updated, so that the results the user gets at the end relate to the new data, as expected. The user is  informed that `Test data were updated and tests were rerun.`
* if the tests pass, the test data are not updated and the user is explicitly informed that `All x test(s) executed passed. Therefore, no test data were updated.`