### PR TITLE
Updates to workflow autoupdate required for IWC bot

### DIFF
--- a/planemo/autoupdate.py
+++ b/planemo/autoupdate.py
@@ -2,15 +2,20 @@
 from __future__ import absolute_import
 
 import collections
+import json
 import re
 import xml.etree.ElementTree as ET
 
 import packaging.version
 import requests
+import yaml
+from bioblend import toolshed
 from galaxy.tool_util.deps import conda_util
 
 import planemo.conda
 from planemo.io import error, info
+
+AUTOUPDATE_TOOLSHED_URL = "https://toolshed.g2.bx.psu.edu"
 
 
 def find_macros(xml_tree):
@@ -211,7 +216,111 @@ def _update_wf(config, workflow_id, instance=False):
     config.user_gi.workflows.refactor_workflow(workflow_id, actions=[{"action_type": "upgrade_all_steps"}])
 
 
+def outdated_tools(wf_dict, ts):
+    def check_tool_step(step, ts):  # return a dict with current and newest tool version, in case they don't match
+        if not step['tool_id'].startswith(AUTOUPDATE_TOOLSHED_URL[8:]):
+            return {}  # assume a built in tool
+        try:
+            repos = ts.repositories._get(params={"tool_ids": step['tool_id']})
+        except Exception:
+            return {}  # some ToolShed bugs - we just skip these
+        base_id = '/'.join((step['tool_id'].split('/')[:-1]))
+        tool_ids_found = set(tool['guid'] for repo in repos.values() if type(repo) == dict for tool in repo.get('tools', []))
+        updated_tool_id = sorted(set(tool_id for tool_id in tool_ids_found if f"{base_id}/" in tool_id), key=lambda n: packaging.version.parse(n))[-1]
+        if step['tool_id'] != updated_tool_id:
+            return {base_id: {'current': step['tool_id'], 'updated': updated_tool_id}}
+        else:
+            return {}
+
+    outdated_tool_dict = {}
+    steps = wf_dict['steps'].values() if type(wf_dict['steps']) == dict else wf_dict['steps']
+    for step in steps:
+        if step.get('type', 'tool') == 'tool' and not step.get('run', {}).get('class') == 'GalaxyWorkflow':
+            outdated_tool_dict.update(check_tool_step(step, ts))
+        elif step.get('type') == 'subworkflow':  # GA SWF
+            outdated_tool_dict.update(outdated_tools(step["subworkflow"], ts))
+        elif step.get('run', {}).get('class') == 'GalaxyWorkflow':  # gxformat2 SWF
+            outdated_tool_dict.update(outdated_tools(step["run"], ts))
+        else:
+            continue
+    return outdated_tool_dict
+
+
+def get_tools_to_update(workflow, tools_to_skip):
+    # before we run the autoupdate, we check the tools against the toolshed to see if there
+    # are any new versions. This saves spinning up Galaxy and installing the tools if there
+    # is nothing to do, and also allows us to collect a list of the tools which need updating
+    if workflow.path.endswith('ga'):
+        with open(workflow.path) as f:
+            wf_dict = json.load(f)
+    else:
+        with open(workflow.path) as f:
+            wf_dict = yaml.load(f, Loader=yaml.SafeLoader)
+
+    ts = toolshed.ToolShedInstance(url=AUTOUPDATE_TOOLSHED_URL)
+    tools_to_update = outdated_tools(wf_dict, ts)
+    return {tool: versions for tool, versions in tools_to_update.items() if tool not in tools_to_skip}
+
+
 def autoupdate_wf(ctx, config, wf):
     workflow_id = config.workflow_id_for_runnable(wf)
     _update_wf(config, workflow_id)
     return config.user_gi.workflows.export_workflow_dict(workflow_id)
+
+
+def fix_workflow_ga(original_wf, updated_wf):
+    # the Galaxy refactor action can't do everything right now... some manual fixes here
+    # * bump release number if present
+    # * update tool_ids ... refactor only updates tool_version
+    # * order steps numerically, leave everything else sorted as in the original workflow
+    # * recurse over subworkflows
+    edited_wf = original_wf.copy()
+    updated_wf_steps = collections.OrderedDict(sorted(updated_wf["steps"].items(), key=lambda item: int(item[0])))
+    edited_wf['steps'] = updated_wf_steps
+    # check release; bump if it exists
+    if edited_wf.get('release'):
+        release = [int(n) for n in edited_wf['release'].split('.')]
+        release[-1] += 1
+        edited_wf['release'] = '.'.join([str(n) for n in release])
+    # iterate over the steps
+    for step in edited_wf['steps']:
+        # recurse over subworkflows
+        if edited_wf['steps'][step].get("type") == "subworkflow":
+            edited_wf['steps'][step]["subworkflow"] = fix_workflow_ga(edited_wf['steps'][step]["subworkflow"],
+                                                                      updated_wf['steps'][step]["subworkflow"])
+        # fix tool_id and content_id to march tool_version
+        elif edited_wf['steps'][step]['type'] == 'tool':
+            if edited_wf['steps'][step].get('tool_id', '').startswith(AUTOUPDATE_TOOLSHED_URL[8:]):
+                if edited_wf['steps'][step]["tool_id"].split('/')[-1] != edited_wf['steps'][step]["tool_version"]:
+                    tool_id = edited_wf['steps'][step]["tool_id"].split('/')
+                    tool_id[-1] = edited_wf['steps'][step]["tool_version"]
+                    edited_wf['steps'][step]["tool_id"] = '/'.join(tool_id)
+                    if edited_wf['steps'][step].get("content_id"):
+                        edited_wf['steps'][step]["content_id"] = '/'.join(tool_id)
+    return edited_wf
+
+
+def fix_workflow_gxformat2(original_wf, updated_wf):
+    # does the same as fix_workflow_ga for gxformat2
+    edited_wf = original_wf.copy()
+    # check release; bump if it exists
+    if edited_wf.get('release'):
+        release = [int(n) for n in edited_wf['release'].split('.')]
+        release[-1] += 1
+        edited_wf['release'] = '.'.join([str(n) for n in release])
+    # iterate over the steps
+    for step_index, step in enumerate(edited_wf['steps']):
+        # recurse over subworkflows
+        if step.get('run', {}).get('class') == 'GalaxyWorkflow':  # subworkflow
+            step["run"] = fix_workflow_gxformat2(step["run"], updated_wf['steps'][str(step_index + len(original_wf['inputs']))]["subworkflow"])
+        # fix tool_id and content_id to march tool_version
+        elif updated_wf['steps'][str(step_index + len(original_wf['inputs']))]['type'] == 'tool':
+            if updated_wf['steps'][str(step_index + len(original_wf['inputs']))].get('tool_id', '').startswith(AUTOUPDATE_TOOLSHED_URL[8:]):
+                step['tool_version'] = updated_wf['steps'][str(step_index + len(original_wf['inputs']))]['tool_version']
+                if step["tool_id"].split('/')[-1] != step["tool_version"]:
+                    tool_id = step["tool_id"].split('/')
+                    tool_id[-1] = step["tool_version"]
+                    step["tool_id"] = '/'.join(tool_id)
+                    if step.get("content_id"):
+                        step["content_id"] = '/'.join(tool_id)
+    return edited_wf

--- a/planemo/autoupdate.py
+++ b/planemo/autoupdate.py
@@ -288,15 +288,6 @@ def fix_workflow_ga(original_wf, updated_wf):
         if edited_wf['steps'][step].get("type") == "subworkflow":
             edited_wf['steps'][step]["subworkflow"] = fix_workflow_ga(edited_wf['steps'][step]["subworkflow"],
                                                                       updated_wf['steps'][step]["subworkflow"])
-        # fix tool_id and content_id to march tool_version
-        elif edited_wf['steps'][step]['type'] == 'tool':
-            if edited_wf['steps'][step].get('tool_id', '').startswith(AUTOUPDATE_TOOLSHED_URL[8:]):
-                if edited_wf['steps'][step]["tool_id"].split('/')[-1] != edited_wf['steps'][step]["tool_version"]:
-                    tool_id = edited_wf['steps'][step]["tool_id"].split('/')
-                    tool_id[-1] = edited_wf['steps'][step]["tool_version"]
-                    edited_wf['steps'][step]["tool_id"] = '/'.join(tool_id)
-                    if edited_wf['steps'][step].get("content_id"):
-                        edited_wf['steps'][step]["content_id"] = '/'.join(tool_id)
     return edited_wf
 
 
@@ -317,10 +308,7 @@ def fix_workflow_gxformat2(original_wf, updated_wf):
         elif updated_wf['steps'][str(step_index + len(original_wf['inputs']))]['type'] == 'tool':
             if updated_wf['steps'][str(step_index + len(original_wf['inputs']))].get('tool_id', '').startswith(AUTOUPDATE_TOOLSHED_URL[8:]):
                 step['tool_version'] = updated_wf['steps'][str(step_index + len(original_wf['inputs']))]['tool_version']
-                if step["tool_id"].split('/')[-1] != step["tool_version"]:
-                    tool_id = step["tool_id"].split('/')
-                    tool_id[-1] = step["tool_version"]
-                    step["tool_id"] = '/'.join(tool_id)
-                    if step.get("content_id"):
-                        step["content_id"] = '/'.join(tool_id)
+                step['tool_id'] = updated_wf['steps'][str(step_index + len(original_wf['inputs']))]['tool_id']
+                step['content_id'] = updated_wf['steps'][str(step_index + len(original_wf['inputs']))]['content_id']
+
     return edited_wf

--- a/planemo/commands/cmd_autoupdate.py
+++ b/planemo/commands/cmd_autoupdate.py
@@ -115,7 +115,7 @@ def cli(ctx, paths, **kwds):  # noqa C901
     workflows = [r for r in runnables if r.type == RunnableType.galaxy_workflow and r.path.split('/')[-1] not in tools_to_skip]
     modified_workflows = []
     for workflow in workflows:
-        tools_to_update = autoupdate.get_tools_to_update(workflow, tools_to_skip)
+        tools_to_update = autoupdate.get_tools_to_update(ctx, workflow, tools_to_skip)
         if tools_to_update:
             modified_workflows.append(workflow)
             info("The following tools are outdated:")

--- a/tests/data/wf_repos/autoupdate_tests/diff-refactor-test.ga
+++ b/tests/data/wf_repos/autoupdate_tests/diff-refactor-test.ga
@@ -3,6 +3,7 @@
     "annotation": "",
     "format-version": "0.1",
     "name": "diff-refactor-test",
+    "release": "0.1.0",
     "steps": {
         "0": {
             "annotation": "",

--- a/tests/data/wf_repos/autoupdate_tests/diff-refactor-test.gxwf.yml
+++ b/tests/data/wf_repos/autoupdate_tests/diff-refactor-test.gxwf.yml
@@ -1,6 +1,7 @@
 class: GalaxyWorkflow
 label: diff-refactor-test
 uuid: 22ff99ac-147f-4e23-80cd-ef56f59eedae
+release: 0.1.0
 inputs:
   inp:
     optional: false

--- a/tests/test_cmd_autoupdate.py
+++ b/tests/test_cmd_autoupdate.py
@@ -99,6 +99,7 @@ class CmdAutoupdateTestCase(CliTestCase):
             assert wf["steps"]["1"]["tool_version"] == "3.7+galaxy0"
             # check tool within subworkflow has updated
             assert wf["steps"]["2"]["subworkflow"]["steps"]["1"]["tool_version"] == "3.7+galaxy0"
+            assert wf["steps"]["2"]["subworkflow"]["steps"]["1"]["tool_id"] == "toolshed.g2.bx.psu.edu/repos/bgruening/diff/diff/3.7+galaxy0"
             assert wf["version"] == 2
             assert wf["release"] == "0.1.1"
 
@@ -113,5 +114,6 @@ class CmdAutoupdateTestCase(CliTestCase):
             with open(wf_file) as f:
                 wf = yaml.safe_load(f)
             assert wf["steps"][0]["tool_version"] == "3.7+galaxy0"
+            assert wf["steps"][0]["tool_version"] == "toolshed.g2.bx.psu.edu/repos/bgruening/diff/diff/3.7+galaxy0"
             assert wf['steps'][1]['run']['steps'][0]['tool_version'] == "3.7+galaxy0"
             assert wf["release"] == "0.1.1"

--- a/tests/test_cmd_autoupdate.py
+++ b/tests/test_cmd_autoupdate.py
@@ -99,7 +99,8 @@ class CmdAutoupdateTestCase(CliTestCase):
             assert wf["steps"]["1"]["tool_version"] == "3.7+galaxy0"
             # check tool within subworkflow has updated
             assert wf["steps"]["2"]["subworkflow"]["steps"]["1"]["tool_version"] == "3.7+galaxy0"
-            assert wf["version"] == 1
+            assert wf["version"] == 2
+            assert wf["release"] == "0.1.1"
 
             result = self._runner.invoke(self._cli.planemo, autoupdate_command)  # rerun on already updated WF
             assert 'No newer tool versions were found, so the workflow was not updated.' in result.output
@@ -113,3 +114,4 @@ class CmdAutoupdateTestCase(CliTestCase):
                 wf = yaml.safe_load(f)
             assert wf["steps"][0]["tool_version"] == "3.7+galaxy0"
             assert wf['steps'][1]['run']['steps'][0]['tool_version'] == "3.7+galaxy0"
+            assert wf["release"] == "0.1.1"


### PR DESCRIPTION
Here is an example of a resulting PR: https://github.com/simonbray/iwc/pull/37. See https://github.com/simonbray/iwc/pulls for more.

Changes:
- Check for new tool versions in the toolshed before launching Galaxy and running the workflow refactor. This prevents PRs in which the only changes are to `changeset_revision` ids (due to other tools in the TS repos being updated).
- Applying some formatting fixes to the refactored workflows:
  - Bumping release numbers if they exist
  - Updating `tool_id` and `content_id` for updated steps (the refactoring only updates `tool_version`)