### PR TITLE
fix lint_tool_id for tools that are in toolshed but not found by tools_id

### DIFF
--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -416,7 +416,10 @@ def find_potential_workflow_files(directory: str) -> List[str]:
 
 def find_repos_from_tool_id(tool_id: str, ts: ToolShedInstance) -> Tuple[str, Dict[str, Any]]:
     """
-    Return a string which indicates what failed and dict with all revisions for a given tool id
+    Return a string which indicates what failed
+        if the string is empty: either the tool_id does not pretend to be in the MAIN_TOOLSHED or it is installable
+        if the string is not empty: the tool_id was not found installable in the MAIN_TOOLSHED while it was supposed to be
+    and dict with all revisions for a given tool id
     """
     if not tool_id.startswith(MAIN_TOOLSHED_URL[8:]):
         return ("", {})  # assume a built in tool

--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -427,28 +427,32 @@ def find_repos_from_tool_id(tool_id: str, ts: ToolShedInstance) -> Tuple[str, Di
     if len(repos) == 0:
         try:
             # Try with owner and repo
-            owner_repo_tool_version = tool_id.split('/repos/')[1]
-            owner, repo = owner_repo_tool_version.split('/')[:2]
+            owner_repo_tool_version = tool_id.split("/repos/")[1]
+            owner, repo = owner_repo_tool_version.split("/")[:2]
             found_in_ts = False
-            def reformat(repo_dic: Dict[str, Any], meta_dic: Dict[str, Any], add_info_dic: Dict[str, Any]) -> Dict[str, Any]:
+
+            def reformat(
+                repo_dic: Dict[str, Any], meta_dic: Dict[str, Any], add_info_dic: Dict[str, Any]
+            ) -> Dict[str, Any]:
                 """Reformat the output of get_ordered_installable_revisions to get something close to _get tool_ids"""
-                meta_dic['repository'] = repo_dic
-                if 'valid_tools' in meta_dic:
-                    meta_dic['tools'] = meta_dic['valid_tools']
-                    del meta_dic['valid_tools']
+                meta_dic["repository"] = repo_dic
+                if "valid_tools" in meta_dic:
+                    meta_dic["tools"] = meta_dic["valid_tools"]
+                    del meta_dic["valid_tools"]
                 return meta_dic
+
             repos = {}
             for revision in ts.repositories.get_ordered_installable_revisions(name=repo, owner=owner):
                 repo_dic, meta_dic, add_info_dic = ts.repositories.get_repository_revision_install_info(
-                         name=repo, owner=owner, changeset_revision=revision
-                         )
+                    name=repo, owner=owner, changeset_revision=revision
+                )
                 repos[f"{meta_dic['numeric_revision']}:{revision}"] = reformat(repo_dic, meta_dic, add_info_dic)
-                if 'tools' in repos[f"{meta_dic['numeric_revision']}:{revision}"]:
-                    if tool_id in [t['guid'] for t in repos[f"{meta_dic['numeric_revision']}:{revision}"]['tools']]:
+                if "tools" in repos[f"{meta_dic['numeric_revision']}:{revision}"]:
+                    if tool_id in [t["guid"] for t in repos[f"{meta_dic['numeric_revision']}:{revision}"]["tools"]]:
                         found_in_ts = True
             # Try to set current_changeset to the last version
             # But maybe should be only the last with valid_tools?
-            repos['current_changeset'] = f"{meta_dic['numeric_revision']}:{revision}"
+            repos["current_changeset"] = f"{meta_dic['numeric_revision']}:{revision}"
         except Exception:
             return (f"The ToolShed returned an error when searching for {tool_id}", {})
         if found_in_ts:

--- a/tests/data/wf_repos/autoupdate_tests/workflow_with_bamleftalign.ga
+++ b/tests/data/wf_repos/autoupdate_tests/workflow_with_bamleftalign.ga
@@ -1,0 +1,92 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Workflow with bamleftalign",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "BAM"
+                }
+            ],
+            "label": "BAM",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "65194e38-bf3b-48bf-9a31-f5266d924472",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "58b1ccd8-ebe7-42a6-b640-55d6a2cf7035"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.3.1",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "reference_source|input_bam": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool BamLeftAlign",
+                    "name": "reference_source"
+                }
+            ],
+            "label": null,
+            "name": "BamLeftAlign",
+            "outputs": [
+                {
+                    "name": "output_bam",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 174,
+                "top": 108
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.3.1",
+            "tool_shed_repository": {
+                "changeset_revision": "ef2c525bd8cd",
+                "name": "freebayes",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"iterations\": \"5\", \"reference_source\": {\"reference_source_selector\": \"cached\", \"__current_case__\": 0, \"input_bam\": {\"__class__\": \"RuntimeValue\"}, \"ref_file\": \"Arabidopsis_thaliana_TAIR9\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.3.1",
+            "type": "tool",
+            "uuid": "2bb2b194-956a-459f-8e0f-645d941a92ae",
+            "workflow_outputs": [
+                {
+                    "label": "BamLeftAlign",
+                    "output_name": "output_bam",
+                    "uuid": "6d630e73-4937-49d6-81c3-a87d625c5da7"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "e38091f4-4c5b-4241-94fe-3b6c386c0521",
+    "version": 1
+}

--- a/tests/test_cmd_workflow_lint.py
+++ b/tests/test_cmd_workflow_lint.py
@@ -196,6 +196,10 @@ class CmdWorkflowLintTestCase(CliTestCase):
         result = self._runner.invoke(self._cli.planemo, lint_cmd)
         assert "ERROR: The ToolShed returned an error when searching" in result.output
 
+    def test_tool_id_linting_tool_classic_api_fail(self):
+        workflow_path = "/".join((TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_with_bamleftalign.ga"))
+        lint_cmd = ["workflow_lint", workflow_path]
+        self._check_exit_code(lint_cmd, exit_code=0)
 
 def _wf_repo(rel_path):
     return os.path.join(TEST_DATA_DIR, "wf_repos", rel_path)

--- a/tests/test_cmd_workflow_lint.py
+++ b/tests/test_cmd_workflow_lint.py
@@ -222,7 +222,7 @@ class CmdWorkflowLintTestCase(CliTestCase):
 
     def test_tool_id_linting_tool_classic_api_fail(self):
         workflow_path = "/".join((TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_with_bamleftalign.ga"))
-        lint_cmd = ["workflow_lint", workflow_path]
+        lint_cmd = ["workflow_lint", "--skip", "best_practices,structure,tests", workflow_path]
         self._check_exit_code(lint_cmd, exit_code=0)
 
 

--- a/tests/test_cmd_workflow_lint.py
+++ b/tests/test_cmd_workflow_lint.py
@@ -225,5 +225,6 @@ class CmdWorkflowLintTestCase(CliTestCase):
         lint_cmd = ["workflow_lint", workflow_path]
         self._check_exit_code(lint_cmd, exit_code=0)
 
+
 def _wf_repo(rel_path):
     return os.path.join(TEST_DATA_DIR, "wf_repos", rel_path)


### PR DESCRIPTION
I discovered that some tools like: "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/bamleftalign/1.3.1" are in the toolshed but the api get with tools_id fails.
I wrote a 'backup' where the tools are searched through the revisions of the repository.
It is slow so it is good to keep that solution as a backup plan.
Maybe this could be part of the galaxy code but meanwhile I think it helps to not fail lint for workflows which have such tools.