### PR TITLE
supply "kwds" to for_runnable_identifier() directly

### DIFF
--- a/planemo/commands/cmd_workflow_edit.py
+++ b/planemo/commands/cmd_workflow_edit.py
@@ -18,7 +18,7 @@ from planemo.runnable_resolve import for_runnable_identifier
 def cli(ctx, workflow_identifier, output=None, force=False, **kwds):
     """Open a synchronized Galaxy workflow editor."""
     assert is_galaxy_engine(**kwds)
-    runnable = for_runnable_identifier(ctx, workflow_identifier, kwds.get("profile"))
+    runnable = for_runnable_identifier(ctx, workflow_identifier, kwds)
 
     kwds["workflows_from_path"] = True
 


### PR DESCRIPTION
Trying the workflow_edit command I was getting an error that was caused by the fact that, kwds.get("profile") was called here AND in for_runnable_identifier(). With this change workflow_edit successfully boots up the Galaxy instance. 

Unfortunately, I am not yet getting anything different then I would get via the serve command. There is no workflow and the tools used in the workflow aren't installed either.