### PR TITLE
Pin planemo to last known working major galaxy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ configparser
 cwltool>=1.0.20191225192155
 docutils
 ephemeris>=0.10.3
-galaxy-containers
-galaxy-tool-util>=21.1.0.dev4
-galaxy-util>=20.5.0
+galaxy-containers<22.01
+galaxy-tool-util<22.01,>=21.1.0.dev4
+galaxy-util<22.01,>=20.5.0
 glob2
 gxformat2>=0.12.0
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ cwltool>=1.0.20191225192155
 docutils
 ephemeris>=0.10.3
 galaxy-containers<22.01
-galaxy-tool-util<22.01,>=21.1.0.dev4
-galaxy-util<22.01,>=20.5.0
+galaxy-tool-util>=21.1.0.dev4,<22.01
+galaxy-util>=20.5.0,<22.01
 glob2
 gxformat2>=0.12.0
 jinja2


### PR DESCRIPTION
As an alternative to https://github.com/galaxyproject/planemo/pull/1203.
I'd then proceed to create a new planemo release, release the 22.01 galaxy packages, and bump the pin.