### PR TITLE
test: check if extra files were created in Galaxy's file_path

### DIFF
--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -128,17 +128,18 @@ def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None
     # check if tools created extra files in the file_path all files in the files path
     # - end with '.dat' or
     # - are contained in a directory `dataset_.*_files`
-    for (path, dirs, files) in os.walk(config.env["GALAXY_CONFIG_OVERRIDE_FILE_PATH"]):
-        for name in files:
-            if not (name.endswith(".dat") or re.match('.*/dataset_.*_files$', path)):
-                extra_files.append(os.path.join(path, name))
-    if len(extra_files) > 0:
-        msg = f"One of the tested tools wrote to Galaxy's files dir: {extra_files}"
-        for i in range(len(structured_data["tests"])):
-            structured_data["tests"][i]["data"]["status"] = "failure"
-            structured_data["tests"][i]["data"]["job"]["stderr"] += msg
-        error(msg)
-        ec = 1
+    if config.env.get("GALAXY_CONFIG_OVERRIDE_FILE_PATH"):
+        for (path, dirs, files) in os.walk(config.env.get("GALAXY_CONFIG_OVERRIDE_FILE_PATH")):
+            for name in files:
+                if not (name.endswith(".dat") or re.match('.*/dataset_.*_files$', path)):
+                    extra_files.append(os.path.join(path, name))
+        if len(extra_files) > 0:
+            msg = f"One of the tested tools wrote to Galaxy's files dir: {extra_files}"
+            for i in range(len(structured_data["tests"])):
+                structured_data["tests"][i]["data"]["status"] = "failure"
+                structured_data["tests"][i]["data"]["job"]["stderr"] += msg
+            error(msg)
+            ec = 1
     return handle_reports_and_summary(
         ctx,
         structured_data,

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -131,7 +131,7 @@ def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None
     if config.env.get("GALAXY_CONFIG_OVERRIDE_FILE_PATH"):
         for (path, dirs, files) in os.walk(config.env.get("GALAXY_CONFIG_OVERRIDE_FILE_PATH")):
             for name in files:
-                if not (name.endswith(".dat") or re.match('.*/dataset_.*_files$', path)):
+                if not (name.endswith(".dat") or re.match('^.*/dataset_.*_files/.*$', path)):
                     extra_files.append(os.path.join(path, name))
         if len(extra_files) > 0:
             msg = f"One of the tested tools wrote to Galaxy's files dir: {extra_files}"

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -130,8 +130,9 @@ def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None
     # - are contained in a directory `dataset_.*_files`
     if config.env.get("GALAXY_CONFIG_OVERRIDE_FILE_PATH"):
         for (path, dirs, files) in os.walk(config.env.get("GALAXY_CONFIG_OVERRIDE_FILE_PATH")):
+            dirs[:] = [d for d in dirs if not re.match(r'^dataset_[^/]*_files$', d)]
             for name in files:
-                if not (name.endswith(".dat") or re.match('^.*/dataset_.*_files/.*$', path)):
+                if not name.endswith(".dat"):
                     extra_files.append(os.path.join(path, name))
         if len(extra_files) > 0:
             msg = f"One of the tested tools wrote to Galaxy's files dir: {extra_files}"

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -125,16 +125,19 @@ def run_in_config(ctx, config, run=run_galaxy_command, test_data_target_dir=None
     ec = test_results.exit_code
     structured_data = test_results.structured_data
     extra_files = []
-    # check if tools created extra files in the file_path
+    # check if tools created extra files in the file_path all files in the files path
+    # - end with '.dat' or
+    # - are contained in a directory `dataset_.*_files`
     for (path, dirs, files) in os.walk(config.env["GALAXY_CONFIG_OVERRIDE_FILE_PATH"]):
         for name in files:
-            if not (name.endswith(".dat") or re.match('dataset_.*_files', name)):
-                extra_files += os.path.join(path, name)
+            if not (name.endswith(".dat") or re.match('.*/dataset_.*_files$', path)):
+                extra_files.append(os.path.join(path, name))
     if len(extra_files) > 0:
+        msg = f"One of the tested tools wrote to Galaxy's files dir: {extra_files}"
         for i in range(len(structured_data["tests"])):
             structured_data["tests"][i]["data"]["status"] = "failure"
-            structured_data["tests"][i]["data"]["job"]["stderr"] += "One of the tested tools wrote to Galaxy's files dir"
-        error("One of the tested tools wrote to Galaxy's files dir")
+            structured_data["tests"][i]["data"]["job"]["stderr"] += msg
+        error(msg)
         ec = 1
     return handle_reports_and_summary(
         ctx,


### PR DESCRIPTION
This is an attempt to automatize https://github.com/galaxyproject/tools-iuc/pull/3986#issuecomment-926729276

fixes https://github.com/galaxyproject/planemo/issues/1189

Seems difficult / impossible to find out which tool / test generates the extra files, so I just set all tests for failure and add some note to the stderr .. (but IUC style tests run 1 `planemo test` per repo)

I guess this will create quite a bit of noise in the IUC style repos weekly CI tests .. but maybe its a good thing.