### PR TITLE
Drop `allow_none` for finding repository

### DIFF
--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -533,8 +533,7 @@ def _find_repository_id(ctx, shed_context, name, repo_config, **kwds):
     owner = _owner(ctx, repo_config, shed_context, **kwds)
     matching_repository = find_repository(shed_context.tsi, owner, name)
     if matching_repository is None:
-        message = "Failed to find repository for owner/name %s/%s"
-        raise Exception(message % (owner, name))
+        raise Exception(f"Failed to find repository for owner/name {owner}/{name}")
     else:
         repo_id = matching_repository["id"]
         return repo_id

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -533,11 +533,8 @@ def _find_repository_id(ctx, shed_context, name, repo_config, **kwds):
     owner = _owner(ctx, repo_config, shed_context, **kwds)
     matching_repository = find_repository(shed_context.tsi, owner, name)
     if matching_repository is None:
-        if not kwds.get("allow_none", False):
-            message = "Failed to find repository for owner/name %s/%s"
-            raise Exception(message % (owner, name))
-        else:
-            return None
+        message = "Failed to find repository for owner/name %s/%s"
+        raise Exception(message % (owner, name))
     else:
         repo_id = matching_repository["id"]
         return repo_id
@@ -1237,7 +1234,6 @@ class RealizedRepositry:
                 shed_context,
                 name=self.name,
                 repo_config=self.config,
-                allow_none=True,
             )
             return repo_id
         except Exception as e:

--- a/tests/test_shed_operations.py
+++ b/tests/test_shed_operations.py
@@ -21,14 +21,6 @@ def test_find_repository_id():
         assert repo_id == "r1"
 
 
-def test_find_repository_id_missing():
-    with mock_shed_context() as shed_context:
-        repo_id = shed.find_repository_id(
-            ctx=None, shed_context=shed_context, path=".", name="test_repo_absent", owner="iuc", allow_none=True
-        )
-        assert repo_id is None
-
-
 def test_find_repository_id_missing_exception():
     with mock_shed_context() as shed_context:
         exception = None


### PR DESCRIPTION
This was only used in the RealizedRepository class where it is being caught anyway. Should make debugging mismatched in name/owner of .shed.yml much easier. Probably fixes https://github.com/galaxyproject/planemo/issues/1353 ?