### PR TITLE
Drop copy_tree workaround for tool sources

### DIFF
--- a/planemo/commands/cmd_autoupdate.py
+++ b/planemo/commands/cmd_autoupdate.py
@@ -25,7 +25,6 @@ from planemo.io import (
     coalesce_return_codes,
     error,
     info,
-    temp_directory,
 )
 from planemo.runnable import (
     for_paths,
@@ -162,18 +161,14 @@ def cli(ctx, paths, **kwds):  # noqa C901
         if not modified_files and not modified_workflows:
             info("No tools or workflows were updated, so no tests were run.")
         else:
-            with temp_directory(dir=ctx.planemo_directory) as temp_path:
-                # only test tools in updated directories
-                modified_paths = [
-                    path
-                    for path, tool_xml in yield_tool_sources_on_paths(ctx, paths, recursive)
-                    if path in modified_files
-                ]
-                info(f"Running tests for the following auto-updated tools: {', '.join(modified_paths)}")
-                runnables = for_paths(modified_paths + modified_workflows, temp_path=temp_path)
-                kwds["engine"] = "galaxy"
-                return_value = test_runnables(ctx, runnables, original_paths=paths, **kwds)
-                exit_codes.append(return_value)
+            modified_paths = [
+                path for path, tool_xml in yield_tool_sources_on_paths(ctx, paths, recursive) if path in modified_files
+            ]
+            info(f"Running tests for the following auto-updated tools: {', '.join(modified_paths)}")
+            runnables = for_paths(modified_paths + modified_workflows)
+            kwds["engine"] = "galaxy"
+            return_value = test_runnables(ctx, runnables, original_paths=paths, **kwds)
+            exit_codes.append(return_value)
     return coalesce_return_codes(exit_codes, assert_at_least_one=assert_tools)
 
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -19,6 +19,8 @@ from tempfile import (
 from typing import (
     List,
     Optional,
+    Set,
+    TYPE_CHECKING,
 )
 
 from galaxy.containers.docker_model import DockerVolume
@@ -56,6 +58,9 @@ from .workflows import (
     import_workflow,
     install_shed_repos,
 )
+
+if TYPE_CHECKING:
+    from planemo.runnable import Runnable
 
 NO_TEST_DATA_MESSAGE = (
     "planemo couldn't find a target test-data directory, you should likely "
@@ -504,7 +509,7 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
         )
 
 
-def _expand_paths(galaxy_root, extra_tools):
+def _expand_paths(galaxy_root: Optional[str], extra_tools: List[str]) -> List[str]:
     """Replace $GALAXY_FUNCTION_TEST_TOOLS with actual path."""
     if galaxy_root:
         extra_tools = [
@@ -532,11 +537,13 @@ def get_refgenie_config(galaxy_root, refgenie_dir):
     return REFGENIE_CONFIG_TEMPLATE % (config_version, refgenie_dir)
 
 
-def _all_tool_paths(runnables, galaxy_root=None, extra_tools=None):
+def _all_tool_paths(
+    runnables: List["Runnable"], galaxy_root: Optional[str] = None, extra_tools: Optional[List[str]] = None
+) -> Set[str]:
     extra_tools = extra_tools or []
-    all_tool_paths = [r.path for r in runnables if r.has_tools and not r.data_manager_conf_path]
+    all_tool_paths = set(r.path for r in runnables if r.has_tools and not r.data_manager_conf_path)
     extra_tools = _expand_paths(galaxy_root, extra_tools=extra_tools)
-    all_tool_paths.extend(extra_tools)
+    all_tool_paths.update(extra_tools)
     for runnable in runnables:
         if runnable.type.name == "galaxy_workflow":
             tool_ids = find_tool_ids(runnable.path)
@@ -545,9 +552,9 @@ def _all_tool_paths(runnables, galaxy_root=None, extra_tools=None):
                 if tool_paths:
                     if isinstance(tool_paths, str):
                         tool_paths = [tool_paths]
-                    all_tool_paths.extend(tool_paths)
+                    all_tool_paths.update(tool_paths)
 
-    return set(all_tool_paths)
+    return all_tool_paths
 
 
 def _shared_galaxy_properties(config_directory, kwds, for_tests):

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1312,7 +1312,7 @@ def _handle_job_config_file(config_directory, server_name, kwds):
 
 
 def _write_tool_conf(ctx, tool_paths, tool_conf_path):
-    tool_definition = _tool_conf_entry_for(tool_paths)
+    tool_definition = _tool_conf_entry_for(set(tool_paths))
     tool_conf_template_kwds = dict(tool_definition=tool_definition)
     tool_conf_contents = _sub(TOOL_CONF_TEMPLATE, tool_conf_template_kwds)
     write_file(tool_conf_path, tool_conf_contents)

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -541,7 +541,7 @@ def _all_tool_paths(
     runnables: List["Runnable"], galaxy_root: Optional[str] = None, extra_tools: Optional[List[str]] = None
 ) -> Set[str]:
     extra_tools = extra_tools or []
-    all_tool_paths = set(r.path for r in runnables if r.has_tools and not r.data_manager_conf_path)
+    all_tool_paths = {r.path for r in runnables if r.has_tools and not r.data_manager_conf_path}
     extra_tools = _expand_paths(galaxy_root, extra_tools=extra_tools)
     all_tool_paths.update(extra_tools)
     for runnable in runnables:

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -547,7 +547,7 @@ def _all_tool_paths(runnables, galaxy_root=None, extra_tools=None):
                         tool_paths = [tool_paths]
                     all_tool_paths.extend(tool_paths)
 
-    return all_tool_paths
+    return set(all_tool_paths)
 
 
 def _shared_galaxy_properties(config_directory, kwds, for_tests):
@@ -1312,7 +1312,7 @@ def _handle_job_config_file(config_directory, server_name, kwds):
 
 
 def _write_tool_conf(ctx, tool_paths, tool_conf_path):
-    tool_definition = _tool_conf_entry_for(set(tool_paths))
+    tool_definition = _tool_conf_entry_for(tool_paths)
     tool_conf_template_kwds = dict(tool_definition=tool_definition)
     tool_conf_contents = _sub(TOOL_CONF_TEMPLATE, tool_conf_template_kwds)
     write_file(tool_conf_path, tool_conf_contents)

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -194,11 +194,9 @@ def workflow_dir_runnables(path: str, return_all: bool = False) -> Optional[Unio
     return None
 
 
-def tool_dir_runnables(path: str) -> Optional[List[Runnable]]:
+def tool_dir_runnables(path: str) -> List[Runnable]:
     tool_sources = [p for p in yield_tool_sources_on_paths(ctx=None, paths=[path])]
-    if tool_sources:
-        return [for_path(p) for (p, _) in tool_sources]
-    return None
+    return [for_path(p) for (p, _) in tool_sources]
 
 
 @overload

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -195,8 +195,7 @@ def workflow_dir_runnables(path: str, return_all: bool = False) -> Optional[Unio
 
 
 def tool_dir_runnables(path: str) -> List[Runnable]:
-    tool_sources = [p for p in yield_tool_sources_on_paths(ctx=None, paths=[path])]
-    return [for_path(p) for (p, _) in tool_sources]
+    return [for_path(p) for (p, _) in yield_tool_sources_on_paths(ctx=None, paths=[path])]
 
 
 @overload

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -197,7 +197,6 @@ def workflow_dir_runnables(path: str, return_all: bool = False) -> Optional[Unio
 def tool_dir_runnables(path: str) -> Optional[List[Runnable]]:
     tool_sources = [p for p in yield_tool_sources_on_paths(ctx=None, paths=[path])]
     if tool_sources:
-        tool_sources = [p for p in yield_tool_sources_on_paths(ctx=None, paths=[path])]
         return [for_path(p) for (p, _) in tool_sources]
     return None
 

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -3,7 +3,6 @@
 
 import abc
 import os
-from distutils.dir_util import copy_tree
 from enum import (
     auto,
     Enum,
@@ -169,23 +168,6 @@ def _runnable_delegate_attribute(attribute: str) -> property:
     return property(getter)
 
 
-def _copy_runnable_tree(path: str, runnable_type: RunnableType, temp_path: str) -> str:
-    dir_to_copy = None
-    if runnable_type in {RunnableType.galaxy_tool, RunnableType.cwl_tool}:
-        dir_to_copy = os.path.dirname(path)
-        path = os.path.join(temp_path, os.path.basename(path))
-    elif runnable_type == RunnableType.directory:
-        dir_to_copy = path
-        path = temp_path
-    elif runnable_type == RunnableType.galaxy_datamanager:
-        dir_to_copy = os.path.join(os.path.dirname(path), os.pardir)
-        path_to_data_manager_tool = os.path.relpath(path, dir_to_copy)
-        path = os.path.join(temp_path, path_to_data_manager_tool)
-    if dir_to_copy:
-        copy_tree(dir_to_copy, temp_path, update=True)
-    return path
-
-
 def workflows_from_dockstore_yaml(path):
     workflows = []
     parent_dir = Path(path).absolute().parent
@@ -212,31 +194,29 @@ def workflow_dir_runnables(path: str, return_all: bool = False) -> Optional[Unio
     return None
 
 
-def tool_dir_runnables(path: str, temp_path: Optional[str]) -> Optional[List[Runnable]]:
+def tool_dir_runnables(path: str) -> Optional[List[Runnable]]:
     tool_sources = [p for p in yield_tool_sources_on_paths(ctx=None, paths=[path])]
     if tool_sources:
-        if temp_path:
-            path = _copy_runnable_tree(path, RunnableType.directory, temp_path)
         tool_sources = [p for p in yield_tool_sources_on_paths(ctx=None, paths=[path])]
         return [for_path(p) for (p, _) in tool_sources]
     return None
 
 
 @overload
-def for_path(path: str, temp_path: Optional[str] = None, return_all: Literal[False] = False) -> Runnable:
+def for_path(path: str, return_all: Literal[False] = False) -> Runnable:
     ...
 
 
 @overload
-def for_path(path: str, temp_path: Optional[str] = None, return_all: bool = False) -> Union[Runnable, List[Runnable]]:
+def for_path(path: str, return_all: bool = False) -> Union[Runnable, List[Runnable]]:
     pass
 
 
-def for_path(path: str, temp_path: Optional[str] = None, return_all: bool = False) -> Union[Runnable, List[Runnable]]:
+def for_path(path: str, return_all: bool = False) -> Union[Runnable, List[Runnable]]:
     """Produce a class:`Runnable` for supplied path."""
     runnable_type = None
     if os.path.isdir(path):
-        runnable = workflow_dir_runnables(path, return_all=return_all) or tool_dir_runnables(path, temp_path)
+        runnable = workflow_dir_runnables(path, return_all=return_all) or tool_dir_runnables(path)
         if runnable:
             return runnable
         runnable_type = RunnableType.directory
@@ -266,15 +246,12 @@ def for_path(path: str, temp_path: Optional[str] = None, return_all: bool = Fals
         error(f"Unable to determine runnable type for path [{path}]")
         raise ExitCodeException(EXIT_CODE_UNKNOWN_FILE_TYPE)
 
-    if temp_path:
-        path = _copy_runnable_tree(path, runnable_type, temp_path)
-
     return Runnable(path, runnable_type)
 
 
-def for_paths(paths: Iterable[str], temp_path: Optional[str] = None) -> List[Runnable]:
+def for_paths(paths: Iterable[str]) -> List[Runnable]:
     """Return a specialized list of Runnable objects for paths."""
-    return [for_path(path, temp_path=temp_path) for path in paths]
+    return [for_path(path) for path in paths]
 
 
 def for_uri(uri: str) -> Runnable:

--- a/planemo/runnable_resolve.py
+++ b/planemo/runnable_resolve.py
@@ -12,7 +12,7 @@ from .runnable import (
 )
 
 
-def for_runnable_identifier(ctx, runnable_identifier, kwds, temp_path=None, return_all=False):
+def for_runnable_identifier(ctx, runnable_identifier, kwds, return_all=False):
     """Convert URI, path, or alias into Runnable."""
     # could be a URI, path, or alias
     current_profile = kwds.get("profile")
@@ -20,7 +20,7 @@ def for_runnable_identifier(ctx, runnable_identifier, kwds, temp_path=None, retu
     if not runnable_identifier.startswith(GALAXY_WORKFLOWS_PREFIX):
         runnable_identifier = uri_to_path(ctx, runnable_identifier)
     if os.path.exists(runnable_identifier):
-        runnable = for_path(runnable_identifier, temp_path=temp_path, return_all=return_all)
+        runnable = for_path(runnable_identifier, return_all=return_all)
     else:  # assume galaxy workflow or tool id
         if "/repos/" in runnable_identifier:
             runnable_identifier = f"{GALAXY_TOOLS_PREFIX}{runnable_identifier}"
@@ -30,11 +30,11 @@ def for_runnable_identifier(ctx, runnable_identifier, kwds, temp_path=None, retu
     return runnable
 
 
-def for_runnable_identifiers(ctx, runnable_identifiers, kwds, temp_path=None):
+def for_runnable_identifiers(ctx, runnable_identifiers, kwds):
     """Convert lists of URIs, paths, and/or aliases into Runnables."""
     runnables = []
     for r in runnable_identifiers:
-        runnable = for_runnable_identifier(ctx, r, kwds, temp_path=temp_path, return_all=True)
+        runnable = for_runnable_identifier(ctx, r, kwds, return_all=True)
         if isinstance(runnable, list):
             runnables.extend(runnable)
         else:


### PR DESCRIPTION
It comes with a whole bunch of disadvantages and complexitites, and we can also just dereference symlinks in planemo-ci-action.