### PR TITLE
Add planemo_ci_setup command

### DIFF
--- a/planemo/commands/cmd_ci_setup.py
+++ b/planemo/commands/cmd_ci_setup.py
@@ -1,0 +1,20 @@
+"""Module describing the planemo ``ci_setup`` command."""
+import click
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy.serve import serve_daemon
+
+
+@click.command("ci_setup")
+@options.galaxy_target_options()
+@command_function
+def cli(ctx, **kwds):
+    """
+    Launch Galaxy instance, then terminate instance.
+
+    Useful for populating a CI cache.
+    """
+    kwds["galaxy_skip_client_build"] = True
+    with serve_daemon(ctx, **kwds):
+        return


### PR DESCRIPTION
To replace https://github.com/galaxyproject/planemo-ci-action/blob/main/planemo_ci_actions.sh#L16-L18, which will now in addition require a valid tool (a good thing IMO)