### PR TITLE
Add workflow_upload command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ env:
   PLANEMO_TEST_WORKFLOW_RUN_PROFILE: 1
   PGPASSWORD: postgres
   PGHOST: localhost
+  GIT_AUTHOR_NAME: planemo
+  GIT_AUTHOR_EMAIL: planemo@galaxyproject.org
+  GIT_COMMITTER_NAME: planemo
+  GIT_COMMITTER_EMAIL: planemo@galaxyproject.org
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/planemo/commands/cmd_ci_find_repos.py
+++ b/planemo/commands/cmd_ci_find_repos.py
@@ -16,8 +16,8 @@ from planemo.shed import find_raw_repositories
 def cli(ctx, paths, **kwds):
     """Find all shed repositories in one or more directories.
 
-    Currently, a shed repository is considered a directory with a .shed.yml
-    file.
+    Currently, a repository is considered any directory with a .shed.yml
+    or .dockstore.yml file.
     """
     kwds["recursive"] = True
     kwds["fail_fast"] = True

--- a/planemo/commands/cmd_workflow_upload.py
+++ b/planemo/commands/cmd_workflow_upload.py
@@ -1,0 +1,42 @@
+"""Module describing the planemo ``workflow_upload`` command."""
+from collections import defaultdict
+from pathlib import Path
+
+import click
+from gxformat2.yaml import ordered_load_path
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.github_util import create_release
+from planemo.workflow_lint import find_workflow_descriptions
+
+
+@click.command('workflow_upload')
+@options.github_namespace()
+@options.dry_run()
+@options.optional_tools_or_packages_arg(multiple=True)
+@command_function
+def cli(ctx, paths, namespace, dry_run, **kwds):
+    """Upload workflows to github organization."""
+    owner = namespace
+    for path in paths:
+        path = Path(path).absolute()
+        if path.is_dir():
+            repo = path.name
+        else:
+            repo = path.parent.name
+            path = path.parent
+        versions = defaultdict(list)
+        for workflow_file in find_workflow_descriptions(path):
+            workflow = ordered_load_path(workflow_file)
+            version = workflow.get('release')
+            if not version:
+                raise Exception("Must set a release version in workflow file '{}'".format(workflow_file))
+            versions[version].append(workflow_file)
+            if len(versions) > 1:
+                msg = ""
+                for version, paths in versions.items():
+                    msg = "{}version: {}\npaths: {}".format(msg, version, "\n".join(paths))
+                raise Exception("All workflows in repository must have same version.\n{}".format(msg))
+        if versions:
+            create_release(ctx, from_dir=path, target_dir=repo, owner=owner, repo=repo, version=version, dry_run=dry_run)

--- a/planemo/git.py
+++ b/planemo/git.py
@@ -19,6 +19,15 @@ def git_env_for(path):
     return env
 
 
+def ls_remote(ctx, remote_repo):
+    """Return a dictionary with refs as key and commits as value."""
+    commits_and_refs = io.communicate(
+        ["git", "ls-remote", remote_repo],
+        stdout=subprocess.PIPE,
+    )[0]
+    return dict(line.split()[::-1] for line in commits_and_refs.decode('utf-8').splitlines())
+
+
 def init(ctx, repo_path):
     env = git_env_for(repo_path)
     io.communicate(["git", "init"], env=env)
@@ -41,7 +50,7 @@ def push(ctx, repo_path, to=None, branch=None, force=False):
         cmd += ["--force"]
     if to and branch:
         cmd += [to, branch]
-    io.communicate(cmd, env=env)
+    io.communicate(cmd, env=env, cwd=repo_path)
 
 
 def branch(ctx, repo_path, branch, from_branch=None):

--- a/planemo/git.py
+++ b/planemo/git.py
@@ -11,16 +11,22 @@ from planemo import io
 
 def git_env_for(path):
     """Setup env dictionary to target specified git repo with git commands."""
-    env = {
+    env = os.environ.copy()
+    env.update({
         "GIT_WORK_DIR": path,
         "GIT_DIR": os.path.join(path, ".git")
-    }
+    })
     return env
+
+
+def init(ctx, repo_path):
+    env = git_env_for(repo_path)
+    io.communicate(["git", "init"], env=env)
 
 
 def add(ctx, repo_path, file_path):
     env = git_env_for(repo_path)
-    io.communicate("cd '%s' && git add '%s'" % (repo_path, os.path.abspath(file_path)), env=env)
+    io.communicate(["git", "add", os.path.relpath(file_path, repo_path)], env=env, cwd=repo_path)
 
 
 def commit(ctx, repo_path, message=""):
@@ -28,12 +34,13 @@ def commit(ctx, repo_path, message=""):
     io.communicate(["git", "commit", "-m", message], env=env)
 
 
-def push(ctx, repo_path, to, branch, force=False):
+def push(ctx, repo_path, to=None, branch=None, force=False):
     env = git_env_for(repo_path)
     cmd = ["git", "push"]
     if force:
         cmd += ["--force"]
-    cmd += [to, branch]
+    if to and branch:
+        cmd += [to, branch]
     io.communicate(cmd, env=env)
 
 

--- a/planemo/github_util.py
+++ b/planemo/github_util.py
@@ -88,8 +88,19 @@ def create_repository(ctx, owner, repo, dest, dry_run, **kwds):
     return os.path.join(dest, repo)
 
 
+def rm_dir_contents(directory, ignore_dirs=(".git")):
+    directory = Path(directory)
+    for item in directory.iterdir():
+        if not item.name in ignore_dirs:
+            if item.is_dir():
+                rm_dir_contents(item)
+            else:
+                item.unlink()
+
+
 def add_dir_contents_to_repo(ctx, from_dir, target_dir, target_repository_path, version, dry_run, notes=""):
     ctx.log("From {} to {}".format(from_dir, target_repository_path))
+    rm_dir_contents(target_repository_path)
     copy_tree(from_dir, target_repository_path)
     git.add(ctx, target_repository_path, target_repository_path)
     message = "Update for version {version}".format(version=version)

--- a/planemo/github_util.py
+++ b/planemo/github_util.py
@@ -127,7 +127,7 @@ def _get_raw_github_config(ctx):
                 "access_token": os.environ["GITHUB_TOKEN"],
             }
     if "github" not in ctx.global_config:
-        raise Exception("github account not found in planemo config and GITHUB_USER / GITHUB_PASSWORD environment variables unset")
+        raise Exception("github account not found in planemo config and GITHUB_TOKEN environment variables unset")
     return ctx.global_config["github"]
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1079,6 +1079,25 @@ def conda_target_options(include_local=True):
     )
 
 
+def github_namespace():
+    return planemo_option(
+        '--namespace',
+        use_env_var=True,
+        help=('Organization or username under which to create or update workflow repository. '
+              'Must be a valid github username or organization'),
+        default="iwc-workflows"
+    )
+
+
+def dry_run():
+    return planemo_option(
+        '--dry_run',
+        help="Don't execute action, show preview of action.",
+        is_flag=True,
+        default=False,
+    )
+
+
 def galaxy_run_options():
     return _compose(
         galaxy_target_options(),

--- a/tests/test_github_create_release.py
+++ b/tests/test_github_create_release.py
@@ -6,6 +6,7 @@ import pytest
 from planemo import git
 from planemo.github_util import (
     add_dir_contents_to_repo,
+    assert_new_version,
     get_or_create_repository,
 )
 from planemo.io import temp_directory
@@ -68,3 +69,19 @@ def test_add_dir_contents_to_repo_dry_run():
             notes='The big release!',
             dry_run=True
         )
+
+
+def test_git_ls_remote():
+    ctx = test_context()
+    tags_and_commits = git.ls_remote(ctx, 'https://github.com/galaxyproject/galaxy')
+    assert 'refs/heads/release_20.09' in tags_and_commits
+
+
+def test_assert_is_new_version_raises_exception():
+    with pytest.raises(Exception) as excinfo:
+        assert_new_version(None, version='v20.05', owner='galaxyproject', repo='galaxy')
+    assert "Please change the version" in str(excinfo)
+
+
+def test_assert_is_new_version():
+    assert_new_version(None, version='v20.06', owner='galaxyproject', repo='galaxy')

--- a/tests/test_github_create_release.py
+++ b/tests/test_github_create_release.py
@@ -1,0 +1,70 @@
+import os
+import uuid
+
+import pytest
+
+from planemo import git
+from planemo.github_util import (
+    add_dir_contents_to_repo,
+    get_or_create_repository,
+)
+from planemo.io import temp_directory
+from .test_utils import (
+    test_context,
+)
+
+
+def test_get_or_create_repo_with_existing_repo():
+    ctx = test_context()
+    ctx._global_config = {"github": {"access_token": 'ABCDEFG'}}
+    repository_path = get_or_create_repository(ctx, owner='galaxyproject', repo='planemo', dry_run=False)
+    assert os.path.exists(os.path.join(repository_path, 'README.rst'))
+
+
+def test_get_or_create_repo_with_new_repo():
+    ctx = test_context()
+    ctx._global_config = {"github": {"access_token": 'ABCDEFG'}}
+    with pytest.raises(RuntimeError) as excinfo:
+        # Token isn't valid, so this errors out while running gh create
+        get_or_create_repository(ctx, owner=str(uuid.uuid4()), repo='some-repo', dry_run=False)
+    assert "Problem executing commands" in str(excinfo.value)
+    assert "gh repo create -y" in str(excinfo.value)
+
+
+def test_add_dir_contents_to_repo():
+    ctx = test_context()
+    ctx._global_config = {"github": {"access_token": 'ABCDEFG'}}
+    with temp_directory() as test_dir, temp_directory() as repo_dir:
+        with open(os.path.join(test_dir, 'Readme.md'), 'w') as readme:
+            readme.write('#Very important!')
+        git.init(ctx, repo_path=repo_dir)
+        with pytest.raises(RuntimeError) as excinfo:
+            # Can't push without remote
+            add_dir_contents_to_repo(
+                ctx,
+                from_dir=test_dir,
+                target_dir="workflows/my-cool-workflow",
+                target_repository_path=repo_dir,
+                version=1.0,
+                notes='The big release!',
+                dry_run=False
+            )
+        assert "Problem executing commands git push" in str(excinfo.value)
+
+
+def test_add_dir_contents_to_repo_dry_run():
+    ctx = test_context()
+    ctx._global_config = {"github": {"access_token": 'ABCDEFG'}}
+    with temp_directory() as test_dir, temp_directory() as repo_dir:
+        with open(os.path.join(test_dir, 'Readme.md'), 'w') as readme:
+            readme.write('#Very important!')
+        git.init(ctx, repo_path=repo_dir)
+        add_dir_contents_to_repo(
+            ctx,
+            from_dir=test_dir,
+            target_dir="workflows/my-cool-workflow",
+            target_repository_path=repo_dir,
+            version=1.0,
+            notes='The big release!',
+            dry_run=True
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv =
     PG*
     HOME
     DOCS
+    GIT_*
 
 deps =
     lint: flake8-import-order


### PR DESCRIPTION
`planemo workflow_upload` will update or create a github repository with the contents of a directory that contains a workflow.
Every upload will create a new release. Workflow versions are taken from the workflow files.

Also moves from `hub` to `gh` and makes `planemo ci_find_repos` return directories with workflows.

TODO:
- [x] Check if version already exists / handle empty diff ?
- [ ] `--force` that will override existing version
- [x] Handle deleted files (remove everything in work dir, then copy ?)