### PR TITLE
Sync planemo and planemo virtual appliance docs

### DIFF
--- a/docs/writing_standalone.rst
+++ b/docs/writing_standalone.rst
@@ -10,6 +10,7 @@ if you have not already installed it.
 .. include:: _writing_intro.rst
 .. include:: _writing_test_and_serve.rst
 .. include:: _writing_parameters.rst
+.. include:: _writing_publish_intro.rst
 .. include:: _writing_scripts.rst
 .. include:: _writing_suites.rst
 .. include:: _writing_conclusion.rst


### PR DESCRIPTION
I am wondering what this virtual appliance thing is anyway for many years? Was wondering if we can remove this, ie. `docs/writing_appliance.rst` .. 