### PR TITLE
Add option to pass extra arguments to `docker run`

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -130,6 +130,7 @@ JOB_CONFIG_LOCAL = """<job_conf>
             <param id="docker_sudo_cmd">${docker_sudo_cmd}</param>
             <param id="docker_cmd">${docker_cmd}</param>
             <param id="docker_volumes">${docker_volumes}</param>
+            <param id="docker_run_extra_arguments"><![CDATA[${docker_run_extra_arguments}]]></param>
             ${docker_host_param}
         </destination>
         <destination id="upload_dest" runner="planemo_runner">
@@ -1363,6 +1364,7 @@ def _handle_job_config_file(
                 "docker_cmd": str(kwds.get("docker_cmd", docker_util.DEFAULT_DOCKER_COMMAND)),
                 "docker_host_param": docker_host_param,
                 "docker_volumes": docker_volumes_str,
+                "docker_run_extra_arguments": kwds.get("docker_run_extra_arguments", ""),
             }
         )
         write_file(job_config_file, conf_contents)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -955,6 +955,14 @@ def docker_host_option():
         default=docker_util.DEFAULT_HOST,
     )
 
+def docker_run_extra_arguments_option():
+    return planemo_option(
+        "--docker_run_extra_arguments",
+        help="Extra arguments to pass to docker run.",
+        use_global_config=True,
+        default="",
+    )
+
 
 def docker_config_options():
     return _compose(
@@ -962,6 +970,7 @@ def docker_config_options():
         docker_sudo_option(),
         docker_host_option(),
         docker_sudo_cmd_option(),
+        docker_run_extra_arguments_option(),
     )
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -955,6 +955,7 @@ def docker_host_option():
         default=docker_util.DEFAULT_HOST,
     )
 
+
 def docker_run_extra_arguments_option():
     return planemo_option(
         "--docker_run_extra_arguments",


### PR DESCRIPTION
I have a [usecase](https://github.com/bernt-matthias/mb-galaxy-tools/pull/17) where I want to test a tool that uses another server running in CI as container. In order to allow be able to access the host's `localhost` I need to pass `--add-host=host.docker.internal:host-gateway` to docker run (at least I do not know of another way). 