### PR TITLE
Don't crash autoupdate on non-PEP440-compliant tool versions

### DIFF
--- a/planemo/autoupdate.py
+++ b/planemo/autoupdate.py
@@ -17,12 +17,12 @@ from typing import (
 )
 from xml.etree.ElementTree import ElementTree
 
-import packaging.version
 import requests
 import yaml
 from bioblend import toolshed
 from bioblend.toolshed import ToolShedInstance
 from galaxy.tool_util.deps import conda_util
+from galaxy.tool_util.version import parse_version
 
 import planemo.conda
 from planemo.io import (
@@ -89,7 +89,7 @@ def check_conda(package_name: str, ctx: "PlanemoCliContext", **kwds) -> str:
         search_results = itertools.chain.from_iterable(
             n["versions"] for n in r.json() if n["name"] == package_name and n["owner"] in kwds["conda_ensure_channels"]
         )
-        return sorted(search_results, key=packaging.version.parse, reverse=True)[0]
+        return sorted(search_results, key=parse_version, reverse=True)[0]
 
     target = conda_util.CondaTarget(package_name)
     best_search_results = conda_util.best_search_result(target, conda_context=conda_context)
@@ -289,7 +289,7 @@ def _update_wf(config: "LocalGalaxyConfig", workflow_id: str, instance: bool = F
 def get_newest_tool_id(tool_ids: List[str]) -> str:
     return sorted(
         tool_ids,
-        key=lambda n: packaging.version.parse(n.split("/")[-1]),
+        key=lambda n: parse_version(n.split("/")[-1]),
     )[-1]
 
 


### PR DESCRIPTION
Fix errors like:

```
File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/commands/cmd_autoupdate.py", line 120, in cli
    tools_to_update = autoupdate.get_tools_to_update(ctx, workflow, tools_to_skip)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/autoupdate.py", line 363, in get_tools_to_update
    return outdated_tools(ctx, wf_dict, ts, tools_to_skip)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/autoupdate.py", line 349, in outdated_tools
    outdated_tools_rec(wf_dict)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/autoupdate.py", line 337, in outdated_tools_rec
    outdated_tool_dict.update(check_tool_step(tool_id))
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/autoupdate.py", line 324, in check_tool_step
    updated_tool_id = get_newest_tool_id(matching_tool_ids)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/autoupdate.py", line 290, in get_newest_tool_id
    return sorted(
           ^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/planemo/autoupdate.py", line 292, in <lambda>
    key=lambda n: packaging.version.parse(n.split("/")[-1]),
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/packaging/version.py", line 54, in parse
    return Version(version)
           ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/packaging/version.py", line 200, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: '0.8.1+galaxy0+galaxy0'
```

seen e.g. in https://github.com/planemo-autoupdate/autoupdate/actions/runs/7443075417/job/20247438333 by using `parse_version` from `galaxy.tool_util.version`.