### PR TITLE
training-init: add the FAQ index page to tutorial folder

### DIFF
--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -561,6 +561,7 @@ class Tutorial(object):
             with open(os.path.join(self.faq_dir, 'index.md'), 'w') as handle:
                 handle.write('---\nlayout: faq-page\n---\n')
 
+
 def get_galaxy_datatype(z_ext, datatype_fp):
     """Get the Galaxy datatype corresponding to a Zenodo file type."""
     g_datatype = ''

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -347,6 +347,12 @@ class Tutorial(object):
         # get the data library
         self.init_data_lib()
 
+        # create the FAQ page
+        if not os.path.exists(os.path.join(self.faq_dir, 'index.md')):
+            with open(os.path.join(self.faq_dir, 'index.md'), 'w') as handle:
+                handle.write('---\nlayout: faq-page\n---\n')
+
+
     def init_data_lib(self):
         """Init the data library dictionary."""
         if os.path.exists(self.data_lib_fp):
@@ -409,6 +415,7 @@ class Tutorial(object):
         self.data_lib_fp = os.path.join(self.dir, "data-library.yaml")
         self.wf_dir = os.path.join(self.dir, "workflows")
         self.wf_fp = os.path.join(self.wf_dir, "main_workflow.ga")
+        self.faq_dir = os.path.join(self.dir, "faqs")
         self.tour_dir = os.path.join(self.dir, "tours")
         # remove empty workflow file if there
         empty_wf_filepath = os.path.join(self.wf_dir, "empty_workflow.ga")
@@ -440,6 +447,7 @@ class Tutorial(object):
                 self.init_wf_id,
                 self.wf_fp,
                 use_default_filename=False)
+
 
     # OTHER METHODS
     def get_files_from_zenodo(self):

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -352,7 +352,6 @@ class Tutorial(object):
             with open(os.path.join(self.faq_dir, 'index.md'), 'w') as handle:
                 handle.write('---\nlayout: faq-page\n---\n')
 
-
     def init_data_lib(self):
         """Init the data library dictionary."""
         if os.path.exists(self.data_lib_fp):

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -556,6 +556,7 @@ class Tutorial(object):
                     templates.render(TUTO_SLIDES_TEMPLATE, **{"metadata": self.get_tuto_metata()}))
 
         # create the FAQ page
+        os.makedirs(self.faq_dir)
         if not os.path.exists(os.path.join(self.faq_dir, 'index.md')):
             with open(os.path.join(self.faq_dir, 'index.md'), 'w') as handle:
                 handle.write('---\nlayout: faq-page\n---\n')

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -347,11 +347,6 @@ class Tutorial(object):
         # get the data library
         self.init_data_lib()
 
-        # create the FAQ page
-        if not os.path.exists(os.path.join(self.faq_dir, 'index.md')):
-            with open(os.path.join(self.faq_dir, 'index.md'), 'w') as handle:
-                handle.write('---\nlayout: faq-page\n---\n')
-
     def init_data_lib(self):
         """Init the data library dictionary."""
         if os.path.exists(self.data_lib_fp):
@@ -446,6 +441,7 @@ class Tutorial(object):
                 self.init_wf_id,
                 self.wf_fp,
                 use_default_filename=False)
+
 
     # OTHER METHODS
     def get_files_from_zenodo(self):
@@ -560,6 +556,10 @@ class Tutorial(object):
                 slide_f.write(
                     templates.render(TUTO_SLIDES_TEMPLATE, **{"metadata": self.get_tuto_metata()}))
 
+        # create the FAQ page
+        if not os.path.exists(os.path.join(self.faq_dir, 'index.md')):
+            with open(os.path.join(self.faq_dir, 'index.md'), 'w') as handle:
+                handle.write('---\nlayout: faq-page\n---\n')
 
 def get_galaxy_datatype(z_ext, datatype_fp):
     """Get the Galaxy datatype corresponding to a Zenodo file type."""

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -442,7 +442,6 @@ class Tutorial(object):
                 self.wf_fp,
                 use_default_filename=False)
 
-
     # OTHER METHODS
     def get_files_from_zenodo(self):
         """Extract a list of URLs and dictionary describing the files from the JSON output of the Zenodo API."""

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -448,7 +448,6 @@ class Tutorial(object):
                 self.wf_fp,
                 use_default_filename=False)
 
-
     # OTHER METHODS
     def get_files_from_zenodo(self):
         """Extract a list of URLs and dictionary describing the files from the JSON output of the Zenodo API."""


### PR DESCRIPTION
Since reworking the FAQ pages in GTN (xref https://github.com/galaxyproject/training-material/pull/3188), each tutorial directory should have an `faqs` folder and an `index.md` file.