### PR TITLE
add option to limit test run time time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 100
     strategy:
       fail-fast: false
       matrix:

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -506,9 +506,9 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         env = _build_env_for_galaxy(properties, template_args)
         env.update(install_env)
         _build_test_env(properties, env)
-        test_default_wait = kwds.get("test_default_wait")
-        if test_default_wait:
-            env["GALAXY_TEST_DEFAULT_WAIT"] = str(test_default_wait)
+        test_timeout = kwds.get("test_timeout")
+        if test_timeout:
+            env["GALAXY_TEST_DEFAULT_WAIT"] = str(test_timeout)
         env["GALAXY_TEST_SHED_TOOL_CONF"] = shed_tool_conf
         env["GALAXY_TEST_DBURI"] = properties["database_connection"]
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -506,6 +506,9 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         env = _build_env_for_galaxy(properties, template_args)
         env.update(install_env)
         _build_test_env(properties, env)
+        test_default_wait = kwds.get("test_default_wait")
+        if test_default_wait:
+            env["GALAXY_TEST_DEFAULT_WAIT"] = str(test_default_wait)
         env["GALAXY_TEST_SHED_TOOL_CONF"] = shed_tool_conf
         env["GALAXY_TEST_DBURI"] = properties["database_connection"]
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1591,6 +1591,12 @@ def test_options():
                 "to disable completely."
             ),
         ),
+        planemo_option(
+            "--test_default_wait",
+            type=int,
+            help="Maximum runtime of a single test in seconds.",
+            default=0,
+        ),
     )
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1592,7 +1592,7 @@ def test_options():
             ),
         ),
         planemo_option(
-            "--test_default_wait",
+            "--test_timeout",
             type=int,
             help="Maximum runtime of a single test in seconds.",
             default=0,

--- a/tests/data/tools/timeout.xml
+++ b/tests/data/tools/timeout.xml
@@ -1,0 +1,22 @@
+<tool id="timeout" name="time out" version="1.0">
+    <description>just wastes time</description>
+    <command detect_errors="exit_code"><![CDATA[
+        echo "output" > '$output' &&
+        sleep 30;
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="output">
+                <assert_contents>
+                    <has_text text="output"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help/>
+</tool>

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -73,10 +73,10 @@ class CmdTestTestCase(CliTestCase):
                 # check run time, for smaller 10 since the test will take a bit longer than 1s
                 # the important bit is that it's not about 30s (since the test tool calls `sleep 30`)
                 assert (
-                    float(tool_test_json["tests"][0]["data"]["time_seconds"]) > 10
+                    float(tool_test_json["tests"][0]["data"]["time_seconds"]) <= 10
                 ), "Test needed more than 10 sec but should time out after 1"
                 assert (
-                    "Timed out after" not in tool_test_json["tests"][0]["data"]["problem_log"]
+                    "Timed out after" in tool_test_json["tests"][0]["data"]["problem_log"]
                 ), "Time out did not happen"
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -75,9 +75,7 @@ class CmdTestTestCase(CliTestCase):
                 assert (
                     float(tool_test_json["tests"][0]["data"]["time_seconds"]) <= 10
                 ), "Test needed more than 10 sec but should time out after 1"
-                assert (
-                    "Timed out after" in tool_test_json["tests"][0]["data"]["problem_log"]
-                ), "Time out did not happen"
+                assert "Timed out after" in tool_test_json["tests"][0]["data"]["problem_log"], "Time out did not happen"
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     def test_workflow_test_simple_yaml_dockerized(self):


### PR DESCRIPTION
fixes https://github.com/galaxyproject/planemo/issues/999

not sure if we need an option in planemo / if setting the env variable in planemo ci action would be sufficient (but a bit more complex in bash, since it must be checked against zero)