### PR TITLE
Improve dockstore_init

### DIFF
--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -29,11 +29,16 @@ class WorkflowLintContext(LintContext):
 def generate_dockstore_yaml(directory):
     workflows = []
     for workflow_path in find_workflow_descriptions(directory):
-        workflows.append({
+        test_parameter_path = f"{workflow_path.rsplit('.', 1)[0]}-tests.yml"
+        workflow_entry = {
             # TODO: support CWL
             "subclass": "Galaxy",
-            "primaryDescriptorPath": os.path.relpath(workflow_path, directory)
-        })
+            "name": "main",
+            "primaryDescriptorPath": f"/{os.path.relpath(workflow_path, directory)}"
+        }
+        if os.path.exists(test_parameter_path):
+            workflow_entry['testParameterFiles'] = [f"/{os.path.relpath(test_parameter_path, directory)}"]
+        workflows.append(workflow_entry)
     # Force version to the top of file but serializing rest of config seprately
     contents = "version: %s\n" % DOCKSTORE_REGISTRY_CONF_VERSION
     contents += yaml.dump({"workflows": workflows})

--- a/tests/test_cmd_dockstore_init.py
+++ b/tests/test_cmd_dockstore_init.py
@@ -15,8 +15,10 @@ class CmdDockstoreInitTestCase(CliTestCase):
             init_cmd = ["dockstore_init"]
             self._check_exit_code(init_cmd)
             assert os.path.exists(".dockstore.yml")
-            with open(".dockstore.yml", "r") as f:
-                dockstore_config = yaml.safe_load(f)
+            with open(".dockstore.yml", "r") as fh:
+                dockstore_config = yaml.safe_load(fh)
             assert str(dockstore_config["version"]) == "1.2"
             assert "workflows" in dockstore_config
             assert len(dockstore_config["workflows"]) == 1
+            workflow_lint_cmd = ["workflow_lint", '--fail_level', 'error', f]
+            self._check_exit_code(workflow_lint_cmd)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands =
     lint_docs: make lint-docs
     lint_docstrings: flake8 --ignore='D107,D401,D105' {[tox]source_dir}
     unit: pytest {env:PYTEST_FAIL_FAIL:} {env:PYTEST_CAPTURE:} -m {env:PYTEST_MARK:""} {env:PYTEST_TARGET:{[tox]test_dir}} {posargs}
-    mypy: mypy {[tox]source_dir} {posargs}
+    mypy: mypy --install-types --non-interactive {[tox]source_dir} {posargs}
     gxwf_test_test: make setup-venv gxwf-test-test
 
 passenv = 


### PR DESCRIPTION
File paths seem to necessarily start with `/`, see https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html#workflow-yml-file and planemo's own .dockstore.yml test files. `planemo workflow_lint` already checks for that in https://github.com/galaxyproject/planemo/blob/960b61ee7da3a32990cb448957e4fd6fe4deeb31/planemo/workflow_lint.py#L213

That means the .dockstore.yml file generated with the fix passes `planemo workflow_lint`, which I've used as the test case here.

Also adds the testParameterFiles array if a test file is present.