### PR TITLE
Run galaxy with default tools included

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1372,10 +1372,6 @@ def _handle_job_config_file(
 
 
 def _write_tool_conf(ctx, tool_paths: List[str], tool_conf_path: str, galaxy_root: str):
-    ctx.vlog(f"_write_tool_conf tool_paths {tool_paths}")
-    ctx.vlog(f"_write_tool_conf tool_conf_path {tool_conf_path}")
-    ctx.vlog(f"_write_tool_conf galaxy_root {galaxy_root}")
-
     tool_conf_sample_path = os.path.join(galaxy_root, "config", "tool_conf.xml.sample")
     tree = ElementTree.parse(tool_conf_sample_path)
     root = tree.getroot()


### PR DESCRIPTION
I wanted to test some Galaxy tools and needed the collection operations. So I thought it might be a good idea to serve planemo with Galaxy's default tools installed:

![Screenshot from 2023-08-04 15-59-25](https://github.com/galaxyproject/planemo/assets/25689525/7c7f3303-dfba-4363-9ea2-0394d937bee2)

Not sure what happens if some one calls planemo test/serve on one of the builtin tools....

Alternatively one could use `--extra_tools ` but then the tools are just installed flat in the tool menu. 