### PR TITLE
Make simultaneous file upload configurable for planemo run / test

### DIFF
--- a/planemo/options.py
+++ b/planemo/options.py
@@ -618,6 +618,17 @@ def conda_global_option():
     )
 
 
+def simultaneous_upload_option():
+    return planemo_option(
+        "--simultaneous_uploads/--no_simultaneous_uploads",
+        is_flag=True,
+        default=False,
+        help=("When uploading files to Galaxy for tool or workflow tests or runs, "
+              "upload multiple files simultaneously without waiting for the previous "
+              "file upload to complete.")
+    )
+
+
 def required_tool_arg(allow_uris=False):
     """ Decorate click method as requiring the path to a single tool.
     """
@@ -1142,6 +1153,7 @@ def galaxy_config_options():
         conda_copy_dependencies_option(),
         conda_auto_install_option(),
         conda_auto_init_option(),
+        simultaneous_upload_option(),
         # Profile options...
         profile_option(),
         profile_database_options(),


### PR DESCRIPTION
So that if we are running a tool or workflow with multiple input datasets that need to be uploaded, we can choose to have all uploads started at once, rather than waiting for each to complete before the next one starts.

In my opinion this simultaneous uploading could even be the default (it makes more sense for running against an external galaxy at least) but it seems it was considered a bad idea, as planemo explicitly overrides the default behaviour of the Galaxy StagingInterface here: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/client/staging.py#L57. Do you remember why you thought this was necessary @jmchilton?