### PR TITLE
[WIP] Generate workflow test from invocation id

### DIFF
--- a/planemo/commands/cmd_workflow_test_init.py
+++ b/planemo/commands/cmd_workflow_test_init.py
@@ -39,7 +39,6 @@ def cli(ctx, workflow_identifier, output=None, split_test=False, **kwds):
         path_basename = get_workflow_from_invocation_id(workflow_identifier, kwds["galaxy_url"], kwds["galaxy_user_key"])
     else:
         path_basename = os.path.basename(workflow_identifier)
-    print(path_basename)
     job = job_template(workflow_identifier, **kwds)
     if output is None:
         output = new_workflow_associated_path(path_basename if kwds["from_invocation"] else workflow_identifier)

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -329,7 +329,7 @@ def _job_inputs_template_from_invocation(invocation_id, galaxy_url, galaxy_api_k
             user_gi.datasets.download_dataset(input_step["id"], use_default_filename=False, file_path=f"test-data/{input_step['label']}.{ext}")
             template[input_step['label']] = {
                 "class": "File",
-                "path": f"{input_step['label']}.{ext}",
+                "path": f"test-data/{input_step['label']}.{ext}",
                 "filetype": ext
             }
         elif input_step["src"] == "hdca":

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -291,7 +291,6 @@ def get_workflow_from_invocation_id(invocation_id, galaxy_url, galaxy_api_key):
     workflow_id = user_gi.invocations.show_invocation(invocation_id)['workflow_id']
     workflow = user_gi.workflows._get(workflow_id, params={'instance': 'true'})
     workflow_name = '-'.join(workflow["name"].split())
-    # user_gi.workflows.export_workflow_to_local_path(path=f'{workflow["name"]}.ga', workflow_id=workflow["id"])
     user_gi.workflows.export_workflow_to_local_path(use_default_filename=False, file_local_path=f'./{workflow_name}.ga', workflow_id=workflow["id"])
 
     return workflow_name

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -12,6 +12,7 @@ from gxformat2.interface import BioBlendImporterGalaxyInterface
 from gxformat2.interface import ImporterGalaxyInterface
 from gxformat2.normalize import inputs_normalized, outputs_normalized
 
+from planemo.galaxy.api import gi
 from planemo.io import warn
 
 FAILED_REPOSITORIES_MESSAGE = "Failed to install one or more repositories."
@@ -201,10 +202,12 @@ def output_labels(workflow_path):
     return [o["id"] for o in outputs]
 
 
-def output_stubs_for_workflow(workflow_path):
+def output_stubs_for_workflow(workflow_path, **kwds):
     """
     Return output labels and class.
     """
+    if kwds.get("from_invocation"):
+        return _job_outputs_template_from_invocation(workflow_path, kwds["galaxy_url"], kwds["galaxy_user_key"])
     outputs = {}
     for label in output_labels(workflow_path):
         if not label.startswith('_anonymous_'):
@@ -212,12 +215,15 @@ def output_stubs_for_workflow(workflow_path):
     return outputs
 
 
-def job_template(workflow_path):
+def job_template(workflow_path, **kwds):
     """Return a job template for specified workflow.
 
     A dictionary describing non-optional inputs that must be specified to
     run the workflow.
     """
+    if kwds.get("from_invocation"):
+        return _job_inputs_template_from_invocation(workflow_path, kwds["galaxy_url"], kwds["galaxy_user_key"])
+
     template = {}
     for required_input_step in required_input_steps(workflow_path):
         i_label = input_label(required_input_step)
@@ -278,6 +284,87 @@ def rewrite_job_file(input_file, output_file, job):
             # else: presumably a parameter, no need to modify
     with open(output_file, "w") as f:
         yaml.dump(job_contents, f)
+
+
+def get_workflow_from_invocation_id(invocation_id, galaxy_url, galaxy_api_key):
+    user_gi = gi(url=galaxy_url, key=galaxy_api_key)
+    workflow_id = user_gi.invocations.show_invocation(invocation_id)['workflow_id']
+    workflow = user_gi.workflows._get(workflow_id, params={'instance': 'true'})
+    workflow_name = '-'.join(workflow["name"].split())
+    # user_gi.workflows.export_workflow_to_local_path(path=f'{workflow["name"]}.ga', workflow_id=workflow["id"])
+    user_gi.workflows.export_workflow_to_local_path(use_default_filename=False, file_local_path=f'./{workflow_name}.ga', workflow_id=workflow["id"])
+
+    return workflow_name
+
+
+def _job_inputs_template_from_invocation(invocation_id, galaxy_url, galaxy_api_key):
+    def _template_from_collection(user_gi, collection_id):
+        collection = user_gi.dataset_collections.show_dataset_collection(collection_id)
+        template = {
+            "class": "Collection",
+            "collection_type": collection["collection_type"],
+            "elements": []
+        }
+        for element in collection["elements"]:
+            if element["element_type"] == "hdca":
+                template['elements'].append(_template_from_collection(element["object"]["id"]))
+            elif element["element_type"] == "hda":
+                user_gi.datasets.download_dataset(element["object"]["id"], use_default_filename=False,
+                                                  file_path=f"test-data/{input_step['label']}_{element['element_identifier']}.{ext}")
+                template['elements'].append(
+                    {
+                        "class": "File",
+                        "identifier": element['element_identifier'],
+                        "path": f"test-data/{input_step['label']}_{element['element_identifier']}.{ext}",
+                    }
+                )
+            return template
+
+    user_gi = gi(url=galaxy_url, key=galaxy_api_key)
+    invocation = user_gi.invocations.show_invocation(invocation_id)
+    template = {}
+    for input_step in invocation['inputs'].values():
+        if input_step["src"] == "hda":
+            ext = user_gi.datasets.show_dataset(input_step["id"])["extension"]
+            user_gi.datasets.download_dataset(input_step["id"], use_default_filename=False, file_path=f"test-data/{input_step['label']}.{ext}")
+            template[input_step['label']] = {
+                "class": "File",
+                "path": f"{input_step['label']}.{ext}",
+                "filetype": ext
+            }
+        elif input_step["src"] == "hdca":
+            template[input_step['label']] = _template_from_collection(user_gi, input_step["id"])
+    for param, param_step in invocation['input_step_parameters'].items():
+        template[param] = param_step["parameter_value"]
+
+    return template
+
+
+def _job_outputs_template_from_invocation(invocation_id, galaxy_url, galaxy_api_key):
+    user_gi = gi(url=galaxy_url, key=galaxy_api_key)
+    invocation = user_gi.invocations.show_invocation(invocation_id)
+    outputs = {}
+    for label, output in invocation["outputs"].items():
+        ext = user_gi.datasets.show_dataset(output["id"])["extension"]
+        user_gi.datasets.download_dataset(output["id"], use_default_filename=False, file_path=f"test-data/{label}.{ext}")
+        outputs[label] = {
+            'file': f"test-data/{label}.{ext}"
+        }
+    for label, output in invocation["output_collections"].items():
+        collection = user_gi.dataset_collections.show_dataset_collection(output['id'])
+        if ':' not in collection["collection_type"]:
+            user_gi.datasets.download_dataset(collection["elements"][0]["object"]["id"], use_default_filename=False,
+                                              file_path=f"test-data/{label}.{collection['elements'][0].get('extension', 'txt')}")
+            outputs[label] = {
+                'element_tests': {  # only check the first element
+                    collection["elements"][0]["element_identifier"]: f"test-data/{label}.{collection['elements'][0]['extension']}"
+                }
+            }
+        else:
+            outputs[label] = {
+                'element_tests': 'nested_collection_todo'
+            }
+    return outputs
 
 
 __all__ = (

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -727,6 +727,16 @@ def split_job_and_test():
     return click.option("--split_test/--no_split_test", default=False, help="Write workflow job and test definitions to separate files.")
 
 
+def from_invocation():
+    return planemo_option(
+        "--from_invocation/--not_from_invocation",
+        is_flag=True,
+        default=False,
+        help="Build a workflow test or job description from an invocation ID run on an external Galaxy."
+             "A Galaxy URL and API key must also be specified."
+    )
+
+
 def required_job_arg():
     """Decorate click method as requiring the path to a single tool.
     """

--- a/tests/test_external_galaxy_commands.py
+++ b/tests/test_external_galaxy_commands.py
@@ -38,6 +38,8 @@ class ExternalGalaxyCommandsTestCase(CliTestCase):
                 rerun_cmd = ["rerun", "--invocation", "invocation_id", "--profile", "test_ext_profile"]
                 upload_data_cmd = ["upload_data", "test_wf_alias", os.path.join(TEST_DATA_DIR, "wf2-job.yml"), "new-job.yml",
                                    "--profile", "test_ext_profile"]
+                workflow_test_init_cmd = ["workflow_test_init", "invocation_id", "--from_invocation", "--profile", "test_ext_profile"]
+                test_workflow_test_init_cmd = ["test", "TestWorkflow1.ga",  "--profile", "test_ext_profile"]
 
                 # test alias and profile creation
                 result = self._check_exit_code(profile_list_cmd)
@@ -69,9 +71,17 @@ class ExternalGalaxyCommandsTestCase(CliTestCase):
                 assert '1 jobs ok' in result.output or '"ok": 1' in result.output  # so it passes regardless if tabulate is installed or not
 
                 # test rerun
-                rerun_cmd[2] = config.user_gi.workflows.get_invocations(wfid)[0]['id']
+                invocation_id = config.user_gi.workflows.get_invocations(wfid)[0]['id']
+                rerun_cmd[2] = invocation_id
                 result = self._check_exit_code(rerun_cmd)
                 assert 'No jobs matching the specified invocation' in result.output
+
+                # test generating test case from invocation_id
+                workflow_test_init_cmd[2] = invocation_id
+                self._check_exit_code(workflow_test_init_cmd)
+                assert os.path.exists('TestWorkflow1.ga')
+                assert os.path.exists('TestWorkflow1-tests.yml')
+                self._check_exit_code(test_workflow_test_init_cmd)
 
                 # test alias and profile deletion
                 result = self._check_exit_code(alias_delete_cmd)


### PR DESCRIPTION
Implementation of #1141:

```
planemo workflow_test_init eed6c2f8d951be9e --from_invocation --profile usegalaxy-eu
```
to create the GA file, tests file and download the test data. I found the process of writing tests for IWC workflows recently quite tricky, I think this would have helped a bit.