### PR TITLE
Exclude click version 8.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 allure-python-commons
 BeautifulSoup4
 bioblend>=0.14.0
-Click
+click!=8.0.2
 configparser
 cwltool>=1.0.20191225192155
 docutils


### PR DESCRIPTION
As an addition/alternative to https://github.com/galaxyproject/galaxy/pull/12682. I'm gonna assume it'll be fixed upstream (https://github.com/pallets/click/issues/2088 is the issue, I think).