### PR TITLE
consider exclude in shed update

### DIFF
--- a/planemo/commands/cmd_shed_build.py
+++ b/planemo/commands/cmd_shed_build.py
@@ -20,7 +20,8 @@ def cli(ctx, path, **kwds):
     (which you could upload to the Tool Shed manually).
     """
     def build(realized_repository):
-        tarpath = shed.build_tarball(realized_repository.path)
+        exclude = shed._shed_config_excludes(realized_repository.config)
+        tarpath = shed.build_tarball(realized_repository.path, exclude)
         outpath = realized_repository.real_path + ".tar.gz"
         shutil.move(tarpath, outpath)
         print("Created: %s" % (outpath))

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -289,7 +289,7 @@ def report_non_existent_repository(realized_repository):
 def upload_repository(ctx, realized_repository, **kwds):
     """Upload a tool directory as a tarball to a tool shed."""
     path = realized_repository.path
-    exclude = realized_repository.config.get("exclude", [])
+    exclude = _shed_config_excludes(realized_repository.config)
     tar_path = kwds.get("tar")
     if not tar_path:
         tar_path = build_tarball(path, exclude, **kwds)
@@ -707,7 +707,7 @@ def create_repository_for(ctx, tsi, name, repo_config):
 
 
 def download_tarball(ctx, shed_context, realized_repository, **kwds):
-    exclude = realized_repository.config.get("exclude", [])
+    exclude = _shed_config_excludes(realized_repository.config)
     repo_id = realized_repository.find_repository_id(ctx, shed_context)
     if repo_id is None:
         message = "Unable to find repository id, cannot download."

--- a/planemo/shed/interface.py
+++ b/planemo/shed/interface.py
@@ -99,13 +99,15 @@ def find_category_ids(tsi, categories):
     return category_ids
 
 
-def download_tar(tsi, repo_id, destination, to_directory):
+def download_tar(tsi, repo_id, destination, to_directory, exclude):
     base_url = tsi.base_url
     if not base_url.endswith("/"):
         base_url += "/"
     download_url = REPOSITORY_DOWNLOAD_TEMPLATE % (base_url, repo_id)
     if to_directory:
         tar_args = ['-xzf', '-', '--strip-components=1']
+        for e in exclude:
+            tar_args.extend(["--exclude", e])
         untar_to(download_url, tar_args=tar_args, dest_dir=destination)
     else:
         untar_to(download_url, path=destination)


### PR DESCRIPTION
by considering exclude when

- build and downloading tar balls
- diff

shed update should now consider exclude in .shed.yml

I checked this (https://github.com/galaxyproject/planemo/pull/1106/commits/a1e2cae620bf195c70ea97ae09f3ea0db8488861) in the following way on the TTS. 

- added a file (exclude.txt) to a repo (https://testtoolshed.g2.bx.psu.edu/repos/mbernt/fail)
- shed_update
- added the exclude to shed.yml
- shed_update

Afterwards the file was gone again (on the TTS).

Would be great to have for updating the OpenMS tools (where we have quite a few extra files in the TS that shouldn't be there, i.e. we would like to remove them from the TS and not consider them for the question if a repo should be updated). 

TODO(?):

- [ ] I guess we could/should do the same for include, but I'm not sure what the default '**' does
- [ ] not sure if the use of exclude in diff, os.walk, and tar is equivalent (which would be nice) .. also it should be consistent with the docs (https://planemo.readthedocs.io/en/latest/standards/docs/best_practices/shed_yml.html#shed-upload-includes-excludes) and I think it is not yet
- [ ] which other planemo commands no not consider exclude/include and should


may fix: https://github.com/galaxyproject/planemo/issues/554