### PR TITLE
Fix markdown template: add missing closing details tag

### DIFF
--- a/planemo/reports/macros.tmpl
+++ b/planemo/reports/macros.tmpl
@@ -65,7 +65,8 @@
         * {{value}}
    {% endif %}
 {%    endfor %}
-      </details>
+
+     </details>
 {% endmacro %}
 
 

--- a/planemo/reports/macros.tmpl
+++ b/planemo/reports/macros.tmpl
@@ -18,6 +18,7 @@
 
 {%      endif %}
 {%    endfor %}
+      </details>
 {% endmacro %}
 
 

--- a/planemo/reports/report_markdown.tpl
+++ b/planemo/reports/report_markdown.tpl
@@ -38,11 +38,11 @@
 {%     if test.data.status == status %}
 {%       if test.data.status == 'success' %}
 
-* <details class="rcorners light-green"><summary class="light-green">&#9989; {{ test.id }}</summary><div class="padded">
+* <details class="rcorners light-green"><summary class="light-green">&#9989; {{ test.id|replace("#","# ") }}</summary><div class="padded">
 
 {%       else %}
 
-* <details class="rcorners light-red"><summary class="light-red">&#10060; {{ test.id }}</summary><div class="padded">
+* <details class="rcorners light-red"><summary class="light-red">&#10060; {{ test.id|replace("#","# ") }}</summary><div class="padded">
 
 {%       endif %}
 {%       if test.data.output_problems %}

--- a/planemo/reports/report_markdown.tpl
+++ b/planemo/reports/report_markdown.tpl
@@ -84,7 +84,7 @@
 
 {%       endif %}
 
-  </div></details>
+    </div></details>
 
 {%     endif %}
 {%   endfor %}


### PR DESCRIPTION
If I'm not wrong this is missing and leads to a display like [here](https://github.com/galaxyproject/iwc/pull/354#issuecomment-2020102783) where 

- the first test is only shown if `Passed` is unfolded 
- the other three tests are shown also if passed is folded
