### PR TITLE
Fix documentation to include `--download_outputs` flag

### DIFF
--- a/docs/_running_external.rst
+++ b/docs/_running_external.rst
@@ -22,8 +22,8 @@ If you want to set the name of the history in which the workflow executes, add
 ``--history_name NAME`` to the command. You should be able to see the workflow
 executing in the web browser, if you navigate to the 'List all histories' view. 
 If you prefer to download data without interacting with the web interface at all,
-you can add ``--output_directory`` and ``--output_json`` to the command as
-before.
+you can add ``--download_outputs --output_directory . --output_json output.json``
+to the command as before.
 
 Typing ``--engine external_galaxy --galaxy_url SERVER_URL --galaxy_user_key YOUR_API_KEY``
 each time you want to execute a workflow is a bit annoying. Fortunately, Planemo

--- a/docs/_running_intro.rst
+++ b/docs/_running_intro.rst
@@ -48,16 +48,16 @@ achieved with the command
 
 ::
 
-    $ planemo run tutorial.ga tutorial-job.yml --output_directory . --output_json output.json
+    $ planemo run tutorial.ga tutorial-job.yml --download_outputs --output_directory . --output_json output.json
 
 
 You can optionally (and probably should) add the ``--galaxy_root`` flag with
 the location of a local copy of the Galaxy source code, which will allow the
 instance to be spun up considerably faster.
 
-Note that the ``--output_directory`` and ``--output_json`` flags are optional,
-but allow saving the output to a local file. The contents should be something
-like:
+Note that ``--download_outputs --output_directory . --output_json output.json``
+is optional, but allow saving the output to a local file. The contents should
+be something like:
 
 ::
 
@@ -76,7 +76,7 @@ significantly longer to complete than the previous command.
 
 ::
 
-    $ planemo run tutorial.ga tutorial-job.yml --output_directory . --output_json output.json --engine docker_galaxy --ignore_dependency_problems
+    $ planemo run tutorial.ga tutorial-job.yml --download_outputs --output_directory . --output_json output.json --engine docker_galaxy --ignore_dependency_problems
 
 
 This introduces the concept of an engine, which Planemo provides to allow


### PR DESCRIPTION
The `--download_outputs` flag was introduced in https://github.com/galaxyproject/planemo/pull/1157 but not mentioned in the documentation. Reported by @ZimmerA, thanks a lot!