### PR TITLE
More fixes for auto-generating workflow tests

### DIFF
--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -315,6 +315,7 @@ def _job_inputs_template_from_invocation(invocation_id, galaxy_url, galaxy_api_k
             if element["element_type"] == "hdca":
                 template["elements"].append(_template_from_collection(element["object"]["id"]))
             elif element["element_type"] == "hda":
+                ext = element["object"]["file_ext"]
                 user_gi.datasets.download_dataset(
                     element["object"]["id"],
                     use_default_filename=False,
@@ -360,7 +361,7 @@ def _job_outputs_template_from_invocation(invocation_id, galaxy_url, galaxy_api_
         user_gi.datasets.download_dataset(
             output["id"], use_default_filename=False, file_path=f"test-data/{label}.{ext}"
         )
-        outputs[label] = {"file": f"test-data/{label}.{ext}"}
+        outputs[label] = {"path": f"test-data/{label}.{ext}"}
     for label, output in invocation["output_collections"].items():
         collection = user_gi.dataset_collections.show_dataset_collection(output["id"])
         if ":" not in collection["collection_type"]:
@@ -371,9 +372,9 @@ def _job_outputs_template_from_invocation(invocation_id, galaxy_url, galaxy_api_
             )
             outputs[label] = {
                 "element_tests": {  # only check the first element
-                    collection["elements"][0][
-                        "element_identifier"
-                    ]: f"test-data/{label}.{collection['elements'][0]['object']['file_ext']}"
+                    collection["elements"][0]["element_identifier"]: {
+                        "path": f"test-data/{label}.{collection['elements'][0]['object']['file_ext']}"
+                    }
                 }
             }
         else:


### PR DESCRIPTION
Fixes the following traceback when running tests:
```
Traceback (most recent call last):
  File "/Users/mvandenb/miniconda3/bin/planemo", line 33, in <module>
    sys.exit(load_entry_point('planemo', 'console_scripts', 'planemo')())
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
- doc: Test outline for Generic-variation-analysis-reporting
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/mvandenb/src/planemo/planemo/cli.py", line 96, in handle_blended_options
    return f(*args, **kwds)
  File "/Users/mvandenb/src/planemo/planemo/commands/cmd_test.py", line 78, in cli
    return_value = test_runnables(ctx, runnables, original_paths=uris, **kwds)
  File "/Users/mvandenb/src/planemo/planemo/engine/test.py", line 23, in test_runnables
    test_data = engine.test(runnables)
  File "/Users/mvandenb/src/planemo/planemo/engine/interface.py", line 79, in test
    test_case_data = test_case.structured_test_data(run_response)
  File "/Users/mvandenb/src/planemo/planemo/runnable.py", line 361, in structured_test_data
    return run_response.structured_data(self)
  File "/Users/mvandenb/src/planemo/planemo/runnable.py", line 573, in structured_data
    output_problems.extend(test_case._check_output(output_id, output_value, output_test))
  File "/Users/mvandenb/src/planemo/planemo/runnable.py", line 411, in _check_output
    output_test,
  File "/Users/mvandenb/src/planemo/planemo/test/_check_output.py", line 24, in check_output
    return checker(runnable, output_properties, test_properties, **kwds)
  File "/Users/mvandenb/src/planemo/planemo/test/_check_output.py", line 43, in _check_output_collection
    verify_collection(output_def, data_collection, verify_dataset)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/galaxy/tool_util/verify/interactor.py", line 922, in verify_collection
    verify_elements(data_collection["elements"], output_collection_def.element_tests)
  File "/Users/mvandenb/miniconda3/lib/python3.7/site-packages/galaxy/tool_util/verify/interactor.py", line 892, in verify_elements
    element_outfile, element_attrib = element_test
ValueError: too many values to unpack (expected 2)
```

For ease of use I think it makes sense to just always use path in a
separate map, since you can then add additional keys like `compare:` and
so on.