### PR TITLE
Fix ``for_paths`` when path is directory of tools

### DIFF
--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -189,7 +189,14 @@ def workflow_dir_runnables(path: str) -> List[Runnable]:
 
 
 def tool_dir_runnables(path: str) -> List[Runnable]:
-    return [for_path(p) for (p, _) in yield_tool_sources_on_paths(ctx=None, paths=[path])]
+    runnables = []
+    for tool_path, _ in yield_tool_sources_on_paths(ctx=None, paths=[path]):
+        runnable = for_path(tool_path)
+        if isinstance(runnable, list):
+            runnables.extend(runnable)
+        else:
+            runnables.append(runnable)
+    return runnables
 
 
 def for_path(path: str) -> Union[Runnable, List[Runnable]]:

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -247,7 +247,14 @@ def for_path(path: str, return_all: bool = False) -> Union[Runnable, List[Runnab
 
 def for_paths(paths: Iterable[str]) -> List[Runnable]:
     """Return a specialized list of Runnable objects for paths."""
-    return [for_path(path) for path in paths]
+    runnables = []
+    for path in paths:
+        runnables_for_path = for_path(path)
+        if isinstance(runnables_for_path, list):
+            runnables.extend(runnables_for_path)
+        else:
+            runnables.append(runnables_for_path)
+    return runnables
 
 
 def for_uri(uri: str) -> Runnable:

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -15,7 +15,6 @@ from typing import (
     List,
     NamedTuple,
     Optional,
-    overload,
     Union,
 )
 from urllib.parse import urlparse
@@ -31,7 +30,6 @@ from galaxy.tool_util.loader_directory import (
     looks_like_a_tool_xml,
 )
 from galaxy.tool_util.parser import get_tool_source
-from typing_extensions import Literal
 
 from planemo.exit_codes import (
     EXIT_CODE_UNKNOWN_FILE_TYPE,
@@ -181,16 +179,13 @@ def workflows_from_dockstore_yaml(path):
     return workflows
 
 
-def workflow_dir_runnables(path: str, return_all: bool = False) -> Optional[Union[Runnable, List[Runnable]]]:
+def workflow_dir_runnables(path: str) -> Optional[List[Runnable]]:
     dockstore_path = os.path.join(path, DOCKSTORE_REGISTRY_CONF)
     if os.path.exists(dockstore_path):
         runnables = [
             Runnable(str(path), RunnableType.galaxy_workflow) for path in workflows_from_dockstore_yaml(dockstore_path)
         ]
-        if return_all:
-            return runnables
-        else:
-            return runnables[0]
+        return runnables
     return None
 
 
@@ -198,21 +193,11 @@ def tool_dir_runnables(path: str) -> List[Runnable]:
     return [for_path(p) for (p, _) in yield_tool_sources_on_paths(ctx=None, paths=[path])]
 
 
-@overload
-def for_path(path: str, return_all: Literal[False] = False) -> Runnable:
-    ...
-
-
-@overload
-def for_path(path: str, return_all: bool = False) -> Union[Runnable, List[Runnable]]:
-    pass
-
-
-def for_path(path: str, return_all: bool = False) -> Union[Runnable, List[Runnable]]:
+def for_path(path: str) -> Union[Runnable, List[Runnable]]:
     """Produce a class:`Runnable` for supplied path."""
     runnable_type = None
     if os.path.isdir(path):
-        runnable = workflow_dir_runnables(path, return_all=return_all) or tool_dir_runnables(path)
+        runnable = workflow_dir_runnables(path) or tool_dir_runnables(path)
         if runnable:
             return runnable
         runnable_type = RunnableType.directory

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -189,14 +189,7 @@ def workflow_dir_runnables(path: str) -> List[Runnable]:
 
 
 def tool_dir_runnables(path: str) -> List[Runnable]:
-    runnables = []
-    for tool_path, _ in yield_tool_sources_on_paths(ctx=None, paths=[path]):
-        runnable = for_path(tool_path)
-        if isinstance(runnable, list):
-            runnables.extend(runnable)
-        else:
-            runnables.append(runnable)
-    return runnables
+    return for_paths(tool_path for tool_path, _ in yield_tool_sources_on_paths(ctx=None, paths=[path]))
 
 
 def for_path(path: str) -> Union[Runnable, List[Runnable]]:

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -179,14 +179,13 @@ def workflows_from_dockstore_yaml(path):
     return workflows
 
 
-def workflow_dir_runnables(path: str) -> Optional[List[Runnable]]:
+def workflow_dir_runnables(path: str) -> List[Runnable]:
     dockstore_path = os.path.join(path, DOCKSTORE_REGISTRY_CONF)
     if os.path.exists(dockstore_path):
-        runnables = [
+        return [
             Runnable(str(path), RunnableType.galaxy_workflow) for path in workflows_from_dockstore_yaml(dockstore_path)
         ]
-        return runnables
-    return None
+    return []
 
 
 def tool_dir_runnables(path: str) -> List[Runnable]:

--- a/planemo/runnable_resolve.py
+++ b/planemo/runnable_resolve.py
@@ -12,7 +12,7 @@ from .runnable import (
 )
 
 
-def for_runnable_identifier(ctx, runnable_identifier, kwds, return_all=False):
+def for_runnable_identifier(ctx, runnable_identifier, kwds):
     """Convert URI, path, or alias into Runnable."""
     # could be a URI, path, or alias
     current_profile = kwds.get("profile")
@@ -20,7 +20,7 @@ def for_runnable_identifier(ctx, runnable_identifier, kwds, return_all=False):
     if not runnable_identifier.startswith(GALAXY_WORKFLOWS_PREFIX):
         runnable_identifier = uri_to_path(ctx, runnable_identifier)
     if os.path.exists(runnable_identifier):
-        runnable = for_path(runnable_identifier, return_all=return_all)
+        runnable = for_path(runnable_identifier)
     else:  # assume galaxy workflow or tool id
         if "/repos/" in runnable_identifier:
             runnable_identifier = f"{GALAXY_TOOLS_PREFIX}{runnable_identifier}"
@@ -34,7 +34,7 @@ def for_runnable_identifiers(ctx, runnable_identifiers, kwds):
     """Convert lists of URIs, paths, and/or aliases into Runnables."""
     runnables = []
     for r in runnable_identifiers:
-        runnable = for_runnable_identifier(ctx, r, kwds, return_all=True)
+        runnable = for_runnable_identifier(ctx, r, kwds)
         if isinstance(runnable, list):
             runnables.extend(runnable)
         else:

--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -119,7 +119,7 @@ def _lint_workflow_artifacts_on_path(
 
 # misspell for pytest
 def _lint_tsts(path: str, lint_context: WorkflowLintContext) -> None:
-    runnables = for_path(path, return_all=True)
+    runnables = for_path(path)
     if not isinstance(runnables, list):
         runnables = [runnables]
     for runnable in runnables:


### PR DESCRIPTION
We'd previously return the directory type runnable, but with 0.75.1 we're expanding the directory into a list of workflow or tool runnables.
This makes it match the return type annotation.

Fixes https://github.com/galaxyproject/planemo/issues/1311