### PR TITLE
Compare versions, not tool ids to find latest tool ids

### DIFF
--- a/tests/test_autoupdate.py
+++ b/tests/test_autoupdate.py
@@ -1,0 +1,9 @@
+from planemo.autoupdate import get_newest_tool_id
+
+
+def test_get_newest_tool_id():
+    tool_ids = [
+        "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.7.8a+galaxy0",
+        "toolshed.g2.bx.psu.edu/repos/iuc/rgrnastar/rna_star/2.7.8a",
+    ]
+    assert get_newest_tool_id(tool_ids) == tool_ids[0]


### PR DESCRIPTION
Fixes upgrades that are actually downgrades, like https://github.com/galaxyproject/iwc/pull/148