### PR TITLE
Allow location to point to url for outputs

### DIFF
--- a/tests/data/wf11-remote.gxwf-test.yml
+++ b/tests/data/wf11-remote.gxwf-test.yml
@@ -7,4 +7,6 @@
   job: wf1.gxwf-job-url.yml
   outputs:
     wf_output_1:
-      checksum: "sha1$a0b65939670bc2c010f4d5d6a0b3e4e4590fb92b"
+      class: File
+      location: https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/hello.txt
+      compare: contains

--- a/tests/data/wf11-remote.gxwf-test.yml
+++ b/tests/data/wf11-remote.gxwf-test.yml
@@ -8,5 +8,5 @@
   outputs:
     wf_output_1:
       class: File
-      location: https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/hello.txt
+      location: https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt
       compare: contains


### PR DESCRIPTION
Came up in https://github.com/galaxyproject/iwc/pull/47. If we allow inputs to be urls I think we should allow outputs as well.