### PR TITLE
Optimize disk space usage for `planemo test`

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1232,7 +1232,7 @@ def _install_galaxy_via_download(ctx, galaxy_root, env, kwds):
     branch = _galaxy_branch(kwds)
     source = _galaxy_source(kwds)
     if source.startswith("https://github.com/"):
-        source = source[len("https://github.com/"):]
+        source = source[len("https://github.com/") :]
     untar_to(
         f"https://codeload.github.com/{source}/tar.gz/{branch}",
         tar_args=["--strip-components", "1", "-xvzf", "-", "galaxy-" + branch],

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1244,7 +1244,7 @@ def _install_galaxy_via_download(ctx, galaxy_root, env, kwds):
 def _install_galaxy_via_git(ctx, galaxy_root, env, kwds):
     gx_repo = _ensure_galaxy_repository_available(ctx, kwds)
     branch = _galaxy_branch(kwds)
-    command = git.command_clone(ctx, gx_repo, galaxy_root, branch=branch)
+    command = git.command_clone(ctx, f"file://{gx_repo}", galaxy_root, branch=branch, depth=1)
     exit_code = shell(command, env=env)
     if exit_code != 0:
         raise Exception("Failed to clone Galaxy via git")

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1235,7 +1235,7 @@ def _install_galaxy_via_download(ctx, galaxy_root, env, kwds):
         source = source[len("https://github.com/") :]
     untar_to(
         f"https://codeload.github.com/{source}/tar.gz/{branch}",
-        tar_args=["--strip-components", "1", "-xvzf", "-", "galaxy-" + branch],
+        tar_args=["--strip-components", "1", "-xvzf", "-", "galaxy-" + branch.replace("/", "-")],
         dest_dir=galaxy_root,
     )
     _install_with_command(ctx, galaxy_root, env, kwds)

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1230,9 +1230,12 @@ def _install_galaxy(ctx, galaxy_root, env, kwds):
 
 def _install_galaxy_via_download(ctx, galaxy_root, env, kwds):
     branch = _galaxy_branch(kwds)
+    source = _galaxy_source(kwds)
+    if source.startswith("https://github.com/"):
+        source = source[len("https://github.com/"):]
     untar_to(
-        "https://codeload.github.com/galaxyproject/galaxy/tar.gz/" + branch,
-        tar_args=["-xvzf", "-", "galaxy-" + branch],
+        f"https://codeload.github.com/{source}/tar.gz/{branch}",
+        tar_args=["--strip-components", "1", "-xvzf", "-", "galaxy-" + branch],
         dest_dir=galaxy_root,
     )
     _install_with_command(ctx, galaxy_root, env, kwds)

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1244,7 +1244,7 @@ def _install_galaxy_via_download(ctx, galaxy_root, env, kwds):
 def _install_galaxy_via_git(ctx, galaxy_root, env, kwds):
     gx_repo = _ensure_galaxy_repository_available(ctx, kwds)
     branch = _galaxy_branch(kwds)
-    command = git.command_clone(ctx, f"file://{gx_repo}", galaxy_root, branch=branch, depth=1)
+    command = git.command_clone(ctx, gx_repo, galaxy_root, branch=branch, depth=1)
     exit_code = shell(command, env=env)
     if exit_code != 0:
         raise Exception("Failed to clone Galaxy via git")

--- a/planemo/git.py
+++ b/planemo/git.py
@@ -98,6 +98,9 @@ def command_clone(
         cmd.append("--mirror")
     if branch is not None:
         cmd.extend(["--branch", branch])
+        cmd.extend(["--depth", "1"])
+        if not src.startswith("file://"):
+            src = f"file://{src}"
     cmd.extend([src, dest])
     return cmd
 

--- a/planemo/git.py
+++ b/planemo/git.py
@@ -87,7 +87,7 @@ def checkout(ctx, remote_repo, local_path, branch=None, remote="origin", from_br
 
 
 def command_clone(
-    ctx: "PlanemoCliContext", src: str, dest: str, mirror: bool = False, branch: Optional[str] = None
+    ctx: "PlanemoCliContext", src: str, dest: str, mirror: bool = False, branch: Optional[str] = None, depth: Optional[int] = None
 ) -> List[str]:
     """Produce a command-line string to clone a repository.
 
@@ -98,9 +98,8 @@ def command_clone(
         cmd.append("--mirror")
     if branch is not None:
         cmd.extend(["--branch", branch])
-        cmd.extend(["--depth", "1"])
-        if not src.startswith("file://"):
-            src = f"file://{src}"
+    if depth is not None:
+        cmd.extend(["--depth", str(depth)])
     cmd.extend([src, dest])
     return cmd
 

--- a/planemo/git.py
+++ b/planemo/git.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import urllib.parse
 from typing import (
     Dict,
     List,
@@ -87,7 +88,12 @@ def checkout(ctx, remote_repo, local_path, branch=None, remote="origin", from_br
 
 
 def command_clone(
-    ctx: "PlanemoCliContext", src: str, dest: str, mirror: bool = False, branch: Optional[str] = None, depth: Optional[int] = None
+    ctx: "PlanemoCliContext",
+    src: str,
+    dest: str,
+    mirror: bool = False,
+    branch: Optional[str] = None,
+    depth: Optional[int] = None,
 ) -> List[str]:
     """Produce a command-line string to clone a repository.
 
@@ -100,6 +106,8 @@ def command_clone(
         cmd.extend(["--branch", branch])
     if depth is not None:
         cmd.extend(["--depth", str(depth)])
+        if urllib.parse.urlparse(src).scheme == "":
+            src = f"file://{src}"
     cmd.extend([src, dest])
     return cmd
 


### PR DESCRIPTION
Had CI tests that failed due to full disk and noticed that the temporary Galaxy dir has ~1GB. 

- So I thought a shallow clone from the bare repository in `.planemo` might be a good idea: 135cef81b954fe72e8aeccc9abf58a5e01e0c59e
- Then I discovered `--no_cache_galaxy` which might be even better for CI jobs, but noticed that it does not support forks and branches of the galaxy sources: b08209e409fa28099c4d38f5d65cdd4646fe9952 .. also it did not work anymore as shown here https://github.com/galaxyproject/planemo-ci-action/pull/50: `/bin/sh: 1: ./scripts/common_startup.sh: not found`
