### PR TITLE
Fix rendering of subworkflow steps for workflow testing report

### DIFF
--- a/planemo/reports/macros.tmpl
+++ b/planemo/reports/macros.tmpl
@@ -14,7 +14,7 @@
           </details>
 {%      elif step_data.subworkflow%}
 
-{{      render_steps(step_data.subworkflow.values(), display_job_attributes, "Subworkflow Steps")|indent(5, first=True) }}
+{{      render_steps(step_data.subworkflow.steps.values(), display_job_attributes, "Subworkflow Steps")|indent(5, first=True) }}
 
 {%      endif %}
 {%    endfor %}


### PR DESCRIPTION
I have been trying to run tests for a workflow containing a subworkflow and although tests were completing successfully, rendering of the HTML report was failing with:

```
Traceback (most recent call last):
  File "/home/simon/GitRepos/.planemo/bin/planemo", line 8, in <module>
    sys.exit(planemo())
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/cli.py", line 98, in handle_blended_options
    return f(*args, **kwds)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/commands/cmd_test_reports.py", line 32, in cli
    handle_reports(ctx, test_data.structured_data, kwds)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/galaxy/test/actions.py", line 184, in handle_reports
    raise exceptions[0]
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/galaxy/test/actions.py", line 177, in handle_reports
    _handle_test_output_file(
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/galaxy/test/actions.py", line 204, in _handle_test_output_file
    contents = build_report.build_report(
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/reports/build_report.py", line 24, in build_report
    markdown = template_data(environment, 'report_markdown.tpl')
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/reports/build_report.py", line 49, in template_data
    return template.render(**environment)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/reports/report_markdown.tpl", line 78, in top-level template code
    {{render_steps(test.data.invocation_details.values(), display_job_attributes)}}
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/jinja2/runtime.py", line 828, in _invoke
    rv = self._func(*arguments)
  File "/home/simon/GitRepos/.planemo/lib/python3.8/site-packages/planemo/reports/macros.tmpl", line 5, in template
    - **Step {{step_data.order_index + 1}}: {{step_data.workflow_step_label or (step_data.jobs[0].tool_id if step_data.jobs[0] else 'Unlabelled step')|replace("_", "\_")}}**:
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'order_index'

```

This change fixed it for me.