### PR TITLE
Fix printing planemo test logs

### DIFF
--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -40,4 +40,5 @@ def cli(ctx, uris, **kwds):
     paths = uris_to_paths(ctx, uris)
     runnables = for_paths(paths)
     kwds["galaxy_skip_client_build"] = kwds.pop("skip_client_build", False)
-    galaxy_serve(ctx, runnables, **kwds)
+    with galaxy_serve(ctx, runnables, **kwds):
+        pass

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -332,12 +332,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         if not os.path.isdir(galaxy_root):
             _install_galaxy(ctx, galaxy_root, install_env, kwds)
 
-        if parse_version(kwds.get("galaxy_python_version") or DEFAULT_PYTHON_VERSION) >= parse_version("3"):
-            # on python 3 we use gunicorn,
-            # which requires 'main' as server name
-            server_name = "main"
-        else:
-            server_name = f"planemo{random.randint(0, 100000)}"
+        server_name = "main"
         # Once we don't have to support earlier than 18.01 - try putting these files
         # somewhere better than with Galaxy.
         log_file = f"{server_name}.log"

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -624,7 +624,7 @@ def _config_directory(ctx, **kwds):
     finally:
         cleanup = not kwds.get("no_cleanup", False)
         if created_config_directory and cleanup:
-            shutil.rmtree(config_directory)
+            shutil.rmtree(config_directory, ignore_errors=True)
 
 
 class GalaxyInterface(metaclass=abc.ABCMeta):

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -40,7 +40,6 @@ from planemo.io import (
 )
 from planemo.mulled import build_involucro_context
 from planemo.shed import tool_shed_url
-from planemo.virtualenv import DEFAULT_PYTHON_VERSION
 from .api import (
     DEFAULT_ADMIN_API_KEY,
     gi,

--- a/tests/test_galaxy_serve.py
+++ b/tests/test_galaxy_serve.py
@@ -29,7 +29,7 @@ class GalaxyServeTestCase(CliTestCase):
         """Test serving a galaxy tool via a daemon Galaxy process."""
         port = network_util.get_free_port()
         cat_path = os.path.join(TEST_REPOS_DIR, "single_tool", "cat.xml")
-        config = galaxy_serve(
+        with galaxy_serve(
             self.test_context,
             [for_path(cat_path)],
             install_galaxy=True,
@@ -37,9 +37,9 @@ class GalaxyServeTestCase(CliTestCase):
             port=port,
             daemon=True,
             no_dependency_resolution=True,
-        )
-        _assert_service_up(config)
-        config.kill()
+        ) as config:
+            _assert_service_up(config)
+            config.kill()
         _assert_service_down(config)
 
     @skip_if_environ("PLANEMO_SKIP_REDUNDANT_TESTS")  # redundant with test_cmd_serve -> test_serve_workflow
@@ -52,7 +52,7 @@ class GalaxyServeTestCase(CliTestCase):
         cat = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml")
         workflow = os.path.join(TEST_DATA_DIR, "wf1.gxwf.yml")
         extra_tools = [random_lines, cat]
-        config = galaxy_serve(
+        with galaxy_serve(
             self.test_context,
             [for_path(workflow)],
             install_galaxy=True,
@@ -61,13 +61,13 @@ class GalaxyServeTestCase(CliTestCase):
             daemon=True,
             extra_tools=extra_tools,
             no_dependency_resolution=True,
-        )
-        _assert_service_up(config)
-        user_gi = config.user_gi
-        assert user_gi.tools.show_tool("random_lines1")
-        assert len(user_gi.workflows.get_workflows()) == 1
-        config.kill()
-        _assert_service_down(config)
+        ) as config:
+            _assert_service_up(config)
+            user_gi = config.user_gi
+            assert user_gi.tools.show_tool("random_lines1")
+            assert len(user_gi.workflows.get_workflows()) == 1
+            config.kill()
+            _assert_service_down(config)
 
 
 def _assert_service_up(config):


### PR DESCRIPTION
We were quitting the context manager scope too early, so the print threads would stop too early.
I think this is the last fix after which I would create a new planemo release.