### PR TITLE
Pin allure-python-commons version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-allure-python-commons<=2.13.0
+allure-python-commons<2.13.0
 bioblend>=1.0.0
 click!=8.0.2
 cwltool>=1.0.20191225192155

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-allure-python-commons
+allure-python-commons<=2.13.0
 bioblend>=1.0.0
 click!=8.0.2
 cwltool>=1.0.20191225192155


### PR DESCRIPTION
The new release of v. 2.13.0 makes planemo crash:

...
File "/home/ubuntu/miniconda3/envs/planemo/lib/python3.8/site-packages/planemo/reports/[allure.py](http://allure.py/)", line 19, in <module>
from allure_commons.utils import (
ImportError: cannot import name 'escape_non_unicode_symbols' from 'allure_commons.utils' (/home/ubuntu/miniconda3/envs/planemo/lib/python3.8/site-packages/allure_commons/[utils.py](http://utils.py/))