### PR TITLE
Drop call to ``escape_non_unicode_symbols``

### DIFF
--- a/planemo/reports/allure.py
+++ b/planemo/reports/allure.py
@@ -17,7 +17,6 @@ from allure_commons.types import (
     LinkType,
 )
 from allure_commons.utils import (
-    escape_non_unicode_symbols,
     md5,
     platform_label,
     uuid4,
@@ -117,9 +116,7 @@ class AllureWriter:
             self._record_tool_link(test_result, tool_id)
             self._record_status(test_result, test_data)
             if test_result.status in [Status.BROKEN, Status.FAILED]:
-                test_result.statusDetails = StatusDetails(
-                    message=escape_non_unicode_symbols(problem_message or "Unknown problem"), trace=None
-                )
+                test_result.statusDetails = StatusDetails(message=(problem_message or "Unknown problem"), trace=None)
 
         self.lifecycle.write_test_case()
 


### PR DESCRIPTION
which was removed from allure-python-commons in 2.13.0 .

Alternative to https://github.com/galaxyproject/planemo/pull/1356 .