### PR TITLE
Addition of metadata generation for planemo run

### DIFF
--- a/docs/commands/run.rst
+++ b/docs/commands/run.rst
@@ -168,6 +168,8 @@ Planemo command for running tools and jobs.
                                       Where to store outputs of a 'run' task.
       --output_json FILE              Where to store JSON dictionary describing
                                       outputs of a 'run' task.
+      --output_metadata FILE          Where to store JSON dictionary describing
+                                      the metadata of a 'run' task.
       --download_outputs / --no_download_outputs
                                       After tool or workflow runs are complete,
                                       download the output files to the location

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -51,15 +51,16 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
             kwds["engine"] = "galaxy"
     with engine_context(ctx, **kwds) as engine:
         run_result = engine.run([runnable], [job_path])[0]
-        run_infos = {
-            "history_id": run_result._history_id,
-            "invocation_id": run_result._invocation_id,
-            "workflow_id": run_result._workflow_id,
-        }
-        output_metadata = kwds.get("output_metadata", None)
-        if output_metadata:
-            with open(output_metadata, "w") as f:
-                json.dump(run_infos, f)
+        if kwds["engine"] == "galaxy" or kwds["engine"] == "external_galaxy":
+            run_infos = {
+                "history_id": run_result._history_id,
+                "invocation_id": run_result._invocation_id,
+                "workflow_id": run_result._workflow_id,
+            }
+            output_metadata = kwds.get("output_metadata", None)
+            if output_metadata:
+                with open(output_metadata, "w") as f:
+                    json.dump(run_infos, f)
 
     if not run_result.was_successful:
         warn("Run failed [%s]" % unicodify(run_result))

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -52,13 +52,13 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
     with engine_context(ctx, **kwds) as engine:
         run_result = engine.run([runnable], [job_path])[0]
         if kwds["engine"] == "galaxy" or kwds["engine"] == "external_galaxy":
-            run_infos = {
-                "history_id": run_result._history_id,
-                "invocation_id": run_result._invocation_id,
-                "workflow_id": run_result._workflow_id,
-            }
             output_metadata = kwds.get("output_metadata", None)
             if output_metadata:
+                run_infos = {
+                    "history_id": run_result._history_id,
+                    "invocation_id": run_result._invocation_id,
+                    "workflow_id": run_result._workflow_id,
+                }
                 with open(output_metadata, "w") as f:
                     json.dump(run_infos, f)
 

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -51,16 +51,6 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
             kwds["engine"] = "galaxy"
     with engine_context(ctx, **kwds) as engine:
         run_result = engine.run([runnable], [job_path])[0]
-        if kwds["engine"] == "galaxy" or kwds["engine"] == "external_galaxy":
-            output_metadata = kwds.get("output_metadata", None)
-            if output_metadata:
-                run_infos = {
-                    "history_id": run_result._history_id,
-                    "invocation_id": run_result._invocation_id,
-                    "workflow_id": run_result._workflow_id,
-                }
-                with open(output_metadata, "w") as f:
-                    json.dump(run_infos, f)
 
     if not run_result.was_successful:
         warn("Run failed [%s]" % unicodify(run_result))

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -27,6 +27,7 @@ from planemo.test.results import StructuredData
 @options.run_history_tags_option()
 @options.run_output_directory_option()
 @options.run_output_json_option()
+@options.run_output_metadata_option()
 @options.run_download_outputs_option()
 @options.engine_options()
 @options.test_options()
@@ -50,6 +51,11 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
             kwds["engine"] = "galaxy"
     with engine_context(ctx, **kwds) as engine:
         run_result = engine.run([runnable], [job_path])[0]
+        run_infos ={"history_id": run_result._history_id, "invocation_id": run_result._invocation_id, "workflow_id": run_result._workflow_id}
+        output_metadata = kwds.get("output_metadata", None)
+        if output_metadata:
+            with open(output_metadata, "w") as f:
+                json.dump(run_infos, f)
 
     if not run_result.was_successful:
         warn("Run failed [%s]" % unicodify(run_result))

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -51,7 +51,11 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
             kwds["engine"] = "galaxy"
     with engine_context(ctx, **kwds) as engine:
         run_result = engine.run([runnable], [job_path])[0]
-        run_infos ={"history_id": run_result._history_id, "invocation_id": run_result._invocation_id, "workflow_id": run_result._workflow_id}
+        run_infos = {
+            "history_id": run_result._history_id,
+            "invocation_id": run_result._invocation_id,
+            "workflow_id": run_result._workflow_id,
+        }
         output_metadata = kwds.get("output_metadata", None)
         if output_metadata:
             with open(output_metadata, "w") as f:

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -1,5 +1,6 @@
 """Module provides generic interface to running Galaxy tools and workflows."""
 
+import json
 import os
 import sys
 import tempfile
@@ -216,6 +217,16 @@ def _execute(  # noqa C901
             start_datetime=start_datetime,
             log=log_contents_str(config),
         )
+        if kwds["engine"] == "galaxy" or kwds["engine"] == "external_galaxy":
+            output_metadata = kwds.get("output_metadata", None)
+            if output_metadata:
+                run_infos = {
+                    "history_id": history_id,
+                    "invocation_id": invocation["id"],
+                    "workflow_id": workflow_id,
+                }
+                with open(output_metadata, "w") as f:
+                    json.dump(run_infos, f)
 
     else:
         raise NotImplementedError()

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -284,7 +284,7 @@ def run_output_metadata_option():
             resolve_path=True,
         ),
         default=None,
-        help=("Where to store JSON dictionary describing the metadata of " "a 'run' task."),
+        help=("Where to store JSON dictionary describing the metadata of " "a workflow 'run' task."),
     )
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -273,6 +273,18 @@ def run_output_directory_option():
         help=("Where to store outputs of a 'run' task."),
     )
 
+def run_output_metadata_option():
+    return planemo_option(
+        "output_metadata",
+        "--output_metadata",
+        type=click.Path(
+            file_okay=True,
+            dir_okay=False,
+            resolve_path=True,
+        ),
+        default=None,
+        help=("Where to store JSON dictionary describing the metadata of " "a 'run' task."),
+    )
 
 def run_output_json_option():
     return planemo_option(

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -273,6 +273,7 @@ def run_output_directory_option():
         help=("Where to store outputs of a 'run' task."),
     )
 
+
 def run_output_metadata_option():
     return planemo_option(
         "output_metadata",
@@ -285,6 +286,7 @@ def run_output_metadata_option():
         default=None,
         help=("Where to store JSON dictionary describing the metadata of " "a 'run' task."),
     )
+
 
 def run_output_json_option():
     return planemo_option(

--- a/tests/data/first_lines.ga
+++ b/tests/data/first_lines.ga
@@ -1,0 +1,100 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "comments": [],
+    "format-version": "0.1",
+    "name": "Testing",
+    "report": {
+        "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\r\n```galaxy\nhistory_dataset_peek(output=\"Truncated file\")\n```\r\n\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+    },
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "File to head"
+                }
+            ],
+            "label": "File to head",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "6cada1bd-e96e-43d2-a41b-2f396c9ad2ca",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "infile": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select first",
+                    "name": "infile"
+                }
+            ],
+            "label": null,
+            "name": "Select first",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 296.265625,
+                "top": 57.5703125
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Truncated_file"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_head_tool/1.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "ddf54b12c295",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"complement\": \"\", \"count\": \"3\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "97a55f13-2d30-4ecd-a3fb-d8d433d3b3bb",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Truncated file",
+                    "output_name": "outfile",
+                    "uuid": "61afcb1c-d26e-4a98-988f-a73fbb074d0c"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "1649a361-0381-444c-bdb6-b099609f7f62",
+    "version": 4
+}

--- a/tests/data/first_lines.yml
+++ b/tests/data/first_lines.yml
@@ -1,0 +1,3 @@
+File to head:
+  class: File
+  path: gxfiles://genomeark/species/Taeniopygia_guttata/bTaeGut2/assembly_vgp_trio_2.0/evaluation/busco/bTaeGut2_trio.dip.hap1_busco_shortsummary.txt

--- a/tests/data/first_lines.yml
+++ b/tests/data/first_lines.yml
@@ -1,3 +1,3 @@
 File to head:
   class: File
-  path: gxfiles://genomeark/species/Taeniopygia_guttata/bTaeGut2/assembly_vgp_trio_2.0/evaluation/busco/bTaeGut2_trio.dip.hap1_busco_shortsummary.txt
+  path: hello.txt

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -133,6 +133,8 @@ class RunTestCase(CliTestCase):
                 "--no_wait",
                 "--output_metadata",
                 info_path,
+                "--test_data",
+                TEST_DATA_DIR,
             ]
             self._check_exit_code(test_cmd)
             assert os.path.exists(os.path.join(f, "run_info.json"))

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -115,3 +115,24 @@ class RunTestCase(CliTestCase):
             assert os.path.exists(output_path)
             with open(output_path) as fh:
                 assert fh.read().startswith("  16  198 1111")
+
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    def test_run_metadata(self):
+        with self._isolate() as f:
+            workflow_path = os.path.join(TEST_DATA_DIR, "first_lines.ga")
+            job_path = os.path.join(TEST_DATA_DIR, "first_lines.yml")
+            info_path = os.path.join(f, "run_info.json")
+            test_cmd = [
+                "--verbose",
+                "run",
+                workflow_path,
+                job_path,
+                "--no_dependency_resolution",
+                "--galaxy_branch",
+                target_galaxy_branch(),
+                "--no_wait",
+                "--output_metadata",
+                info_path,
+            ]
+            self._check_exit_code(test_cmd)
+            assert os.path.exists(os.path.join(f, "run_info.json"))


### PR DESCRIPTION
Add the command `--output_metadata FILE` to planemo run. Generate a json file containing the workflow ID, invocation ID, and history ID created by the 'run' command. 