### PR TITLE
Create --download_outputs flag for planemo run

### DIFF
--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -23,6 +23,7 @@ from planemo.runnable_resolve import for_runnable_identifier
 @options.run_history_tags_option()
 @options.run_output_directory_option()
 @options.run_output_json_option()
+@options.run_download_outputs_option()
 @options.engine_options()
 @command_function
 def cli(ctx, runnable_identifier, job_path, **kwds):

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -218,10 +218,11 @@ def _execute(ctx, config, runnable, job_path, **kwds):
         end_datetime=datetime.now(),
         **response_kwds
     )
-    output_directory = kwds.get("output_directory", None)
-    ctx.vlog("collecting outputs from run...")
-    run_response.collect_outputs(ctx, output_directory)
-    ctx.vlog("collecting outputs complete")
+    if kwds.get("download_outputs", True):
+        output_directory = kwds.get("output_directory", None)
+        ctx.vlog("collecting outputs from run...")
+        run_response.collect_outputs(ctx, output_directory)
+        ctx.vlog("collecting outputs complete")
     return run_response
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -284,6 +284,17 @@ def run_output_json_option():
     )
 
 
+def run_download_outputs_option():
+    return planemo_option(
+        "--download_outputs/--no_download_outputs",
+        is_flag=True,
+        default=False,
+        help=("After tool or workflow runs are complete, download "
+              "the output files to the location specified by --output_directory. "
+              )
+    )
+
+
 def no_dependency_resolution():
     return planemo_option(
         "--no_dependency_resolution",


### PR DESCRIPTION
When running using `--external_galaxy`, downloading the outputs is probably superfluous, so this PR adds a `--download_outputs` flag which needs to be specified to perform downloads when using `planemo run`.

For `planemo test` the current behaviour is unchanged (files need to be downloaded to be compared against test data.)

ping @wm75