### PR TITLE
Check if main requirement is `None`

### DIFF
--- a/planemo/autoupdate.py
+++ b/planemo/autoupdate.py
@@ -205,6 +205,8 @@ def autoupdate_tool(ctx, tool_path, modified_files, **kwds):
         xml_files[macro_path] = ET.parse(macro_path)
 
     requirements, main_req = create_requirement_dict(xml_files, kwds.get("skip_requirements", "").split(","))
+    if main_req is None:
+        return
     tokens, xml_to_update, current_main_req, updated_main_req = create_token_dict(ctx, xml_files, main_req, **kwds)
 
     if current_main_req == updated_main_req and not (modified_files & set(xml_files)):


### PR DESCRIPTION
user currently sees:

```
No requirement uses the token @TOOL_VERSION@!
/home/runner/work/tools-iuc/tools-iuc/tools/hansel/bio_hansel.xml could not be updated - the following error was raised: 'NoneType' object is not subscriptable
```
The second is not really helpful. Its due to:

```
Traceback (most recent call last):
  File "/home/berntm/miniconda3/envs/python38/bin/planemo", line 8, in <module>
    sys.exit(planemo())
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/planemo/cli.py", line 96, in handle_blended_options
    return f(*args, **kwds)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/planemo/commands/cmd_autoupdate.py", line 101, in cli
    updated = autoupdate.autoupdate_tool(ctx, tool_path, modified_files=modified_files, **kwds)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/planemo/autoupdate.py", line 210, in autoupdate_tool
    tokens, xml_to_update, current_main_req, updated_main_req = create_token_dict(ctx, xml_files, main_req, **kwds)
  File "/home/berntm/miniconda3/envs/python38/lib/python3.8/site-packages/planemo/autoupdate.py", line 141, in create_token_dict
    updated_main_req = check_conda(main_req[0], ctx, **kwds)
```