### PR TITLE
Remove myself from committer list

### DIFF
--- a/docs/organization.rst
+++ b/docs/organization.rst
@@ -45,7 +45,6 @@ Committers
 
 - Dannon Baker (@dannon)
 - Bérénice Batut (@bebatut)
-- Simon Bray (@simonbray)
 - Martin Cech (@martenson)
 - John Chilton (@jmchilton)
 - Peter Cock (@peterjc)


### PR DESCRIPTION
I've also removed myself from the BioBlend committer team, but I don't believe there is any page to update there.

The page is not in sync with https://github.com/orgs/galaxyproject/teams/planemo, just as an observation :)