### PR TITLE
store datasets by UUID

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -436,6 +436,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
                 test_data_dir=test_data_dir,  # TODO: make gx respect this
                 shed_data_manager_config_file=shed_data_manager_config_file,
                 outputs_to_working_directory="True",  # this makes Galaxy's files dir RO for dockerized testing
+                object_store_store_by="uuid",
             )
         )
         _handle_container_resolution(ctx, kwds, properties)


### PR DESCRIPTION
thereby datasets get different IDs in different test sessions

this will make tests more robust in the long run. currently datasets get the same ID in each test (containing the same set of tests). since in weekly CI tests this set is different than in PR tests tools may fail in weekly tests that just were successful in PR tests.