### PR TITLE
print debug messages for galaxy.tools.actions

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -513,7 +513,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         env["GALAXY_TEST_LOGGING_CONFIG"] = config_join("logging.ini")
         env["GALAXY_DEVELOPMENT_ENVIRONMENT"] = "1"
         # disable all access log messages from uvicorn
-        env["GALAXY_UVICORN_ACCESS_LOG"] = "False"
+        env["GALAXY_TEST_DISABLE_ACCESS_LOG"] = "False"
         # Following are needed in 18.01 to prevent Galaxy from changing log and pid.
         # https://github.com/galaxyproject/planemo/issues/788
         env["GALAXY_LOG"] = log_file

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -130,7 +130,7 @@ JOB_CONFIG_LOCAL = """<job_conf>
 LOGGING_TEMPLATE = """
 ## Configure Python loggers.
 [loggers]
-keys = root,paste,displayapperrors,galaxydeps,galaxymasterapikey,galaxy
+keys = root,paste,urllib,displayapperrors,galaxydeps,galaxytoolsactions,galaxymasterapikey,galaxy
 
 [handlers]
 keys = console
@@ -148,10 +148,22 @@ handlers = console
 qualname = paste
 propagate = 0
 
+[logger_urllib]
+level = WARN
+handlers = console
+qualname = urllib3
+propagate = 0
+
 [logger_galaxydeps]
 level = DEBUG
 handlers = console
 qualname = galaxy.tools.deps
+propagate = 0
+
+[logger_galaxytoolsactions]
+level = DEBUG
+handlers = console
+qualname = galaxy.tools.actions
 propagate = 0
 
 [logger_galaxymasterapikey]

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -512,6 +512,8 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         env["GALAXY_TEST_UPLOAD_ASYNC"] = "false"
         env["GALAXY_TEST_LOGGING_CONFIG"] = config_join("logging.ini")
         env["GALAXY_DEVELOPMENT_ENVIRONMENT"] = "1"
+        # disable all access log messages from uvicorn
+        env["GALAXY_UVICORN_ACCESS_LOG"] = "False"
         # Following are needed in 18.01 to prevent Galaxy from changing log and pid.
         # https://github.com/galaxyproject/planemo/issues/788
         env["GALAXY_LOG"] = log_file


### PR DESCRIPTION
in order to see output filter errors

also set level to WARN for urllib3 to ignore messages like

```
2021-04-29 12:00:19,558 DEBUG [urllib3.connectionpool] http://127.0.0.1:9925 "GET /api/jobs/54f2a3a23292eb07 HTTP/1.1" 200 None
2021-04-29 12:00:19,821 DEBUG [urllib3.connectionpool] Starting new HTTP connection (1): 127.0.0.1:9925
```

which are flooding the logs

I still see 

```
INFO:     127.0.0.1:35964 - "POST /api/tools HTTP/1.1" 200 OK
```

but have no idea where this is coming from. Is there a way to address logging for all modules but a certain set (i.e. set warn for all modules but galaxy and planemo)?