### PR TITLE
Set upstream branch when pushing workflows to GitHub

### DIFF
--- a/planemo/commands/cmd_workflow_upload.py
+++ b/planemo/commands/cmd_workflow_upload.py
@@ -13,10 +13,11 @@ from planemo.workflow_lint import find_workflow_descriptions
 
 @click.command("workflow_upload")
 @options.github_namespace()
+@options.github_branch()
 @options.dry_run()
 @options.optional_tools_or_packages_arg(multiple=True)
 @command_function
-def cli(ctx, paths, namespace, dry_run, **kwds):
+def cli(ctx, paths, namespace, dry_run, github_branch, **kwds):
     """Upload workflows to github organization."""
     owner = namespace
     for path in paths:
@@ -40,5 +41,12 @@ def cli(ctx, paths, namespace, dry_run, **kwds):
                 raise Exception(f"All workflows in repository must have same version.\n{msg}")
         if versions:
             create_release(
-                ctx, from_dir=path, target_dir=repo, owner=owner, repo=repo, version=version, dry_run=dry_run
+                ctx,
+                from_dir=path,
+                target_dir=repo,
+                owner=owner,
+                repo=repo,
+                version=version,
+                dry_run=dry_run,
+                branch=github_branch,
             )

--- a/planemo/github_util.py
+++ b/planemo/github_util.py
@@ -107,7 +107,9 @@ def rm_dir_contents(directory, ignore_dirs=(".git")):
                 item.unlink()
 
 
-def add_dir_contents_to_repo(ctx, from_dir, target_dir, target_repository_path, version, dry_run, notes=""):
+def add_dir_contents_to_repo(
+    ctx, from_dir, target_dir, target_repository_path, version, dry_run, branch="main", notes=""
+):
     ctx.log(f"From {from_dir} to {target_repository_path}")
     rm_dir_contents(target_repository_path)
     copy_tree(from_dir, target_repository_path)
@@ -117,7 +119,7 @@ def add_dir_contents_to_repo(ctx, from_dir, target_dir, target_repository_path, 
         message += f"\n{notes}"
     git.commit(ctx, repo_path=target_repository_path, message=message)
     if not dry_run:
-        git.push(ctx, target_repository_path)
+        git.push(ctx, target_repository_path, to="origin", branch=branch)
 
 
 def assert_new_version(ctx, version, owner, repo):
@@ -161,11 +163,11 @@ def changelog_in_repo(target_repository_path):
     return "\n".join(changelog).rstrip()
 
 
-def create_release(ctx, from_dir, target_dir, owner, repo, version, dry_run, notes="", **kwds):
+def create_release(ctx, from_dir, target_dir, owner, repo, version, dry_run, branch, notes="", **kwds):
     assert_new_version(ctx, version, owner=owner, repo=repo)
     target_repository_path = get_or_create_repository(ctx, owner=owner, repo=repo, dry_run=dry_run)
     add_dir_contents_to_repo(
-        ctx, from_dir, target_dir, target_repository_path, version=version, dry_run=dry_run, notes=notes
+        ctx, from_dir, target_dir, target_repository_path, version=version, dry_run=dry_run, branch=branch, notes=notes
     )
     gh_path = ensure_gh(ctx, **kwds)
     gh_env = get_gh_env(ctx, dry_run=dry_run, **kwds)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1115,6 +1115,14 @@ def dry_run():
     )
 
 
+def github_branch():
+    return planemo_option(
+        "--github_branch",
+        help="GitHub branch to use for the action. Default is main.",
+        default="main",
+    )
+
+
 def galaxy_run_options():
     return _compose(
         galaxy_target_options(),


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/planemo/issues/1248.

Bit difficult to write a test but I tested manually with `planemo workflow_upload iwc/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga --namespace simonbray` and it successfully created https://github.com/simonbray/fragment-based-docking-scoring.