### PR TITLE
Fix workflow test when input is optional but also workflow output

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -420,18 +420,13 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
             output_src = self.output_src(runnable_output)
             output_dataset_id = output_src["id"]
             galaxy_output = self.to_galaxy_output(runnable_output)
-            try:
-                cwl_output = output_to_cwl_json(
-                    galaxy_output,
-                    self._get_metadata,
-                    get_dataset,
-                    self._get_extra_files,
-                    pseduo_location=True,
-                )
-            except AssertionError:
-                # In galaxy-tool-util < 21.05 output_to_cwl_json will raise an AssertionError when the output state is not OK
-                # Remove with new galaxy-tool-util release.
-                continue
+            cwl_output = output_to_cwl_json(
+                galaxy_output,
+                self._get_metadata,
+                get_dataset,
+                self._get_extra_files,
+                pseduo_location=True,
+            )
             if is_cwl or output_src["src"] == "hda":
                 output_dict_value = cwl_output
             else:

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -261,7 +261,7 @@ def stage_in(ctx, runnable, config, job_path, **kwds):  # noqa C901
 
     ctx.vlog("final state is %s" % final_state)
     if final_state != "ok":
-        msg = "Failed to run job final job state is [%s]." % final_state
+        msg = "Failed to upload data, upload state is [%s]." % final_state
         summarize_history(ctx, user_gi, history_id)
         raise Exception(msg)
     return job_dict, datasets, history_id

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -145,7 +145,7 @@ def find_tool_ids(path):
     return list(tool_ids)
 
 
-WorkflowOutput = namedtuple("WorkflowOutput", ["order_index", "output_name", "label"])
+WorkflowOutput = namedtuple("WorkflowOutput", ["order_index", "output_name", "label", "optional"])
 
 
 def remote_runnable_to_workflow_id(runnable):
@@ -165,12 +165,18 @@ def describe_outputs(runnable, gi=None):
 
     outputs = []
     for (order_index, step) in workflow["steps"].items():
+        optional = False
+        if not step.get("tool_id"):
+            # One of the parameter types ... need eliminate this guesswork on the Galaxy side
+            tool_state = json.loads(step.get("tool_state", "{}"))
+            optional = tool_state.get("optional", False)
         step_outputs = step.get("workflow_outputs", [])
         for step_output in step_outputs:
             output = WorkflowOutput(
                 int(order_index),
                 step_output["output_name"],
                 step_output["label"],
+                optional,
             )
             outputs.append(output)
     return outputs

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -538,6 +538,9 @@ class RunnableOutput(metaclass=abc.ABCMeta):
     def get_id(self):
         """An identifier that describes this output."""
 
+    def is_optional(self):
+        return False
+
 
 class ToolOutput(RunnableOutput):
     """Implementation of RunnableOutput corresponding to Galaxy tool outputs."""
@@ -557,6 +560,9 @@ class GalaxyWorkflowOutput(RunnableOutput):
 
     def get_id(self) -> Optional[str]:
         return self._workflow_output.label
+
+    def is_optional(self):
+        return self.workflow_output.optional
 
     @property
     def workflow_output(self):

--- a/tests/data/wf16_optional_input_output_label-test.yml
+++ b/tests/data/wf16_optional_input_output_label-test.yml
@@ -1,0 +1,2 @@
+- doc: Test optional input workflow output
+  job: {}

--- a/tests/data/wf16_optional_input_output_label.ga
+++ b/tests/data/wf16_optional_input_output_label.ga
@@ -1,0 +1,38 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "optional_input_label",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [],
+            "label": null,
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0.0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": true, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "e6301247-43c4-452d-a3d1-8e140c3945fd",
+            "workflow_outputs": [
+                {
+                    "label": "optional_output",
+                    "output_name": "output",
+                    "uuid": "6b333ea9-6c5c-4823-be37-be9a36112c39"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "25f7fecd-45f1-4ece-93a9-86e085e02fc3",
+    "version": 1
+}

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -290,3 +290,12 @@ class CmdTestTestCase(CliTestCase):
                 command += ["--database_type", database_type]
 
         return command
+
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    def test_workflow_with_optional_input_output_not_provided(self):
+        with self._isolate():
+            test_artifact = os.path.join(TEST_DATA_DIR, "wf16_optional_input_output_label.ga")
+            test_command = self._test_command()
+            test_command = self.append_profile_argument_if_needed(test_command)
+            test_command.append(test_artifact)
+            self._check_exit_code(test_command, exit_code=0)


### PR DESCRIPTION
i.e:
```
        "0": {
            "annotation": "",
            "content_id": null,
            "errors": null,
            "id": 0,
            "input_connections": {},
            "inputs": [],
            "label": null,
            "name": "Input dataset",
            "outputs": [],
            "position": {
                "left": 0,
                "top": 0.0
            },
            "tool_id": null,
            "tool_state": "{\"optional\": true, \"tag\": \"\"}",
            "tool_version": null,
            "type": "data_input",
            "uuid": "e6301247-43c4-452d-a3d1-8e140c3945fd",
            "workflow_outputs": [
                {
                    "label": "optional_output",
                    "output_name": "output",
                    "uuid": "6b333ea9-6c5c-4823-be37-be9a36112c39"
                }
            ]
```
To enable testing this workflow without jobs we now poll on the invocation jobs instead of the history jobs (5cb3de0bddc3bf0c4f49615607b7bd1625725180) after the invocation has finished scheduling.

Also includes a better error message when the uploads fails and removes an old workaround that isn't necessary anymore.