### PR TITLE
Allow referencing remote URI runnables with local effective paths.

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -14,7 +14,7 @@ from planemo.runnable_resolve import for_runnable_identifiers
 
 
 @click.command('test')
-@options.optional_tools_arg(multiple=True)
+@options.optional_tools_arg(multiple=True, allow_uris=True)
 @click.option(
     "--failed",
     is_flag=True,
@@ -37,7 +37,7 @@ from planemo.runnable_resolve import for_runnable_identifiers
 @options.test_options()
 @options.engine_options()
 @command_function
-def cli(ctx, paths, **kwds):
+def cli(ctx, uris, **kwds):
     """Run specified tool's tests within Galaxy.
 
     All referenced tools (by default all the tools in the current working
@@ -67,7 +67,7 @@ def cli(ctx, paths, **kwds):
     """
     with temp_directory(dir=ctx.planemo_directory) as temp_path:
         # Create temp dir(s) outside of temp, docker can't mount $TEMPDIR on OSX
-        runnables = for_runnable_identifiers(ctx, paths, kwds, temp_path=temp_path)
+        runnables = for_runnable_identifiers(ctx, uris, kwds, temp_path=temp_path)
 
         # pick a default engine type if needed
         is_cwl = all(r.type in {RunnableType.cwl_tool, RunnableType.cwl_workflow} for r in runnables)
@@ -79,6 +79,6 @@ def cli(ctx, paths, **kwds):
             else:
                 kwds["engine"] = "galaxy"
 
-        return_value = test_runnables(ctx, runnables, original_paths=paths, **kwds)
+        return_value = test_runnables(ctx, runnables, original_paths=uris, **kwds)
 
     ctx.exit(return_value)

--- a/planemo/galaxy/api.py
+++ b/planemo/galaxy/api.py
@@ -4,14 +4,14 @@ from six import StringIO
 from planemo.bioblend import ensure_module
 from planemo.bioblend import galaxy
 
-DEFAULT_MASTER_API_KEY = "test_key"
+DEFAULT_ADMIN_API_KEY = "test_key"
 
 
 def gi(port=None, url=None, key=None):
     """Return a bioblend ``GalaxyInstance`` for Galaxy on this port."""
     ensure_module()
     if key is None:
-        key = DEFAULT_MASTER_API_KEY
+        key = DEFAULT_ADMIN_API_KEY
     if port is None:
         url = url
     else:
@@ -131,7 +131,7 @@ def _dataset_provenance(gi, history_id, id):
 
 
 __all__ = (
-    "DEFAULT_MASTER_API_KEY",
+    "DEFAULT_ADMIN_API_KEY",
     "gi",
     "user_api_key",
 )

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -39,7 +39,7 @@ from planemo.mulled import build_involucro_context
 from planemo.shed import tool_shed_url
 from planemo.virtualenv import DEFAULT_PYTHON_VERSION
 from .api import (
-    DEFAULT_MASTER_API_KEY,
+    DEFAULT_ADMIN_API_KEY,
     gi,
     user_api_key,
 )
@@ -562,7 +562,7 @@ def external_galaxy_config(ctx, runnables, for_tests=False, **kwds):
 
 
 def _get_master_api_key(kwds):
-    master_api_key = kwds.get("galaxy_admin_key") or DEFAULT_MASTER_API_KEY
+    master_api_key = kwds.get("galaxy_admin_key") or DEFAULT_ADMIN_API_KEY
     return master_api_key
 
 

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -2,6 +2,7 @@
 import json
 import os
 from collections import namedtuple
+from urllib.parse import urlparse
 
 import yaml
 from ephemeris import generate_tool_list_from_ga_workflow_files
@@ -14,7 +15,7 @@ from gxformat2.normalize import inputs_normalized, outputs_normalized
 from planemo.io import warn
 
 FAILED_REPOSITORIES_MESSAGE = "Failed to install one or more repositories."
-GALAXY_WORKFLOWS_PREFIX = "gxprofile://workflows/"
+GALAXY_WORKFLOWS_PREFIX = "gxid://workflows/"
 
 
 def load_shed_repos(runnable):
@@ -109,8 +110,8 @@ WorkflowOutput = namedtuple("WorkflowOutput", ["order_index", "output_name", "la
 
 def remote_runnable_to_workflow_id(runnable):
     assert runnable.is_remote_workflow_uri
-    workflow_id = runnable.uri[len(GALAXY_WORKFLOWS_PREFIX):]
-    return workflow_id
+    parse_result = urlparse(runnable.uri)
+    return parse_result.path[1:]
 
 
 def describe_outputs(runnable, gi=None):

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -7,6 +7,7 @@ import collections
 import os
 from distutils.dir_util import copy_tree
 from enum import auto, Enum
+from urllib.parse import urlparse
 
 import yaml
 from galaxy.tool_util.cwl.parser import workflow_proxy
@@ -76,8 +77,25 @@ class Runnable(_Runnable):
 
     @property
     def path(self):
-        assert not self.is_remote_workflow_uri
-        return self.uri
+        uri = self.uri
+        if self.is_remote_workflow_uri:
+            parse_result = urlparse(uri)
+            query = parse_result.query
+            if query:
+                assert query.startswith("runnable_path=")
+                return query[len("runnable_path="):]
+            else:
+                raise ValueError(f"Runnable with URI {uri} is remote resource without local path")
+        else:
+            return uri
+
+    @property
+    def has_path(self):
+        try:
+            self.path
+            return True
+        except ValueError:
+            return False
 
     @property
     def is_remote_workflow_uri(self):
@@ -184,9 +202,9 @@ def for_paths(paths, temp_path=None):
     return [for_path(path, temp_path=temp_path) for path in paths]
 
 
-def for_id(runnable_id):
+def for_uri(uri):
     """Produce a class:`Runnable` for supplied Galaxy workflow ID."""
-    uri = GALAXY_WORKFLOWS_PREFIX + runnable_id
+    # TODO: allow galaxy_tool also, this trick would work fine for running tools
     runnable = Runnable(uri, RunnableType.galaxy_workflow)
     return runnable
 

--- a/planemo/runnable_resolve.py
+++ b/planemo/runnable_resolve.py
@@ -1,10 +1,11 @@
 import os
 
 from planemo.galaxy.profiles import translate_alias
+from planemo.galaxy.workflows import GALAXY_WORKFLOWS_PREFIX
 from planemo.tools import uri_to_path
 from .runnable import (
-    for_id,
     for_path,
+    for_uri,
 )
 
 
@@ -13,11 +14,14 @@ def for_runnable_identifier(ctx, runnable_identifier, kwds, temp_path=None):
     # could be a URI, path, or alias
     current_profile = kwds.get('profile')
     runnable_identifier = translate_alias(ctx, runnable_identifier, current_profile)
-    runnable_identifier = uri_to_path(ctx, runnable_identifier)
+    if not runnable_identifier.startswith(GALAXY_WORKFLOWS_PREFIX):
+        runnable_identifier = uri_to_path(ctx, runnable_identifier)
     if os.path.exists(runnable_identifier):
         runnable = for_path(runnable_identifier, temp_path=temp_path)
     else:  # assume galaxy workflow id
-        runnable = for_id(runnable_identifier)
+        if not runnable_identifier.startswith(GALAXY_WORKFLOWS_PREFIX):
+            runnable_identifier = f"{GALAXY_WORKFLOWS_PREFIX}{runnable_identifier}"
+        runnable = for_uri(runnable_identifier)
     return runnable
 
 

--- a/tests/test_cmd_serve.py
+++ b/tests/test_cmd_serve.py
@@ -28,7 +28,41 @@ TEST_HISTORY_NAME = "Cool History 42"
 SERVE_TEST_VERBOSE = True
 
 
-class ServeTestCase(CliTestCase):
+class UsesServeCommand:
+
+    def _run(self, serve_args=[], serve_cmd="serve"):
+        serve_cmd = self._serve_command_list(serve_args, serve_cmd)
+        if run_verbosely():
+            print("Running command for test [%s]" % serve_cmd)
+        self._check_exit_code(serve_cmd)
+
+    def _serve_command_list(self, serve_args=[], serve_cmd="serve"):
+        test_cmd = ["--verbose"] if run_verbosely() else []
+        test_cmd.extend([
+            serve_cmd,
+            "--galaxy_root", self.galaxy_root,
+            "--galaxy_branch", target_galaxy_branch(),
+            "--no_dependency_resolution",
+            "--port", str(self._port),
+            self._serve_artifact,
+        ])
+        test_cmd.extend(serve_args)
+        return test_cmd
+
+    def _launch_thread_and_wait(self, func, args=[], **kwd):
+        future = launch_and_wait_for_galaxy(self._port, func, [args], **kwd)
+        if future is not None:
+            self._futures.append(future)
+
+    @property
+    def _user_gi(self):
+        admin_gi = api.gi(self._port)
+        user_api_key = api.user_api_key(admin_gi)
+        user_gi = api.gi(self._port, key=user_api_key)
+        return user_gi
+
+
+class ServeTestCase(CliTestCase, UsesServeCommand):
 
     @classmethod
     def setUpClass(cls):
@@ -99,7 +133,11 @@ class ServeTestCase(CliTestCase):
         assert len(user_gi.histories.get_histories(name=TEST_HISTORY_NAME)) == 0
         user_gi.histories.create_history(TEST_HISTORY_NAME)
         assert user_gi.tools.get_tools(tool_id="random_lines1")
-        assert len(user_gi.workflows.get_workflows()) == 1
+        workflows = user_gi.workflows.get_workflows()
+        assert len(workflows) == 1
+        workflow = workflows[0]
+        workflow_id = workflow["id"]
+        assert workflow_id
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     @skip_if_environ("PLANEMO_SKIP_SHED_TESTS")
@@ -154,36 +192,5 @@ class ServeTestCase(CliTestCase):
         with cli_daemon_galaxy(self._runner, self._pid_file, self._port, serve_cmd):
             assert len(user_gi.histories.get_histories(name=TEST_HISTORY_NAME)) == 1
 
-    @property
-    def _user_gi(self):
-        admin_gi = api.gi(self._port)
-        user_api_key = api.user_api_key(admin_gi)
-        user_gi = api.gi(self._port, key=user_api_key)
-        return user_gi
-
-    def _launch_thread_and_wait(self, func, args=[], **kwd):
-        future = launch_and_wait_for_galaxy(self._port, func, [args], **kwd)
-        if future is not None:
-            self._futures.append(future)
-
     def _run_shed(self, serve_args=[]):
         return self._run(serve_args=serve_args, serve_cmd="shed_serve")
-
-    def _run(self, serve_args=[], serve_cmd="serve"):
-        serve_cmd = self._serve_command_list(serve_args, serve_cmd)
-        if run_verbosely():
-            print("Running command for test [%s]" % serve_cmd)
-        self._check_exit_code(serve_cmd)
-
-    def _serve_command_list(self, serve_args=[], serve_cmd="serve"):
-        test_cmd = ["--verbose"] if run_verbosely() else []
-        test_cmd.extend([
-            serve_cmd,
-            "--galaxy_root", self.galaxy_root,
-            "--galaxy_branch", target_galaxy_branch(),
-            "--no_dependency_resolution",
-            "--port", str(self._port),
-            self._serve_artifact,
-        ])
-        test_cmd.extend(serve_args)
-        return test_cmd

--- a/tests/test_cmds_with_workflow_id.py
+++ b/tests/test_cmds_with_workflow_id.py
@@ -1,0 +1,76 @@
+import json
+import os
+import tempfile
+import time
+
+from planemo import network_util
+from planemo.galaxy import api
+from .test_cmd_serve import UsesServeCommand
+from .test_utils import (
+    CliTestCase,
+    mark,
+    PROJECT_TEMPLATES_DIR,
+    safe_rmtree,
+    skip_if_environ,
+    TEST_DATA_DIR,
+)
+
+TEST_HISTORY_NAME = "Cool History 42"
+SERVE_TEST_VERBOSE = True
+
+
+class CmdsWithWorkflowIdTestCase(CliTestCase, UsesServeCommand):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.galaxy_root = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        safe_rmtree(cls.galaxy_root)
+
+    def setUp(self):
+        super(CmdsWithWorkflowIdTestCase, self).setUp()
+        self._port = network_util.get_free_port()
+        self._pid_file = os.path.join(self._home, "test.pid")
+
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    @mark.tests_galaxy_branch
+    def test_serve_workflow(self):
+        with self._isolate() as f:
+            random_lines = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "randomlines.xml")
+            cat = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml")
+            self._serve_artifact = os.path.join(TEST_DATA_DIR, "wf1.gxwf.yml")
+            extra_args = [
+                "--daemon",
+                "--skip_client_build",
+                "--pid_file", self._pid_file,
+                "--extra_tools", random_lines,
+                "--extra_tools", cat,
+            ]
+            self._launch_thread_and_wait(self._run, extra_args)
+            time.sleep(30)
+            user_gi = self._user_gi
+            assert len(user_gi.histories.get_histories(name=TEST_HISTORY_NAME)) == 0
+            user_gi.histories.create_history(TEST_HISTORY_NAME)
+            assert user_gi.tools.get_tools(tool_id="random_lines1")
+            workflows = user_gi.workflows.get_workflows()
+            assert len(workflows) == 1
+            workflow = workflows[0]
+            workflow_id = workflow["id"]
+
+            test_command = [
+                "test",
+                "--engine",
+                "external_galaxy",
+                "--galaxy_url",
+                f"http://localhost:{self._port}",
+                "--galaxy_admin_key",
+                api.DEFAULT_ADMIN_API_KEY,
+                f"gxid://workflows/{workflow_id}?runnable_path={self._serve_artifact}",
+            ]
+            self._check_exit_code(test_command, exit_code=0)
+            output_json_path = os.path.join(f, "tool_test_output.json")
+            with open(output_json_path, "r") as f:
+                output = json.load(f)
+            assert "tests" in output

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ setenv =
     trainingwfcmd: PYTEST_TARGET="tests/test_cmd_training_generate_from_wf.py"
     runcmd: PYTEST_TARGET="tests/test_run.py::RunTestCase::test_run_gxtool_randomlines"
     wftest: PYTEST_TARGET="tests/test_test_engines.py::test_galaxy_wf_tests"
+    wfidtest: PYTEST_TARGET="tests/test_cmds_with_workflow_id.py"
     condatest: PYTEST_TARGET="tests/test_cmd_test_conda.py::CmdTestCondaTestCase::test_conda_dependencies_by_default"
     nonredundant: PLANEMO_SKIP_REDUNDANT_TESTS=1
     noclientbuild: PLANEMO_SKIP_GALAXY_CLIENT_TESTS=1


### PR DESCRIPTION
This way we can use local test artifacts with remote workflows in running servers.