### PR TITLE
Rename configuration option removed in tox 4.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ setenv =
     2101: PLANEMO_TEST_GALAXY_BRANCH=release_21.01
 skip_install =
     doc_test,lint,lint_docs,lint_docstrings,mypy,gxwf_test_test: True
-whitelist_externals =
+allowlist_externals =
     lint_docs: make
     gxwf_test_test: make
 
@@ -73,5 +73,5 @@ whitelist_externals =
 [testenv:doc_test]
 commands = bash scripts/run_doc_test.sh
 skipsdist = True
-whitelist_externals = bash
+allowlist_externals = bash
 deps = 


### PR DESCRIPTION
See https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4