### PR TITLE
Remove API key requirement from training_init

### DIFF
--- a/planemo/training/tutorial.py
+++ b/planemo/training/tutorial.py
@@ -508,8 +508,6 @@ class Tutorial:
         if self.init_wf_id:
             if not self.training.galaxy_url:
                 raise ValueError("No Galaxy URL given")
-            if not self.training.galaxy_api_key:
-                raise ValueError("No API key to access the given Galaxy instance")
             self.body = get_hands_on_boxes_from_running_galaxy(
                 self.init_wf_id, self.training.galaxy_url, self.training.galaxy_api_key
             )


### PR DESCRIPTION
This seems to thankfully no longer be required which is fantastic for this use case.

Whenever this version of planemo gets released then we can remove that requirement from ptdk as well @bebatut 