### PR TITLE
Fix linting of asserts with children

### DIFF
--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -334,14 +334,18 @@ def _check_test_assertions(
                 assertions_valid = False
                 continue
             signature = inspect.signature(function)
-            function_args = inspect.getfullargspec(function)
+            function_args = inspect.getfullargspec(function).args
             assertion_params = assertion_description["attributes"].copy()
             if "verify_assertions_function" in function_args:
-                assertion_params["verify_assertions_function"] = asserts.verify_assertion(b"", [])
+                assertion_params["verify_assertions_function"] = asserts.verify_assertion
             if "children" in function_args:
-                assertion_params["children"] = []
+                if "asserts" in assertion_params:
+                    assertion_params["children"] = assertion_params["asserts"]
+                    del assertion_params["asserts"]
+                if "children" not in assertion_params:
+                    assertion_params["children"] = []
+                _check_test_assertions(lint_context, assertion_params["children"])
             del assertion_params["that"]
-
             try:
                 # try mapping the function with the attributes supplied and check for TypeError
                 signature.bind("", **assertion_params)

--- a/tests/data/wf_repos/basic_format2_ok/basic_format2.gxwf-test.yml
+++ b/tests/data/wf_repos/basic_format2_ok/basic_format2.gxwf-test.yml
@@ -6,3 +6,19 @@
   outputs:
     the_output:
       checksum: 'sha1$7bd92c6cd84285e4fc7215d506bbabfe328acb8f'
+      asserts:
+        - has_size:
+            value: 20M
+            delta: 1M
+        - has_archive_member:
+            path: ".*"
+            n: 34
+            asserts:
+              - has_text:
+                  text: ""
+        - has_archive_member:
+            path: ".*/data/metadata.yml"
+            # children is accepted as well (but asserts is more consistent)
+            children:
+              - has_text:
+                  text: "phred-offset: 33"


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/planemo/pull/1437

- missed that the `"asserts"` key needs to be removed
- the "verify_assertions_function" needs to be mapped to the asserts.verify_assertion function
- the check should be done recursively
- basic test