### PR TITLE
Restore running tool tests against directory

### DIFF
--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -35,6 +35,7 @@ class GalaxyEngine(BaseEngine, metaclass=abc.ABCMeta):
         RunnableType.galaxy_workflow,
         RunnableType.galaxy_tool,
         RunnableType.galaxy_datamanager,
+        RunnableType.directory,
     ]
 
     def _run(self, runnables, job_paths):

--- a/planemo/tools.py
+++ b/planemo/tools.py
@@ -7,6 +7,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Optional,
     Tuple,
     TYPE_CHECKING,
     Union,
@@ -47,7 +48,7 @@ def uris_to_paths(ctx, uris):
 
 
 def yield_tool_sources_on_paths(
-    ctx: "PlanemoCliContext",
+    ctx: Optional["PlanemoCliContext"],
     paths: Iterable[str],
     recursive: bool = False,
     yield_load_errors: bool = True,
@@ -62,7 +63,7 @@ def yield_tool_sources_on_paths(
 
 
 def yield_tool_sources(
-    ctx: "PlanemoCliContext", path: str, recursive: bool = False, yield_load_errors: bool = True
+    ctx: Optional["PlanemoCliContext"], path: str, recursive: bool = False, yield_load_errors: bool = True
 ) -> Iterator[Tuple[str, Union[ToolSource, object]]]:
     """Walk single path and yield ToolSource objects discovered."""
     tools = load_tool_sources_from_path(
@@ -100,13 +101,13 @@ def _load_exception_handler(path, exc_info):
     traceback.print_exception(*exc_info, limit=1, file=sys.stderr)
 
 
-def _is_tool_source(ctx: "PlanemoCliContext", tool_path: str, tool_source: "ToolSource") -> bool:
+def _is_tool_source(ctx: Optional["PlanemoCliContext"], tool_path: str, tool_source: "ToolSource") -> bool:
     if os.path.basename(tool_path) in SHED_FILES:
         return False
     root = getattr(tool_source, "root", None)
     if root is not None:
         if root.tag != "tool":
-            if ctx.verbose:
+            if ctx and ctx.verbose:
                 info(SKIP_XML_MESSAGE % tool_path)
             return False
     return True

--- a/tests/data/tools/ok_test_assert_command.xml
+++ b/tests/data/tools/ok_test_assert_command.xml
@@ -1,7 +1,7 @@
 <tool id="copy" name="Copy Dataset" version="1.0">
     <description>copies a dataset</description>
     <command>
-        cp $input $output
+        cp '$input1' '$output'
     </command>
     <inputs>
         <param name="input1" type="data" format="txt" label="Concatenate Dataset"/>

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -1,7 +1,11 @@
 """Module contains :class:`CmdTestTestCase` - integration tests for the ``test`` command."""
 import json
 import os
-from tempfile import NamedTemporaryFile
+import shutil
+from tempfile import (
+    mkdtemp,
+    NamedTemporaryFile,
+)
 
 from .test_utils import (
     assert_exists,
@@ -29,6 +33,16 @@ class CmdTestTestCase(CliTestCase):
                 "--galaxy_startup_timeout", "1", test_artifact, "--no_dependency_resolution"
             )
             self._check_exit_code(test_command, exit_code=1)
+
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    def test_tool_in_directory(self):
+        """Test with (single) tool in directory."""
+        with self._isolate():
+            test_artifact = os.path.join(TEST_DATA_DIR, "tools", "ok_test_assert_command.xml")
+            tempdir = mkdtemp()
+            shutil.copy(test_artifact, tempdir)
+            test_command = self._test_command(tempdir, "--no_dependency_resolution")
+            self._check_exit_code(test_command, exit_code=0)
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     def test_data_manager(self):

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -3,8 +3,8 @@ import json
 import os
 import shutil
 from tempfile import (
-    mkdtemp,
     NamedTemporaryFile,
+    TemporaryDirectory,
 )
 
 from .test_utils import (
@@ -37,9 +37,8 @@ class CmdTestTestCase(CliTestCase):
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     def test_tool_in_directory(self):
         """Test with (single) tool in directory."""
-        with self._isolate():
+        with self._isolate(), TemporaryDirectory() as tempdir:
             test_artifact = os.path.join(TEST_DATA_DIR, "tools", "ok_test_assert_command.xml")
-            tempdir = mkdtemp()
             shutil.copy(test_artifact, tempdir)
             test_command = self._test_command(tempdir, "--no_dependency_resolution")
             self._check_exit_code(test_command, exit_code=0)


### PR DESCRIPTION
This was handled by the old tool testing framework in Galaxy previously. We should prioritize switching to embedded pulsar, so we don't need to copy tool sources around ... .