### PR TITLE
Create more useful output for failed invocations

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -49,9 +49,8 @@ def execute(ctx, config, runnable, job_path, **kwds):
         return _execute(ctx, config, runnable, job_path, **kwds)
     except Exception as e:
         end_datetime = datetime.now()
-        if ctx.verbose:
-            ctx.vlog("Failed to execute Galaxy activity, throwing ErrorRunResponse")
-            traceback.print_exc(file=sys.stdout)
+        ctx.log("Failed to execute Galaxy activity, throwing ErrorRunResponse")
+        traceback.print_exc(file=sys.stdout)
         return ErrorRunResponse(unicodify(e), start_datetime=start_datetime, end_datetime=end_datetime)
 
 
@@ -342,19 +341,15 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
             raise Exception("Unknown history content type encountered [%s]" % history_content_type)
 
     def collect_outputs(self, ctx, output_directory):
-        assert self._outputs_dict is None, "collect_outputs pre-condition violated"
 
         outputs_dict = {}
-        if not output_directory:
-            # TODO: rather than creating a directory just use
-            # Galaxy paths if they are available in this
-            # configuration.
-            output_directory = tempfile.mkdtemp()
+        # TODO: rather than creating a directory just use
+        # Galaxy paths if they are available in this
+        # configuration.
+        output_directory = output_directory or tempfile.mkdtemp()
 
         def get_dataset(dataset_details, filename=None):
-            parent_basename = dataset_details.get("cwl_file_name")
-            if not parent_basename:
-                parent_basename = dataset_details.get("name")
+            parent_basename = dataset_details.get("cwl_file_name") or dataset_details.get("name")
             file_ext = dataset_details["file_ext"]
             if file_ext == "directory":
                 # TODO: rename output_directory to outputs_directory because we can have output directories
@@ -395,13 +390,18 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
             else:
                 output_dataset_id = output_src["id"]
                 galaxy_output = self.to_galaxy_output(runnable_output)
-                cwl_output = output_to_cwl_json(
-                    galaxy_output,
-                    self._get_metadata,
-                    get_dataset,
-                    self._get_extra_files,
-                    pseduo_location=True,
-                )
+                try:
+                    cwl_output = output_to_cwl_json(
+                        galaxy_output,
+                        self._get_metadata,
+                        get_dataset,
+                        self._get_extra_files,
+                        pseduo_location=True,
+                    )
+                except AssertionError:
+                    # In galaxy-tool-util < 21.05 output_to_cwl_json will raise an AssertionError when the output state is not OK
+                    # Remove with new galaxy-tool-util release.
+                    continue
                 if is_cwl:
                     output_dict_value = cwl_output
                 else:

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -202,6 +202,7 @@ genomes: null
 """
 
 EMPTY_TOOL_CONF_TEMPLATE = """<toolbox></toolbox>"""
+GX_TEST_TOOL_PATH = "$GALAXY_FUNCTIONAL_TEST_TOOLS"
 
 DEFAULT_GALAXY_BRANCH = "master"
 DEFAULT_GALAXY_SOURCE = "https://github.com/galaxyproject/galaxy"
@@ -275,7 +276,7 @@ def docker_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         _handle_refgenie_config(config_directory, kwds)
 
         shed_tool_conf = "config/shed_tool_conf.xml"
-        all_tool_paths = _all_tool_paths(runnables, **kwds)
+        all_tool_paths = _all_tool_paths(runnables, kwds.get('galaxy_root'), kwds.get('extra_tools'))
 
         tool_directories = set([])  # Things to mount...
         for tool_path in all_tool_paths:
@@ -418,7 +419,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         _ensure_directory(tool_dependency_dir)
 
         shed_tool_conf = kwds.get("shed_tool_conf") or config_join("shed_tools_conf.xml")
-        all_tool_paths = _all_tool_paths(runnables, **kwds)
+        all_tool_paths = _all_tool_paths(runnables, galaxy_root=galaxy_root, extra_tools=kwds.get('extra_tools'))
         empty_tool_conf = config_join("empty_tool_conf.xml")
 
         tool_conf = config_join("tool_conf.xml")
@@ -543,9 +544,18 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         )
 
 
-def _all_tool_paths(runnables, **kwds):
-    tool_paths = [r.path for r in runnables if r.has_tools and not r.data_manager_conf_path]
-    all_tool_paths = list(tool_paths) + list(kwds.get("extra_tools", []))
+def _expand_paths(galaxy_root, extra_tools):
+    """Replace $GALAXY_FUNCTION_TEST_TOOLS with actual path."""
+    if galaxy_root:
+        extra_tools = [path if path != GX_TEST_TOOL_PATH else os.path.join(galaxy_root, 'test/functional/tools') for path in extra_tools]
+    return extra_tools
+
+
+def _all_tool_paths(runnables, galaxy_root=None, extra_tools=None):
+    extra_tools = extra_tools or []
+    all_tool_paths = [r.path for r in runnables if r.has_tools and not r.data_manager_conf_path]
+    extra_tools = _expand_paths(galaxy_root, extra_tools=extra_tools)
+    all_tool_paths.extend(extra_tools)
     for runnable in runnables:
         if runnable.type.name == "galaxy_workflow":
             tool_ids = find_tool_ids(runnable.path)

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -165,7 +165,7 @@ def handle_reports(ctx, structured_data, kwds):
     """Write reports based on user specified kwds."""
     exceptions = []
     structured_report_file = kwds.get("test_output_json", None)
-    if structured_report_file and not os.path.exists(structured_report_file):
+    if structured_report_file:
         try:
             with io.open(structured_report_file, mode="w", encoding='utf-8') as f:
                 f.write(unicodify(json.dumps(structured_data)))

--- a/tests/data/wf_failed_step-test.yml
+++ b/tests/data/wf_failed_step-test.yml
@@ -1,0 +1,2 @@
+- doc: Workflow with failing step
+  job: {}

--- a/tests/data/wf_failed_step.ga
+++ b/tests/data/wf_failed_step.ga
@@ -1,0 +1,108 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "fail scheduling",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": "job_properties",
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [],
+            "label": null,
+            "name": "Test Job Properties",
+            "outputs": [
+                {
+                    "name": "list_output",
+                    "type": "input"
+                },
+                {
+                    "name": "out_file1",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "bottom": 413.43749237060547,
+                "height": 110.96590423583984,
+                "left": 774.4744262695312,
+                "right": 974.4744262695312,
+                "top": 302.4715881347656,
+                "width": 200,
+                "x": 774.4744262695312,
+                "y": 302.4715881347656
+            },
+            "post_job_actions": {},
+            "tool_id": "job_properties",
+            "tool_state": "{\"failbool\": \"true\", \"thebool\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "2deee78b-961c-42b7-8663-033ffcbc81ce",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "f46e5881-080d-4907-8632-2e8abca38f31"
+                },
+                {
+                    "label": "A list output",
+                    "output_name": "list_output",
+                    "uuid": "327dcce1-2b73-4d76-a5ca-4a7e192e1d57"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "cat",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "input1": {
+                    "id": 0,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Concatenate datasets (for test workflows)",
+                    "name": "input1"
+                }
+            ],
+            "label": null,
+            "name": "Concatenate datasets (for test workflows)",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 640.4545440673828,
+                "height": 111.96022033691406,
+                "left": 830.4971313476562,
+                "right": 1030.4971313476562,
+                "top": 528.4943237304688,
+                "width": 200,
+                "x": 830.4971313476562,
+                "y": 528.4943237304688
+            },
+            "post_job_actions": {},
+            "tool_id": "cat",
+            "tool_state": "{\"input1\": {\"__class__\": \"RuntimeValue\"}, \"queries\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "a355109c-a224-47d6-b5bd-a89c97de0090",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "c982f987-9b42-48a1-aaf3-58609a8db7ea"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "43c451be-11d4-4a07-b658-93b962426afa",
+    "version": 1
+}

--- a/tests/test_test_engines.py
+++ b/tests/test_test_engines.py
@@ -1,3 +1,4 @@
+import json
 import os
 from tempfile import NamedTemporaryFile
 
@@ -169,3 +170,39 @@ def test_galaxy_workflow_non_data_inputs():
         **kwds
     )
     assert exit_code == 0
+
+
+@skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+@mark.tests_galaxy_branch
+def test_galaxy_workflow_step_failed():
+    ctx = t_context()
+    test_artifact = os.path.join(TEST_DATA_DIR, "wf_failed_step.ga")
+    runnables = for_paths([test_artifact])
+    with NamedTemporaryFile(prefix="result_json") as json_out:
+        kwds = {
+            "engine": "galaxy",
+            "no_dependency_resolution": True,
+            "paste_test_data_paths": False,
+            "extra_tools": ['$GALAXY_FUNCTIONAL_TEST_TOOLS'],
+            "test_output_json": json_out.name,
+            "galaxy_branch": target_galaxy_branch(),
+        }
+        exit_code = t_runnables(
+            ctx,
+            runnables,
+            **kwds
+        )
+        assert exit_code == 1
+        report = json.load(json_out)
+    data = report['tests'][0]['data']
+    assert data['status'] == 'error'
+    assert data['execution_problem']
+    invocation_details = data['invocation_details']
+    assert len(invocation_details) == 2
+    first_step, second_step = invocation_details.values()
+    assert first_step['state'] == 'scheduled'
+    job = first_step['jobs'][0]
+    assert job['exit_code'] == 127
+    assert job['state'] == 'error'
+    assert second_step['state'] == 'scheduled'
+    assert second_step['jobs'][0]['state'] == 'paused'


### PR DESCRIPTION
This should make debugging invocations with failed steps much easier. The core of the change is the try/except AssertionError, which is raised when the step that produces a dataset collection is in error (https://github.com/galaxyproject/galaxy/blob/release_21.01//lib/galaxy/tool_util/cwl/util.py#L447). I'll also remove that on the Galaxy side. Without this change no useful output is produced except that the test failed. With the change we get the regular test structure written out.
