### PR TITLE
fix orcid regex for dockstore_init

### DIFF
--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -92,7 +92,7 @@ def generate_dockstore_yaml(directory: str, publish: bool = True) -> str:
                         continue
                     if field == "identifier":
                         # Check if it is an orcid:
-                        orcid = re.findall(r"(?:\d{4}-){3}\d{3}", value)
+                        orcid = re.findall(r"(?:\d{4}-){3}\d{4}", value)
                         if len(orcid) > 0:
                             # Check the orcid is valid
                             if (

--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -97,7 +97,9 @@ def generate_dockstore_yaml(directory: str, publish: bool = True) -> str:
                             # Check the orcid is valid
                             if (
                                 requests.get(
-                                    f"https://orcid.org/{orcid[0]}", headers={"Accept": "application/xml"}
+                                    f"https://orcid.org/{orcid[0]}",
+                                    headers={"Accept": "application/xml"},
+                                    allow_redirects=False,
                                 ).status_code
                                 == 200
                             ):

--- a/tests/test_cmd_dockstore_init.py
+++ b/tests/test_cmd_dockstore_init.py
@@ -47,5 +47,6 @@ class CmdDockstoreInitTestCase(CliTestCase):
             assert "workflows" in dockstore_config
             assert len(dockstore_config["workflows"]) == 1
             assert "authors" in dockstore_config["workflows"]
+            assert dockstore_config["workflows"]["authors"]["orcid"] == "0000-0002-1964-4960"
             workflow_lint_cmd = ["workflow_lint", "--skip", "tool_ids", "--fail_level", "error", f]
             self._check_exit_code(workflow_lint_cmd)


### PR DESCRIPTION
~In addition the test with `requests.get` is useless:
`requests.get("https://orcid.org/0000-0002-1964-496", headers={"Accept": "application/xml"})` gives <Response [200]> even if the orcid is invalid.~
I found how to fix it.