### PR TITLE
Some fixes for workflow_job_init and workflow_test_init

### DIFF
--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -153,7 +153,10 @@ def input_labels(workflow_path):
 
 
 def required_input_steps(workflow_path):
-    steps = inputs_normalized(workflow_path=workflow_path)
+    try:
+        steps = inputs_normalized(workflow_path=workflow_path)
+    except Exception:
+        raise Exception("Input workflow could not be successfully normalized - try linting with planemo workflow_lint.")
     required_steps = []
     for input_step in steps:
         if input_step.get("optional", False) or input_step.get("default"):
@@ -198,12 +201,12 @@ def job_template(workflow_path):
     for required_input_step in required_input_steps(workflow_path):
         i_label = input_label(required_input_step)
         input_type = required_input_step["type"]
-        if input_type == "data_input":
+        if input_type == "data":
             template[i_label] = {
                 "class": "File",
                 "path": "todo_test_data_path.ext",
             }
-        elif input_type == "data_collection_input":
+        elif input_type == "collection":
             template[i_label] = {
                 "class": "Collection",
                 "collection_type": "list",
@@ -215,6 +218,8 @@ def job_template(workflow_path):
                     }
                 ],
             }
+        elif input_type in ['string', 'int', 'float', 'boolean', 'color']:
+            template[i_label] = "todo_param_value"
         else:
             template[i_label] = {
                 "TODO",  # Does this work yet?

--- a/tests/test_cmd_workflow_job_init.py
+++ b/tests/test_cmd_workflow_job_init.py
@@ -20,6 +20,7 @@ class CmdWorkflowJobInitTestCase(CliTestCase):
                 job = yaml.safe_load(stream)
             assert isinstance(job, dict)
             assert "the_input" in job
+            assert job.get("the_input").get("path") == "todo_test_data_path.ext"
 
     def test_cannot_overwrite(self):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:

--- a/tests/test_cmd_workflow_test_init.py
+++ b/tests/test_cmd_workflow_test_init.py
@@ -36,6 +36,7 @@ class CmdWorkflowTestInitTestCase(CliTestCase):
                 job = yaml.safe_load(stream)
             assert isinstance(job, dict)
             assert "the_input" in job
+            assert job.get("the_input").get("path") == "todo_test_data_path.ext"
 
     def test_cannot_overwrite(self):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:


### PR DESCRIPTION
- Recognize the input types as specified by gxformat2 here: https://github.com/galaxyproject/gxformat2/blob/master/gxformat2/model.py#L66
- Add parameters
- Add a more helpful error message for unlinted workflows