### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
         tox-env:
           type: string
       docker:
-        - image: circleci/python:3.6-node
+        - image: circleci/python:3.7-node
       steps:
         - checkout
         - run: git submodule sync
@@ -19,7 +19,7 @@ workflows:
         matrix:
           parameters:
             tox-env:
-              - "py36-diagnostic-unit-servebasic-gx-dev"
-              - "py36-unit-nonredundant-noclientbuild-noshed-gx-2005"
-              - "py36-unit-nonredundant-noclientbuild-noshed-gx-dev"
-              - "py36-unit-nonredundant-noclientbuild-noshed"
+              - "py37-diagnostic-unit-servebasic-gx-dev"
+              - "py37-unit-nonredundant-noclientbuild-noshed-gx-2005"
+              - "py37-unit-nonredundant-noclientbuild-noshed-gx-dev"
+              - "py37-unit-nonredundant-noclientbuild-noshed"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-2. The pull request should work for Python >=3.6. Check
+2. The pull request should work for Python >=3.7. Check
    https://travis-ci.org/galaxyproject/planemo/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
@@ -156,10 +156,10 @@ testing environment. Planemo defines the following environments:
 ``py37-lint_docstrings``
     Lint the project Python docstrings (doesn't pass currently).
 
-``py36-unit-quick``
-    Run the fastest unit tests (with least external dependencies) on Python 3.6.
+``py37-unit-quick``
+    Run the fastest unit tests (with least external dependencies) on Python 3.7.
 
-``py36-unit-nonredundant-noclientbuild-gx-2005``
+``py37-unit-nonredundant-noclientbuild-gx-2005``
     Run tests that are marked as targeting a Galaxy branch and test against Galaxy 20.05.
     Skip tests that are marked as redundant or that require a Galaxy client build.
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ flake8: ## check style using flake8 for current Python (faster than lint)
 	$(IN_VENV) flake8 $(SOURCE_DIR) $(TEST_DIR)
 
 lint: ## check style using tox and flake8 for Python 2 and Python 3
-	$(IN_VENV) tox -e py36-lint
+	$(IN_VENV) tox -e py37-lint
 
 test: ## run tests with the default Python (faster than tox)
 	$(IN_VENV) pytest $(TESTS)

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,9 @@ Obtaining
 -----------------
 
 For a traditional Python installation of Planemo, first set up a virtualenv
-for ``planemo`` (this example creates a new one in ``.venv``) and then
-install with ``pip``. Planemo requires pip 7.0 or newer.
+for ``planemo`` (this example creates a new one in ``.venv``) containing
+Python 3.7 or newer and then install with ``pip``. Planemo must be installed
+with pip 7.0 or newer.
 
 ::
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -162,7 +162,7 @@ def galaxy_python_version():
         "--galaxy_python_version",
         use_global_config=True,
         default=None,
-        type=click.Choice(["3", "3.6", "3.7", "3.8", "3.9"]),
+        type=click.Choice(["3", "3.7", "3.8", "3.9"]),
         help="Python version to start Galaxy under",
     )
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-if sys.version_info < (3, 6):
-    sys.stderr.write("ERROR: planemo requires at least Python Version 3.6\n")
+if sys.version_info < (3, 7):
+    sys.stderr.write("ERROR: planemo requires at least Python version 3.7\n")
     sys.exit(1)
 
 # Allow installer to turn off dependency on lxml by setting the environment variable
@@ -125,7 +125,6 @@ setup(
         "Topic :: Software Development :: Testing",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36}-lint, py36-unit-quick, py36-lint_docstrings, py36-lint_docs, py{36,37}-unit, py36-gxwf_test_test
+envlist = py{37}-lint, py37-unit-quick, py37-lint_docstrings, py37-lint_docs, py{37}-unit, py37-gxwf_test_test
 source_dir = planemo
 test_dir = tests
 


### PR DESCRIPTION
Planemo>=0.78.10 installation no longer works in a Python 3.6 environment (see #1256) as it depends on BioBlend>=0.17.0, which no longer supports Python 3.6.

It would be nice to add Python 3.10 at the same time but afaik that depends on #1232.