### PR TITLE
Use `pytest.raises()` instead of ad-hoc `assert_raises_regexp()` context manager

### DIFF
--- a/planemo/context.py
+++ b/planemo/context.py
@@ -62,6 +62,8 @@ class PlanemoContextInterface(metaclass=abc.ABCMeta):
 class PlanemoContext(PlanemoContextInterface):
     """Implementation of ``PlanemoContextInterface``"""
 
+    planemo_directory: Optional[str]
+
     def __init__(self) -> None:
         """Construct a Context object using execution environment."""
         self.home = os.getcwd()

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,5 @@ max-complexity = 14
 exclude=.eggs,.git,.tox,.venv,.venv3,build,docs/conf.py,docs/standards,project_templates/cwl_draft3_spec/
 
 [mypy]
+exclude = tests/data/
 ignore_missing_imports = True

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -102,7 +102,7 @@ KWDS = {
 }
 
 
-def test_training_init():
+def test_training_init() -> None:
     """Test :func:`planemo.training.Training.init`."""
     train = Training(KWDS)
     assert train.topics_dir == "topics"
@@ -110,7 +110,7 @@ def test_training_init():
     assert train.tuto is None
 
 
-def test_training_init_training():
+def test_training_init_training() -> None:
     """Test :func:`planemo.training.Training.init_training`."""
     train = Training(KWDS)
     # new topic, nothing else
@@ -152,13 +152,13 @@ def test_training_init_training():
     shutil.rmtree("metadata")
 
 
-def create_existing_tutorial(exit_tuto_name, tuto_fp, topic):
+def create_existing_tutorial(exit_tuto_name, tuto_fp, topic) -> None:
     exist_tuto_dir = os.path.join(topic.dir, "tutorials", exit_tuto_name)
     os.makedirs(exist_tuto_dir)
     shutil.copyfile(tuto_fp, os.path.join(exist_tuto_dir, "tutorial.md"))
 
 
-def test_training_check_topic_init_tuto():
+def test_training_check_topic_init_tuto() -> None:
     """Test :func:`planemo.training.Training.check_topic_init_tuto`."""
     train = Training(KWDS)
     # no topic
@@ -181,7 +181,7 @@ def test_training_check_topic_init_tuto():
     shutil.rmtree("metadata")
 
 
-def test_fill_data_library():
+def test_fill_data_library() -> None:
     """Test :func:`planemo.training.fill_data_library`."""
     train = Training(KWDS)
     train.kwds["tutorial_name"] = None
@@ -208,6 +208,7 @@ def test_fill_data_library():
     train.kwds["zenodo_link"] = new_z_link
     train.tuto = None
     train.fill_data_library(CTX)
+    assert train.tuto
     with open(train.tuto.data_lib_fp) as fh:
         assert "DOI: 10.5281/zenodo.1324204" in fh.read()
     with open(train.tuto.tuto_fp) as fh:
@@ -225,7 +226,7 @@ def test_fill_data_library():
 
 
 @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
-def test_generate_tuto_from_wf():
+def test_generate_tuto_from_wf() -> None:
     """Test :func:`planemo.training.generate_tuto_from_wf`."""
     train = Training(KWDS)
     train.kwds["tutorial_name"] = None
@@ -253,7 +254,7 @@ def test_generate_tuto_from_wf():
     shutil.rmtree("metadata")
 
 
-def assert_file_contains(file, text):
+def assert_file_contains(file: str, text: str) -> None:
     with open(file) as fh:
         contents = fh.read()
     if text not in contents:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -3,11 +3,12 @@ import json
 import os
 import shutil
 
+import pytest
+
 from planemo import cli
 from planemo.runnable import for_path
 from planemo.training import Training
 from .test_utils import (
-    assert_raises_regexp,
     skip_if_environ,
     TEST_DATA_DIR,
 )
@@ -123,20 +124,19 @@ def test_training_init_training():
     assert not os.listdir(os.path.join(train.topic.dir, "tutorials"))
     # no new topic, no tutorial name but hands-on
     train.kwds["slides"] = True
-    exp_exception = "A tutorial name is needed to create the skeleton of a tutorial slide deck"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="A tutorial name is needed to create the skeleton of a tutorial slide deck"):
         train.init_training(CTX)
     # no new topic, no tutorial name but workflow
     train.kwds["workflow"] = WF_FP
     train.kwds["slides"] = False
-    exp_exception = "A tutorial name is needed to create the skeleton of the tutorial from a workflow"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(
+        Exception, match="A tutorial name is needed to create the skeleton of the tutorial from a workflow"
+    ):
         train.init_training(CTX)
     # no new topic, no tutorial name but zenodo
     train.kwds["workflow"] = None
     train.kwds["zenodo_link"] = zenodo_link
-    exp_exception = "A tutorial name is needed to add Zenodo information"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="A tutorial name is needed to add Zenodo information"):
         train.init_training(CTX)
     # no new topic, new tutorial
     train.kwds["tutorial_name"] = "new_tuto"
@@ -162,8 +162,7 @@ def test_training_check_topic_init_tuto():
     """Test :func:`planemo.training.Training.check_topic_init_tuto`."""
     train = Training(KWDS)
     # no topic
-    exp_exception = "The topic my_new_topic does not exists. It should be created"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="The topic my_new_topic does not exists. It should be created"):
         train.check_topic_init_tuto()
     # add topic
     train.kwds["tutorial_name"] = None
@@ -193,8 +192,9 @@ def test_fill_data_library():
     create_existing_tutorial("existing_tutorial", tuto_wo_zenodo_fp, train.topic)
     # no Zenodo link
     train.kwds["zenodo_link"] = None
-    exp_exception = "A Zenodo link should be provided either in the metadata file or as argument of the command"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(
+        Exception, match="A Zenodo link should be provided either in the metadata file or as argument of the command"
+    ):
         train.fill_data_library(CTX)
     # with a given Zenodo link and no Zenodo in metadata
     train.kwds["zenodo_link"] = zenodo_link
@@ -235,8 +235,10 @@ def test_generate_tuto_from_wf():
     create_existing_tutorial("existing_tutorial", tuto_fp, train.topic)
     # no workflow
     train.kwds["workflow"] = None
-    exp_exception = "A path to a local workflow or the id of a workflow on a running Galaxy instance should be provided"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(
+        Exception,
+        match="A path to a local workflow or the id of a workflow on a running Galaxy instance should be provided",
+    ):
         train.generate_tuto_from_wf(CTX)
     # with workflow
     train.kwds["workflow"] = WF_FP

--- a/tests/test_training_tool_input.py
+++ b/tests/test_training_tool_input.py
@@ -24,24 +24,24 @@ with open(os.path.join(TEST_DATA_DIR, "training_query_tabular.json")) as tool_de
 tool_inp_desc = tool_desc["inputs"]
 
 
-def test_get_input_tool_name():
+def test_get_input_tool_name() -> None:
     """Test :func:`planemo.training.tool_input.get_input_tool_name`."""
     assert "Input dataset" in get_input_tool_name("1", wf_steps)
     assert "output of" in get_input_tool_name("4", wf_steps)
     assert get_input_tool_name("10", wf_steps) == ""
 
 
-def test_get_empty_input():
+def test_get_empty_input() -> None:
     """Test :func:`planemo.training.tool_input.get_empty_input`."""
     assert '{% icon param-file %} *"Input file"*: File' in get_empty_input()
 
 
-def test_get_empty_param():
+def test_get_empty_param() -> None:
     """Test :func:`planemo.training.tool_input.get_empty_param`."""
     assert '*"Parameter"*: `a value`' in get_empty_param()
 
 
-def test_ToolInput_init():
+def test_ToolInput_init() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.init`."""
     # test type exception
     with pytest.raises(Exception, match="No type for the parameter t"):
@@ -86,7 +86,7 @@ def test_ToolInput_init():
     assert tool_input.wf_param_values == "workdb.sqlite"
 
 
-def test_ToolInput_get_formatted_inputs():
+def test_ToolInput_get_formatted_inputs() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_formatted_inputs`."""
     # test no input
     tool_input = ToolInput(
@@ -125,7 +125,7 @@ def test_ToolInput_get_formatted_inputs():
     assert "(Input dataset)" in inputlist
 
 
-def test_ToolInput_get_lower_param_desc():
+def test_ToolInput_get_lower_param_desc() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_lower_param_desc`."""
     tool_input = ToolInput(
         tool_inp_desc=tool_inp_desc[1],
@@ -139,7 +139,7 @@ def test_ToolInput_get_lower_param_desc():
     assert ">        - {% icon param-collection %}" in sub_param_desc
 
 
-def test_ToolInput_get_formatted_section_desc():
+def test_ToolInput_get_formatted_section_desc() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_formatted_section_desc`."""
     tool_input = ToolInput(
         tool_inp_desc=tool_inp_desc[1],
@@ -154,7 +154,7 @@ def test_ToolInput_get_formatted_section_desc():
     assert ">        - {%" in section_paramlist
 
 
-def test_ToolInput_get_formatted_conditional_desc():
+def test_ToolInput_get_formatted_conditional_desc() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_formatted_conditional_desc`."""
     tool_input = ToolInput(
         tool_inp_desc=tool_inp_desc[5],
@@ -170,7 +170,7 @@ def test_ToolInput_get_formatted_conditional_desc():
     assert '>        - *"' in conditional_paramlist
 
 
-def test_ToolInput_get_formatted_repeat_desc():
+def test_ToolInput_get_formatted_repeat_desc() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_formatted_repeat_desc`."""
     tool_input = ToolInput(
         tool_inp_desc=tool_inp_desc[2],
@@ -186,7 +186,7 @@ def test_ToolInput_get_formatted_repeat_desc():
     assert ">            -" in repeat_desc
 
 
-def test_ToolInput_get_formatted_other_param_desc():
+def test_ToolInput_get_formatted_other_param_desc() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_formatted_other_param_desc`."""
     # test default value of the tool
     tool_input = ToolInput(
@@ -232,7 +232,7 @@ def test_ToolInput_get_formatted_other_param_desc():
     assert "*: ``" in tool_input.get_formatted_other_param_desc()
 
 
-def test_ToolInput_get_formatted_desc():
+def test_ToolInput_get_formatted_desc() -> None:
     """Test :func:`planemo.training.tool_input.ToolInput.get_formatted_desc`."""
     # test no param values
     tool_input = ToolInput(

--- a/tests/test_training_tool_input.py
+++ b/tests/test_training_tool_input.py
@@ -2,6 +2,8 @@
 import json
 import os
 
+import pytest
+
 from planemo.training.tool_input import (
     get_empty_input,
     get_empty_param,
@@ -12,10 +14,7 @@ from .test_training import (
     wf,
     wf_param_values,
 )
-from .test_utils import (
-    assert_raises_regexp,
-    TEST_DATA_DIR,
-)
+from .test_utils import TEST_DATA_DIR
 
 wf_steps = wf["steps"]
 # load the output from
@@ -45,8 +44,7 @@ def test_get_empty_param():
 def test_ToolInput_init():
     """Test :func:`planemo.training.tool_input.ToolInput.init`."""
     # test type exception
-    exp_exception = "No type for the parameter t"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="No type for the parameter t"):
         ToolInput(
             tool_inp_desc={"name": "t"},
             wf_param_values=wf_param_values,
@@ -56,8 +54,7 @@ def test_ToolInput_init():
             force_default=False,
         )
     # test with param not in workflow and exception
-    exp_exception = "t not in workflow"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="t not in workflow"):
         ToolInput(
             tool_inp_desc={"name": "t", "type": ""},
             wf_param_values=wf_param_values,

--- a/tests/test_training_tutorial.py
+++ b/tests/test_training_tutorial.py
@@ -4,10 +4,8 @@ import shutil
 
 import pytest
 
-from planemo.engine import (
-    engine_context,
-    is_galaxy_engine,
-)
+from planemo.engine import engine_context
+from planemo.engine.galaxy import LocalManagedGalaxyEngine
 from planemo.training import Training
 from planemo.training.topic import Topic
 from planemo.training.tutorial import (
@@ -38,14 +36,14 @@ topic = Topic()
 training = Training(KWDS)
 
 
-def test_get_galaxy_datatype():
+def test_get_galaxy_datatype() -> None:
     """Test :func:`planemo.training.tutorial.get_galaxy_datatype`."""
     assert get_galaxy_datatype("csv", datatype_fp) == "csv"
     assert get_galaxy_datatype("test", datatype_fp) == "strange_datatype"
     assert "# Please add" in get_galaxy_datatype("unknown", datatype_fp)
 
 
-def test_get_zenodo_record():
+def test_get_zenodo_record() -> None:
     """Test :func:`planemo.training.tutorial.get_zenodo_record`."""
     z_record, req_res = get_zenodo_record(zenodo_link)
     file_link_prefix = "https://zenodo.org/api/files/51a1b5db-ff05-4cda-83d4-3b46682f921f"
@@ -68,7 +66,7 @@ def test_get_zenodo_record():
     assert file_link_prefix in req_res["files"][0]["links"]["self"]
 
 
-def test_get_wf_inputs():
+def test_get_wf_inputs() -> None:
     """Test :func:`planemo.training.tutorial.get_wf_inputs`."""
     step_inp = {
         "tables_1|table": {"output_name": "output", "id": 2},
@@ -93,7 +91,7 @@ def test_get_wf_inputs():
     assert "tt" in step_inputs["add_to_database"]["tab"]["0"]
 
 
-def test_get_wf_param_values():
+def test_get_wf_param_values() -> None:
     """Test :func:`planemo.training.tutorial.get_wf_param_values`."""
     wf_step = wf["steps"]["3"]
     wf_param_value_tests = get_wf_param_values(wf_step["tool_state"], get_wf_inputs(wf_step["input_connections"]))
@@ -103,7 +101,7 @@ def test_get_wf_param_values():
 
 
 @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
-def test_get_hands_on_boxes_from_local_galaxy():
+def test_get_hands_on_boxes_from_local_galaxy() -> None:
     """Test :func:`planemo.training.tutorial.get_hands_on_boxes_from_local_galaxy`."""
     tuto_body = get_hands_on_boxes_from_local_galaxy(KWDS, WF_FP, CTX)
     assert_body_contains(tuto_body, "## Sub-step with **FastQC**")
@@ -112,11 +110,11 @@ def test_get_hands_on_boxes_from_local_galaxy():
 
 
 @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
-def test_get_hands_on_boxes_from_running_galaxy():
+def test_get_hands_on_boxes_from_running_galaxy() -> None:
     """Test :func:`planemo.training.tutorial.get_hands_on_boxes_from_running_galaxy`."""
-    assert is_galaxy_engine(**KWDS)
     galaxy_url = f"http://{KWDS['host']}:{KWDS['port']}"
     with engine_context(CTX, **KWDS) as galaxy_engine:
+        assert isinstance(galaxy_engine, LocalManagedGalaxyEngine)
         with galaxy_engine.ensure_runnables_served([RUNNABLE]) as config:
             wf_id = config.workflow_id(WF_FP)
             tuto_body = get_hands_on_boxes_from_running_galaxy(wf_id, galaxy_url, config.user_api_key)
@@ -126,7 +124,7 @@ def test_get_hands_on_boxes_from_running_galaxy():
     assert_body_contains(tuto_body, "## Sub-step with **Select first**")
 
 
-def test_tutorial_init():
+def test_tutorial_init() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.init`."""
     # with default parameter
     tuto = Tutorial(training=training, topic=topic)
@@ -149,7 +147,7 @@ def test_tutorial_init():
     assert "my_tuto" in tuto.dir
 
 
-def test_tutorial_init_from_kwds():
+def test_tutorial_init_from_kwds() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.init_from_kwds`."""
     kwds = {
         "tutorial_name": "my_tuto",
@@ -175,7 +173,7 @@ def test_tutorial_init_from_kwds():
     assert "my_tuto" in tuto.dir
 
 
-def test_tutorial_init_from_existing_tutorial():
+def test_tutorial_init_from_existing_tutorial() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.init_from_existing_tutorial`."""
     tuto = Tutorial(training=training, topic=topic)
     # non existing tutorial
@@ -192,7 +190,7 @@ def test_tutorial_init_from_existing_tutorial():
     shutil.rmtree("topics")
 
 
-def test_tutorial_init_data_lib():
+def test_tutorial_init_data_lib() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.init_data_lib`."""
     tuto = Tutorial(training=training, topic=topic)
     tuto.init_data_lib()
@@ -214,7 +212,7 @@ def test_tutorial_init_data_lib():
     shutil.rmtree("topics")
 
 
-def test_tutorial_get_tuto_metata():
+def test_tutorial_get_tuto_metata() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.get_tuto_metata`."""
     tuto = Tutorial(training=training, topic=topic)
     tuto.questions = ["q1", "q2"]
@@ -223,7 +221,7 @@ def test_tutorial_get_tuto_metata():
     assert "- q1" in metadata
 
 
-def test_tutorial_set_dir_name():
+def test_tutorial_set_dir_name() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.set_dir_name`."""
     tuto = Tutorial(training=training, topic=topic)
     tuto.name = "the_tuto"
@@ -236,7 +234,7 @@ def test_tutorial_set_dir_name():
     assert tuto.name in tuto.wf_fp
 
 
-def test_tutorial_exists():
+def test_tutorial_exists() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.exists`."""
     # default
     tuto = Tutorial(training=training, topic=topic)
@@ -247,7 +245,7 @@ def test_tutorial_exists():
     shutil.rmtree("topics")
 
 
-def test_tutorial_has_workflow():
+def test_tutorial_has_workflow() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.has_workflow`."""
     # default
     tuto = Tutorial(training=training, topic=topic)
@@ -265,7 +263,7 @@ def test_tutorial_has_workflow():
 
 
 @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
-def test_tutorial_export_workflow_file():
+def test_tutorial_export_workflow_file() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.export_workflow_file`."""
     tuto = Tutorial(training=training, topic=topic)
     os.makedirs(tuto.wf_dir)
@@ -276,9 +274,9 @@ def test_tutorial_export_workflow_file():
     # with workflow id
     tuto.init_wf_fp = None
     os.remove(tuto.wf_fp)
-    assert is_galaxy_engine(**KWDS)
     galaxy_url = f"http://{KWDS['host']}:{KWDS['port']}"
     with engine_context(CTX, **KWDS) as galaxy_engine:
+        assert isinstance(galaxy_engine, LocalManagedGalaxyEngine)
         with galaxy_engine.ensure_runnables_served([RUNNABLE]) as config:
             tuto.init_wf_id = config.workflow_id(WF_FP)
             tuto.training.galaxy_url = galaxy_url
@@ -288,7 +286,7 @@ def test_tutorial_export_workflow_file():
     shutil.rmtree("topics")
 
 
-def test_tutorial_get_files_from_zenodo():
+def test_tutorial_get_files_from_zenodo() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.get_files_from_zenodo`."""
     tuto = Tutorial(training=training, topic=topic, zenodo_link=zenodo_link)
     tuto.datatype_fp = datatype_fp
@@ -305,7 +303,7 @@ def test_tutorial_get_files_from_zenodo():
     assert files[1]["ext"] == "csv"
 
 
-def test_tutorial_prepare_data_library_from_zenodo():
+def test_tutorial_prepare_data_library_from_zenodo() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.prepare_data_library_from_zenodo`."""
     # without zenodo link
     tuto = Tutorial(training=training, topic=topic)
@@ -323,7 +321,7 @@ def test_tutorial_prepare_data_library_from_zenodo():
     shutil.rmtree("topics")
 
 
-def test_tutorial_write_hands_on_tutorial():
+def test_tutorial_write_hands_on_tutorial() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.write_hands_on_tutorial`."""
     tuto = Tutorial(training=training, topic=topic)
     os.makedirs(tuto.wf_dir)
@@ -340,7 +338,7 @@ def test_tutorial_write_hands_on_tutorial():
 
 
 @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
-def test_tutorial_create_hands_on_tutorial():
+def test_tutorial_create_hands_on_tutorial() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.create_hands_on_tutorial`."""
     tuto = Tutorial(training=training, topic=topic)
     os.makedirs(tuto.wf_dir)
@@ -356,8 +354,8 @@ def test_tutorial_create_hands_on_tutorial():
     with pytest.raises(Exception, match="No API key to access the given Galaxy instance"):
         tuto.create_hands_on_tutorial(CTX)
     # with init_wf_id
-    assert is_galaxy_engine(**KWDS)
     with engine_context(CTX, **KWDS) as galaxy_engine:
+        assert isinstance(galaxy_engine, LocalManagedGalaxyEngine)
         with galaxy_engine.ensure_runnables_served([RUNNABLE]) as config:
             tuto.init_wf_id = config.workflow_id(WF_FP)
             tuto.training.galaxy_api_key = config.user_api_key
@@ -373,7 +371,7 @@ def test_tutorial_create_hands_on_tutorial():
 
 
 @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
-def test_tutorial_create_tutorial():
+def test_tutorial_create_tutorial() -> None:
     """Test :func:`planemo.training.tutorial.tutorial.create_tutorial`."""
     tuto = Tutorial(training=training, topic=topic)
     tuto.init_from_kwds(
@@ -400,7 +398,7 @@ def test_tutorial_create_tutorial():
     shutil.rmtree("topics")
 
 
-def assert_body_contains(body, contents):
+def assert_body_contains(body: str, contents: str) -> None:
     if contents not in body:
         message = f"Expected to find contents [{contents}] in body [{body}]"
         raise AssertionError(message)

--- a/tests/test_training_tutorial.py
+++ b/tests/test_training_tutorial.py
@@ -2,6 +2,8 @@
 import os
 import shutil
 
+import pytest
+
 from planemo.engine import (
     engine_context,
     is_galaxy_engine,
@@ -30,10 +32,7 @@ from .test_training import (
     wf_param_values,
     zenodo_link,
 )
-from .test_utils import (
-    assert_raises_regexp,
-    skip_if_environ,
-)
+from .test_utils import skip_if_environ
 
 topic = Topic()
 training = Training(KWDS)
@@ -180,8 +179,7 @@ def test_tutorial_init_from_existing_tutorial():
     """Test :func:`planemo.training.tutorial.tutorial.init_from_existing_tutorial`."""
     tuto = Tutorial(training=training, topic=topic)
     # non existing tutorial
-    exp_exception = "The tutorial existing_tutorial does not exists. It should be created"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="The tutorial existing_tutorial does not exists. It should be created"):
         tuto.init_from_existing_tutorial("existing_tutorial")
     # existing tutorial
     create_existing_tutorial("existing_tutorial", tuto_fp, tuto.topic)
@@ -349,15 +347,13 @@ def test_tutorial_create_hands_on_tutorial():
     # with init_wf_id and no Galaxy URL
     tuto.init_wf_id = "ID"
     tuto.training.galaxy_url = None
-    exp_exception = "No Galaxy URL given"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="No Galaxy URL given"):
         tuto.create_hands_on_tutorial(CTX)
     # with init_wf_id and no Galaxy API key
     tuto.init_wf_id = "ID"
     tuto.training.galaxy_url = f"http://{KWDS['host']}:{KWDS['port']}"
     tuto.training.galaxy_api_key = None
-    exp_exception = "No API key to access the given Galaxy instance"
-    with assert_raises_regexp(Exception, exp_exception):
+    with pytest.raises(Exception, match="No API key to access the given Galaxy instance"):
         tuto.create_hands_on_tutorial(CTX)
     # with init_wf_id
     assert is_galaxy_engine(**KWDS)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@
 import contextlib
 import functools
 import os
-import re
 import shutil
 import signal
 import traceback
@@ -23,7 +22,6 @@ from unittest import (
 )
 
 import psutil
-import py.code
 import pytest
 from click.testing import CliRunner
 from galaxy.util import (
@@ -405,39 +403,6 @@ def _wait_on_future_suppress_exception(future):
         future.result(timeout=30)
     except Exception as e:
         print(f"Problem waiting on future {e}")
-
-
-# From pytest-raisesregexp
-class assert_raises_regexp:
-    def __init__(self, expected_exception, regexp, *args, **kwargs):
-        __tracebackhide__ = True
-        self.exception = expected_exception
-        self.regexp = regexp
-        self.excinfo = None
-
-        if args:
-            with self:
-                args[0](*args[1:], **kwargs)
-
-    def __enter__(self):
-        self.excinfo = object.__new__(py.code.ExceptionInfo)
-        return self.excinfo
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        __tracebackhide__ = True
-
-        if exc_type is None:
-            pytest.fail(f"DID NOT RAISE {self.exception}")
-
-        self.excinfo.__init__((exc_type, exc_val, exc_tb))
-
-        if not issubclass(exc_type, self.exception):
-            pytest.fail(f"{exc_type} RAISED instead of {self.exception}\n{exc_val!r}")
-
-        if not re.search(self.regexp, str(exc_val)):
-            pytest.fail(f'Pattern "{self.regexp}" not found in "{exc_val!s}"')
-
-        return True
 
 
 def safe_rmtree(path):

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     lint_docs: make lint-docs
     lint_docstrings: flake8 --ignore='D107,D401,D105' {[tox]source_dir}
     unit: pytest {env:PYTEST_FAIL_FAIL:} {env:PYTEST_CAPTURE:} -m {env:PYTEST_MARK:""} {env:PYTEST_TARGET:{[tox]test_dir}} {posargs}
-    mypy: mypy --install-types --non-interactive {[tox]source_dir} {posargs}
+    mypy: mypy --install-types --non-interactive {[tox]source_dir} tests/ {posargs}
     gxwf_test_test: make setup-venv gxwf-test-test
 
 passenv = 


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'py.code'; 'py' is not a package` when importing from `tests/test_utils.py` .

Also add type annotations to training material tests.