### PR TITLE
Autoupdate: start a separate instance for each workflow

### DIFF
--- a/planemo/commands/cmd_autoupdate.py
+++ b/planemo/commands/cmd_autoupdate.py
@@ -135,9 +135,9 @@ def cli(ctx, paths, **kwds):  # noqa C901
             kwds["install_repository_dependencies"] = False
             kwds["shed_install"] = True
 
-        with engine_context(ctx, **kwds) as galaxy_engine:
-            with galaxy_engine.ensure_runnables_served(modified_workflows) as config:
-                for workflow in modified_workflows:
+        for workflow in modified_workflows:
+            with engine_context(ctx, **kwds) as galaxy_engine:
+                with galaxy_engine.ensure_runnables_served([workflow]) as config:
                     if config.updated_repos.get(workflow.path) or kwds.get("engine") == "external_galaxy":
                         info("Auto-updating workflow %s" % workflow.path)
                         updated_workflow = autoupdate.autoupdate_wf(ctx, config, workflow)

--- a/planemo/commands/cmd_autoupdate.py
+++ b/planemo/commands/cmd_autoupdate.py
@@ -135,9 +135,9 @@ def cli(ctx, paths, **kwds):  # noqa C901
             kwds["install_repository_dependencies"] = False
             kwds["shed_install"] = True
 
-        for workflow in modified_workflows:
-            with engine_context(ctx, **kwds) as galaxy_engine:
-                with galaxy_engine.ensure_runnables_served([workflow]) as config:
+        with engine_context(ctx, **kwds) as galaxy_engine:
+            with galaxy_engine.ensure_runnables_served(modified_workflows) as config:
+                for workflow in modified_workflows:
                     if config.updated_repos.get(workflow.path) or kwds.get("engine") == "external_galaxy":
                         info("Auto-updating workflow %s" % workflow.path)
                         updated_workflow = autoupdate.autoupdate_wf(ctx, config, workflow)

--- a/planemo/commands/cmd_autoupdate.py
+++ b/planemo/commands/cmd_autoupdate.py
@@ -138,27 +138,26 @@ def cli(ctx, paths, **kwds):  # noqa C901
         with engine_context(ctx, **kwds) as galaxy_engine:
             with galaxy_engine.ensure_runnables_served(modified_workflows) as config:
                 for workflow in modified_workflows:
-                    if config.updated_repos.get(workflow.path) or kwds.get("engine") == "external_galaxy":
-                        info("Auto-updating workflow %s" % workflow.path)
-                        updated_workflow = autoupdate.autoupdate_wf(ctx, config, workflow)
+                    info("Auto-updating workflow %s" % workflow.path)
+                    updated_workflow = autoupdate.autoupdate_wf(ctx, config, workflow)
 
-                        if workflow.path.endswith(".ga"):
-                            with open(workflow.path) as f:
-                                original_workflow = json.load(f)
-                            edited_workflow = autoupdate.fix_workflow_ga(original_workflow, updated_workflow)
-                            with open(workflow.path, "w") as f:
-                                json.dump(edited_workflow, f, indent=4)
-                        else:
-                            with open(workflow.path) as f:
-                                original_workflow = yaml.load(f, Loader=yaml.SafeLoader)
-                            edited_workflow = autoupdate.fix_workflow_gxformat2(original_workflow, updated_workflow)
-                            with open(workflow.path, "w") as f:
-                                yaml.dump(edited_workflow, f)
-                        if original_workflow.get("release"):
-                            info(
-                                f"The workflow release number has been updated from "
-                                f"{original_workflow.get('release')} to {edited_workflow.get('release')}."
-                            )
+                    if workflow.path.endswith(".ga"):
+                        with open(workflow.path) as f:
+                            original_workflow = json.load(f)
+                        edited_workflow = autoupdate.fix_workflow_ga(original_workflow, updated_workflow)
+                        with open(workflow.path, "w") as f:
+                            json.dump(edited_workflow, f, indent=4)
+                    else:
+                        with open(workflow.path) as f:
+                            original_workflow = yaml.load(f, Loader=yaml.SafeLoader)
+                        edited_workflow = autoupdate.fix_workflow_gxformat2(original_workflow, updated_workflow)
+                        with open(workflow.path, "w") as f:
+                            yaml.dump(edited_workflow, f)
+                    if original_workflow.get("release"):
+                        info(
+                            f"The workflow release number has been updated from "
+                            f"{original_workflow.get('release')} to {edited_workflow.get('release')}."
+                        )
 
     if kwds["test"]:
         if not modified_files and not modified_workflows:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,7 +128,7 @@ class CliTestCase(TestCase):
         with self._isolate() as f:
             repo = os.path.join(TEST_DATA_DIR, relative_path)
             self._copy_directory(repo, f)
-            yield f
+            yield os.path.realpath(f)
 
     def _copy_repo(self, name, dest):
         repo = os.path.join(TEST_REPOS_DIR, name)


### PR DESCRIPTION
An attempt to solve the problem that the workflow autoupdate does not update all workflows in a dir. 
I think the problem occurs if the tool set of the workflows overlaps (e.g. https://github.com/galaxyproject/iwc/pull/422/). 


The symptom that is fixed by my change is that [`config.updated_repos`](https://github.com/galaxyproject/planemo/blob/cb2321b4a2c84c992b57c27822838a55f3bd9c28/planemo/commands/cmd_autoupdate.py#L141C24-L141C44
) gets empty for some workflows which are therefore skipped. 

I guess a cleaner way to fix this might be to uninstall all tools again after a workflow was processed?


