### PR TITLE
Add tool version numbers to autoupdate logging

### DIFF
--- a/planemo/autoupdate.py
+++ b/planemo/autoupdate.py
@@ -62,11 +62,11 @@ def update_xml(tool_path, xml_tree, tags_to_update, wrapper_version_token, is_ma
     Write modified XML to tool_path
     """
     def update_token(xml_text, tag, token_value):
-        new_tag = '>{}<'.format(token_value).join(re.split('>.*<', tag))
+        new_tag = f'>{token_value}<'.join(re.split('>.*<', tag))
         return re.sub(tag, new_tag, xml_text)
 
     def update_requirement(xml_text, tag, requirement_value):
-        new_tag = 'version="{}"'.format(requirement_value).join(re.split('version=".*"', tag))
+        new_tag = f'version="{requirement_value}"'.join(re.split('version=".*"', tag))
         return re.sub(tag, new_tag, xml_text)
 
     with open(tool_path, 'r+', newline='') as f:
@@ -144,8 +144,7 @@ def perform_required_update(ctx, xml_files, tool_path, requirements, tokens, xml
     # finally, update each file separately
     for k, v in xml_files.items():
         update_xml(k, v, xml_to_update[k], wrapper_version_token, is_macro=(k != tool_path))
-
-    info("Tool {} updated.".format(tool_path))
+    info(f"Tool {tool_path} successfully updated.")
     return set(xml_files)
 
 
@@ -182,15 +181,15 @@ def autoupdate_tool(ctx, tool_path, modified_files=set(), **kwds):
     tokens, xml_to_update, current_main_req, updated_main_req = create_token_dict(ctx, xml_files, main_req, **kwds)
 
     if current_main_req == updated_main_req and not (modified_files & set(xml_files)):
-        info("No updates required or made to {}.".format(tool_path))
+        info(f"No updates required or made to {tool_path}.")
         return  # end here if no update needed
 
     if kwds.get('dry_run'):
-        error("Update required to {}! Tool main requirement has version {}, newest conda version is {}".format(
-              tool_path, current_main_req, updated_main_req))
+        error(f"Update required to {tool_path}! Tool main requirement has version {current_main_req}, newest conda version is {updated_main_req}")
         return
 
     else:
+        info(f"Updating {tool_path.split('/')[-1]} from version {current_main_req} to {updated_main_req}")
         return perform_required_update(ctx, xml_files, tool_path, requirements, tokens, xml_to_update, wrapper_version_token, **kwds)
 
 

--- a/planemo/commands/cmd_autoupdate.py
+++ b/planemo/commands/cmd_autoupdate.py
@@ -105,7 +105,7 @@ def cli(ctx, paths, **kwds):  # noqa C901
                 if updated:
                     modified_files.update(updated)
             except Exception as e:
-                error("{} could not be updated - the following error was raised: {}".format(tool_path, e.__str__()))
+                error(f"{tool_path} could not be updated - the following error was raised: {e.__str__()}")
             if handle_tool_load_error(tool_path, tool_xml):
                 exit_codes.append(EXIT_CODE_GENERIC_FAILURE)
                 continue

--- a/tests/test_cmd_autoupdate.py
+++ b/tests/test_cmd_autoupdate.py
@@ -16,9 +16,9 @@ def create_tmp_test_tool_file(tool_version):
     been migrated from bioconda to conda-forge and test with --conda_channels bioconda
     so that the versions are guaranteed not to increase in future.
     """
-    xml_str = """<tool id="autoupdate_test" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+    xml_str = f"""<tool id="autoupdate_test" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <macros>
-        <token name="@TOOL_VERSION@">{}</token>
+        <token name="@TOOL_VERSION@">{tool_version}</token>
         <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
@@ -26,7 +26,7 @@ def create_tmp_test_tool_file(tool_version):
         <requirement type="package" version="2015">smina</requirement>
     </requirements>
 </tool>
-    """.format(tool_version)
+    """
     t = tempfile.NamedTemporaryFile(suffix='.xml', delete=False, mode='w')
     t.write(xml_str)
     return t.name
@@ -50,7 +50,7 @@ class CmdAutoupdateTestCase(CliTestCase):
                 "--dry-run"
             ]
             result = self._runner.invoke(self._cli.planemo, autoupdate_command)
-            assert "Update required to {}!".format(xmlfile) in result.output
+            assert f"Update required to {xmlfile}!" in result.output
             assert "Tool main requirement has version 0.6.0, newest conda version is 0.7.3" in result.output
 
     def test_autoupdate(self):
@@ -63,7 +63,8 @@ class CmdAutoupdateTestCase(CliTestCase):
                 "--conda_channels", "bioconda"
             ]
             result = self._runner.invoke(self._cli.planemo, autoupdate_command)
-            assert 'Tool {} updated.'.format(xmlfile) in result.output
+            assert f'Updating {xmlfile.split("/")[-1]} from version 0.6.0 to 0.7.3' in result.output
+            assert f'Tool {xmlfile} successfully updated.' in result.output
             with open(xmlfile) as f:
                 xmlfile_contents = f.read()
             assert "2017.11.9" in xmlfile_contents
@@ -78,7 +79,7 @@ class CmdAutoupdateTestCase(CliTestCase):
                 "--conda_channels", "bioconda"
             ]
             result = self._runner.invoke(self._cli.planemo, autoupdate_command)
-            assert 'No updates required or made to {}.'.format(xmlfile) in result.output
+            assert f'No updates required or made to {xmlfile}.' in result.output
 
     def test_autoupdate_workflow(self):
         """Test autoupdate command for a workflow is needed."""
@@ -92,7 +93,7 @@ class CmdAutoupdateTestCase(CliTestCase):
             ]
             result = self._runner.invoke(self._cli.planemo, autoupdate_command)
 
-            assert 'Auto-updating workflow {}'.format(wf_file) in result.output
+            assert f'Auto-updating workflow {wf_file}' in result.output
             with open(wf_file) as g:
                 wf = json.load(g)
             # check tool within parent wf has updated
@@ -107,7 +108,7 @@ class CmdAutoupdateTestCase(CliTestCase):
             wf_file = os.path.join(f, "diff-refactor-test.gxwf.yml")
             autoupdate_command[1] = wf_file
             result = self._runner.invoke(self._cli.planemo, autoupdate_command)
-            assert 'Auto-updating workflow {}'.format(wf_file) in result.output
+            assert f'Auto-updating workflow {wf_file}' in result.output
 
             with open(wf_file) as f:
                 wf = yaml.safe_load(f)


### PR DESCRIPTION
Print the old and new version numbers of the updated main requirement for each tool. This can then be shown in the autoupdate PRs.

I also updated the autoupdate code to use f-strings.