### PR TITLE
Fix ci_find_tools and ci_find_repos commands

### DIFF
--- a/planemo/ci.py
+++ b/planemo/ci.py
@@ -32,13 +32,12 @@ def filter_paths(ctx, raw_paths, path_type="repo", **kwds):
                 diff_path = metadata_file_in_path(diff_dir)
                 if diff_path:
                     diff_paths.add(diff_path)
-                    break
         else:
             diff_paths = diff_files
 
     unique_paths = set(os.path.relpath(p, cwd) for p in raw_paths)
     if diff_paths is not None:
-        unique_paths = list(diff_paths)
+        unique_paths = unique_paths.intersection(diff_paths)
     filtered_paths = sorted(io.filter_paths(unique_paths, cwd=cwd, **filter_kwds))
     excluded_paths = sorted(set(unique_paths) - set(filtered_paths))
     if excluded_paths:


### PR DESCRIPTION
Broken in commit 4f7d71878521cb95c0e0a93f6513a1e09a237472 (i.e. affects planemo 0.73.0 and 0.74.0).

See https://github.com/galaxyproject/tools-iuc/pull/3403/files#r550500487