### PR TITLE
Create new --check_uploads_ok option

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -256,7 +256,7 @@ def stage_in(ctx, runnable, config, user_gi, history_id, job_path, **kwds):  # n
         final_state = "ok"
 
     ctx.vlog("final state is %s" % final_state)
-    if final_state != "ok":
+    if final_state != "ok" and kwds['check_uploads_ok']:
         msg = "Failed to run job final job state is [%s]." % final_state
         summarize_history(ctx, user_gi, history_id)
         raise Exception(msg)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -640,6 +640,17 @@ def simultaneous_upload_option():
     )
 
 
+def check_uploads_ok_option():
+    return planemo_option(
+        "--check_uploads_ok_option/--no_check_uploads_ok_option",
+        is_flag=True,
+        default=True,
+        help=("When uploading files to Galaxy for tool or workflow tests or runs, "
+              "check that the history is in an 'ok' state before beginning tool "
+              "or workflow execution.")
+    )
+
+
 def required_tool_arg(allow_uris=False):
     """ Decorate click method as requiring the path to a single tool.
     """
@@ -1165,6 +1176,7 @@ def galaxy_config_options():
         conda_auto_install_option(),
         conda_auto_init_option(),
         simultaneous_upload_option(),
+        check_uploads_ok_option(),
         # Profile options...
         profile_option(),
         profile_database_options(),


### PR DESCRIPTION
Currently planemo does not invoke a workflow unless all the input data uploaded successfully - this makes sense in general, but @wm75 and I are working with input collections with several hundred elements and we'd like the workflow to start even if one or two uploads fail.