### PR TITLE
Mains resource selector must be skipped

### DIFF
--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -652,6 +652,8 @@ def format_wf_steps(wf, gi):
         # get formatted param description
         paramlist = ""
         for inp in tool_desc["inputs"]:
+            if inp["name"] == "__job_resource":
+                continue
             tool_inp = ToolInput(inp, wf_param_values, steps, 1, should_be_there=True)
             paramlist += tool_inp.get_formatted_desc()
         # format the hands-on box

--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -652,7 +652,7 @@ def format_wf_steps(wf, gi):
         # get formatted param description
         paramlist = ""
         for inp in tool_desc["inputs"]:
-            if inp["name"] == "__job_resource":
+            if inp["name"].startswith("__"):
                 continue
             tool_inp = ToolInput(inp, wf_param_values, steps, 1, should_be_there=True)
             paramlist += tool_inp.get_formatted_desc()


### PR DESCRIPTION
In the training subcommands we've discovered today that main's resource selector looks exactly like every other parameter. However this throws an exception and we need to skip specifically job resource selectors.