### PR TITLE
Bump galaxy-tool-util version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cwltool>=1.0.20191225192155
 docutils
 ephemeris>=0.10.3
 galaxy-containers
-galaxy-tool-util>=20.9.0.dev2
+galaxy-tool-util>=21.1.0.dev4
 galaxy-util>=20.5.0
 glob2
 gxformat2>=0.12.0


### PR DESCRIPTION
Specifically, so that that these two little PRs are available: https://github.com/galaxyproject/galaxy/pull/10334, https://github.com/galaxyproject/galaxy/pull/10886