### PR TITLE
#1429 Allow --host parameter

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -523,7 +523,7 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
                     "galaxy": properties,
                     "gravity": {
                         "galaxy_root": galaxy_root,
-                        "gunicorn": {"bind": f"localhost:{template_args['port']}"},
+                        "gunicorn": {"bind": f"{kwds.get('host', 'localhost'}:{template_args['port']}"},
                         "gx-it-proxy": {
                             "enable": False,
                         },

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -523,7 +523,7 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
                     "galaxy": properties,
                     "gravity": {
                         "galaxy_root": galaxy_root,
-                        "gunicorn": {"bind": f"{kwds.get('host', 'localhost'}:{template_args['port']}"},
+                        "gunicorn": {"bind": f"{kwds.get('host', 'localhost')}:{template_args['port']}"},
                         "gx-it-proxy": {
                             "enable": False,
                         },


### PR DESCRIPTION
Don't set a static host when it is able to be provided by planemo, use the provided value if available