### PR TITLE
fix profile version test

### DIFF
--- a/tests/data/tools/fail_bad_profile_3.xml
+++ b/tests/data/tools/fail_bad_profile_3.xml
@@ -1,4 +1,4 @@
-<tool id="fail_bad_profile_3" name="fail_bad_profile_3" version="1.0" profile="16.34">
+<tool id="fail_bad_profile_3" name="fail_bad_profile_3" version="1.0" profile="16,34">
     <description>select param</description>
     <command><![CDATA[
         echo "$select_opt" > $output


### PR DESCRIPTION
linter has been adapted to new style profile versions and got a bit more relaxed.

https://github.com/galaxyproject/galaxy/pull/16480

Alternatively we could work on the linter in Galaxy, e.g. something along:

```python
try:
    profile_year, profile_month =  profile.split(".")
except Exception:
    handle_error
if int(profile_year) < 10:
    handle_error
if int(profile_year) < 23:
    if not profile_month in ["01", "02", "03", "04", ... ]:
        handle_error
else:
    if not re.match(profile_month, r"\d"):
        handle_error
```