### PR TITLE
Make test dockstore init with creator run and pass

### DIFF
--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -99,7 +99,7 @@ def generate_dockstore_yaml(directory: str, publish: bool = True) -> str:
                                 requests.get(
                                     f"https://orcid.org/{orcid[0]}",
                                     headers={"Accept": "application/xml"},
-                                    allow_redirects=False,
+                                    allow_redirects=True,
                                 ).status_code
                                 == 200
                             ):

--- a/tests/test_cmd_dockstore_init.py
+++ b/tests/test_cmd_dockstore_init.py
@@ -41,7 +41,7 @@ class CmdDockstoreInitTestCase(CliTestCase):
             self._check_exit_code(workflow_lint_cmd)
 
     def run_dockstore_init_with_creator(self):
-        with self._isolate_workflow("wf_repos/autoupdate_tests/workflow_with_unexisting_version_of_tool.ga") as f:
+        with self._isolate_workflow("wf_repos/autoupdate_tests/workflow_with_unexisting_tool.ga") as f:
             init_cmd = ["dockstore_init"]
             self._check_exit_code(init_cmd)
             assert os.path.exists(".dockstore.yml")
@@ -50,7 +50,8 @@ class CmdDockstoreInitTestCase(CliTestCase):
             assert str(dockstore_config["version"]) == "1.2"
             assert "workflows" in dockstore_config
             assert len(dockstore_config["workflows"]) == 1
-            assert "authors" in dockstore_config["workflows"]
-            assert dockstore_config["workflows"]["authors"]["orcid"] == "0000-0002-1964-4960"
+            workflow = dockstore_config["workflows"][0]
+            assert "authors" in workflow
+            assert workflow["authors"][0]["orcid"] == "0000-0002-1964-4960"
             workflow_lint_cmd = ["workflow_lint", "--skip", "tool_ids", "--fail_level", "error", f]
             self._check_exit_code(workflow_lint_cmd)

--- a/tests/test_cmd_dockstore_init.py
+++ b/tests/test_cmd_dockstore_init.py
@@ -41,9 +41,10 @@ class CmdDockstoreInitTestCase(CliTestCase):
             self._check_exit_code(workflow_lint_cmd)
 
     def run_dockstore_init_with_creator(self):
-        with self._isolate_with_test_data("wf_repos/autoupdate_tests/workflow_with_unexisting_version_of_tool.ga") as f:
-            init_cmd = ["dockstore_init", f]
+        with self._isolate_workflow("wf_repos/autoupdate_tests/workflow_with_unexisting_version_of_tool.ga") as f:
+            init_cmd = ["dockstore_init"]
             self._check_exit_code(init_cmd)
+            assert os.path.exists(".dockstore.yml")
             with open(".dockstore.yml") as fh:
                 dockstore_config = yaml.safe_load(fh)
             assert str(dockstore_config["version"]) == "1.2"

--- a/tests/test_cmd_dockstore_init.py
+++ b/tests/test_cmd_dockstore_init.py
@@ -17,6 +17,9 @@ class CmdDockstoreInitTestCase(CliTestCase):
     def test_init_publish_false(self):
         self.run_dockstore_init(False)
 
+    def test_init_with_creator(self):
+        self.run_dockstore_init_with_creator()
+
     def run_dockstore_init(self, publish: Optional[bool] = None):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native") as f:
             init_cmd = ["dockstore_init"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,8 +132,8 @@ class CliTestCase(TestCase):
         repo = os.path.join(TEST_REPOS_DIR, name)
         self._copy_directory(repo, dest)
 
-    def _copy_worklfow(self, name, dest):
-        workflow = os.path.join(TEST_REPOS_DIR, name)
+    def _copy_workflow(self, name, dest):
+        workflow = os.path.join(TEST_DATA_DIR, name)
         io.shell(["cp", workflow, dest])
 
     def _copy_directory(self, path, dest):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,6 +116,12 @@ class CliTestCase(TestCase):
             yield f
 
     @contextlib.contextmanager
+    def _isolate_workflow(self, name):
+        with self._isolate() as f:
+            self._copy_workflow(name, f)
+            yield f
+
+    @contextlib.contextmanager
     def _isolate_with_test_data(self, relative_path):
         with self._isolate() as f:
             repo = os.path.join(TEST_DATA_DIR, relative_path)
@@ -125,6 +131,10 @@ class CliTestCase(TestCase):
     def _copy_repo(self, name, dest):
         repo = os.path.join(TEST_REPOS_DIR, name)
         self._copy_directory(repo, dest)
+
+    def _copy_worklfow(self, name, dest):
+        workflow = os.path.join(TEST_REPOS_DIR, name)
+        io.shell(["cp", workflow, dest])
 
     def _copy_directory(self, path, dest):
         io.shell(["cp", "-r", f"{path}/.", dest])


### PR DESCRIPTION
- In #1314 and #1348 I forgot to put a `def test` so the dockstore with creator was not tested...
- I allow redirect because:
https://github.com/galaxyproject/iwc/pull/174#discussion_r1102064590
But strangely, if you put a 16 numbers which does not match a real orcid to get 404 but if you put 15 or 17 numbers it gives 200 and bring you to the login page:
```
>>> requests.get(f"https://orcid.org/0000-0001-6879-5194", headers={"Accept": "application/xml"},).status_code
200
>>> requests.get(f"https://orcid.org/0000-0001-6879-5193", headers={"Accept": "application/xml"},).status_code
404
>>> requests.get(f"https://orcid.org/0000-0001-6879-519", headers={"Accept": "application/xml"},).status_code
200
```