### PR TITLE
Replace Galaxy interactor galaxy_requests_post with make_post_request from BioBlend

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -18,7 +18,6 @@ from galaxy.tool_util.cwl.util import (
     tool_response_to_output,
 )
 from galaxy.tool_util.parser import get_tool_source
-from galaxy.tool_util.verify.interactor import galaxy_requests_post
 from galaxy.util import (
     safe_makedirs,
     unicodify,
@@ -91,7 +90,7 @@ class PlanemoStagingInterface(StagingInterace):
     def _post(self, api_path, payload, files_attached=False):
         params = dict(key=self._user_gi.key)
         url = urljoin(self._user_gi.url, "api/" + api_path)
-        return galaxy_requests_post(url, data=payload, params=params, as_json=True).json()
+        return self._user_gi.make_post_request(url, payload=payload, params=params).json()
 
     def _attach_file(self, path):
         return attach_file(path)

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -88,9 +88,13 @@ class PlanemoStagingInterface(StagingInterace):
         self._simultaneous_uploads = simultaneous_uploads
 
     def _post(self, api_path, payload, files_attached=False):
-        params = dict(key=self._user_gi.key)
         url = urljoin(self._user_gi.url, "api/" + api_path)
-        return self._user_gi.make_post_request(url, payload=payload, params=params).json()
+        if payload.get("__files"):  # put attached files where BioBlend expects them
+            files_attached = True
+            for k, v in payload["__files"].items():
+                payload[k] = v
+            del payload["__files"]
+        return self._user_gi.make_post_request(url, payload=payload, files_attached=files_attached)
 
     def _attach_file(self, path):
         return attach_file(path)

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -49,7 +49,7 @@ def test_refgenie_config_version():
         with open(version_path, 'w') as version_fh:
             version_fh.write('VERSION_MAJOR = "21.05"')
         refgenie_config = get_refgenie_config(galaxy_root=tdc.temp_directory, refgenie_dir='/')
-    assert yaml.load(refgenie_config)['config_version'] == 0.3
+    assert yaml.load(refgenie_config, Loader=yaml.SafeLoader)['config_version'] == 0.3
 
 
 def _assert_property_is(config, prop, value):


### PR DESCRIPTION
Planemo tests are currently failing here (https://github.com/bgruening/galaxytools/pull/1173) with

```
planemo test --galaxy_python_version 3.7 --no_conda_auto_init --galaxy_source https://github.com/galaxyproject/galaxy --galaxy_branch release_21.05 /tmp/tmp.Uk4Nu5LXyy
Problem loading command test, exception cannot import name 'galaxy_requests_post' from 'galaxy.tool_util.verify.interactor' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/galaxy/tool_util/verify/interactor.py)
```
It seems to be because the `galaxy_requests_post` method was removed in Galaxy. Hopefully replacing it with BioBlend's `make_post_request` method will fix it.