### PR TITLE
Make `--channels` also affect mulled channels and update/extend howto use bioconda artifacts

### DIFF
--- a/docs/writing_how_do_i.rst
+++ b/docs/writing_how_do_i.rst
@@ -357,7 +357,7 @@ and a planemo test can then simply use this image::
 
 For the later case it suffices to call planemo as follows::
 
-     $ DEFAULT_MULLED_CONDA_CHANNELS="file://PACKAGES_DIR,conda-forge,bioconda" planemo test ... --biocontainers --no_dependency_resolution --no_conda_auto_init ...
+     $ planemo test ... --biocontainers --no_dependency_resolution --no_conda_auto_init --conda_channels file://PACKAGES_DIR,conda-forge,bioconda,defaults ...
 
 --------------------------------------
 \.\.\. interactively debug tool tests?

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -367,6 +367,7 @@ def docker_galaxy_config(ctx, runnables, for_tests=False, **kwds):
 @contextlib.contextmanager
 def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
     """Set up a ``GalaxyConfig`` in an auto-cleaned context."""
+
     test_data_dir = _find_test_data(runnables, **kwds)
     tool_data_table = _find_tool_data_table(
         runnables,
@@ -499,6 +500,8 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         _handle_container_resolution(ctx, kwds, properties)
         write_file(config_join("logging.ini"), _sub(LOGGING_TEMPLATE, template_args))
         properties["database_connection"] = _database_connection(database_location, **kwds)
+        if kwds.get("mulled_containers", False):
+            properties["mulled_channels"] = kwds.get("conda_ensure_channels", "")
 
         _handle_kwd_overrides(properties, kwds)
 


### PR DESCRIPTION
Adapted `--channels` such that it also affects Galaxy's mulled channels config. 

Update docs due to the recent change in bioconda CI (packages and images are now available only as download)

Also document how to set conda channels for mulled container building (see also https://github.com/galaxyproject/galaxy/pull/13755)