### PR TITLE
Require tabulate for list_invocations.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pyaml
 pyyaml
 six>=1.7.0
 virtualenv
+tabulate


### PR DESCRIPTION
It doesn't have any requirements itself and is MIT licensed, so why not.