### PR TITLE
Add traceback to report template

### DIFF
--- a/planemo/reports/report_markdown.tpl
+++ b/planemo/reports/report_markdown.tpl
@@ -30,7 +30,7 @@
 | Skipped    | {{ state.skipped }} |
 
 
-{% set display_job_attributes = {'command_line': 'Command Line', 'exit_code': 'Exit Code', 'stderr': 'Standard Error', 'stdout': 'Standard Output'} %}
+{% set display_job_attributes = {'command_line': 'Command Line', 'exit_code': 'Exit Code', 'stderr': 'Standard Error', 'stdout': 'Standard Output', 'traceback': 'Traceback'} %}
 {% for status, desc in {'error': 'Errored', 'failure': 'Failed', 'success': 'Passed'}.items() if state[status]%}
 <details><summary>{{ desc }} {{ execution_type }}s</summary>
 {%   for test in raw_data.tests %}


### PR DESCRIPTION
since 0.75 planemo reports metadata setting errors as errors but does not show it yet in the the template.

![Screenshot from 2022-11-28 16-22-54](https://user-images.githubusercontent.com/25689525/204314774-6c49928d-cb1b-4ad8-b877-9961c56d4623.png)
