### PR TITLE
Officially support Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,13 @@ jobs:
           - unit-nonredundant-noclientbuild-noshed-gx-dev
           - unit-nonredundant-noclientbuild-noshed-nogx
           - unit-diagnostic-serveclientcmd
+        include:
+          - python-version: '3.11'
+            tox-action: lint
+          - python-version: '3.11'
+            tox-action: mypy
+          - python-version: '3.11'
+            tox-action: unit-quick
     services:
       postgres:
         image: postgres:10.8

--- a/planemo/shed2tap/base.py
+++ b/planemo/shed2tap/base.py
@@ -298,7 +298,7 @@ class ActionPackage:
 
 class BaseAction:
     _keys: List[str] = []
-    action_type = None  # type: str
+    action_type: str
 
     def __repr__(self):
         return f"Action[type={self.action_type}]"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ SOURCE_DIR = "planemo"
 
 _version_re = re.compile(r"__version__\s+=\s+(.*)")
 
-
 with open("%s/__init__.py" % SOURCE_DIR, "rb") as f:
     init_contents = f.read().decode("utf-8")
 
@@ -40,7 +39,6 @@ with open("%s/__init__.py" % SOURCE_DIR, "rb") as f:
     PROJECT_AUTHOR = get_var("PROJECT_AUTHOR")
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
 
-TEST_DIR = "tests"
 PROJECT_DESCRIPTION = (
     "Command-line utilities to assist in building tools for the Galaxy project (http://galaxyproject.org/)."
 )
@@ -90,11 +88,6 @@ else:
     # In tox, it will cover them anyway.
     requirements = []
 
-test_requirements = [
-    # TODO: put package test requirements here
-]
-
-
 setup(
     name=PROJECT_NAME,
     version=version,
@@ -127,7 +120,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
-    test_suite=TEST_DIR,
-    tests_require=test_requirements,
 )


### PR DESCRIPTION
Also:
- Run some tests on 3.11 as well
- Don't pass deprecated arguments to `setup()` .
- Fix flake8 errors on Python 3.10