### PR TITLE
Add the option to provide a history id to run the workflow in

### DIFF
--- a/docs/commands/lint.rst
+++ b/docs/commands/lint.rst
@@ -23,8 +23,7 @@ Check for common errors and best practices.
                                       (e.g. passing --skip 'citations,xml_order'
                                       would skip linting of citations and best-
                                       practice XML ordering.
-      --xsd / --no_xsd                Include tool XSD validation in linting
-                                      process.
+      --skip_file FILE                File containing a list of lint tests to skip
       -r, --recursive                 Recursively perform command for
                                       subdirectories.
       --urls                          Check validity of URLs in XML files

--- a/docs/commands/run.rst
+++ b/docs/commands/run.rst
@@ -212,6 +212,8 @@ Planemo command for running tools and jobs.
       --galaxy_user_key TEXT          User key to use with external Galaxy engine.
       --history_name TEXT             Name to give a Galaxy history, if one is
                                       created.
+	  --history_id TEXT               Do not create a new history. Send the results 
+	  								  of the run in the history with the provided ID.
       --no_wait                       After invoking a job or workflow, do not wait
                                       for completion.
       --paste_test_data_paths / --no_paste_test_data_paths

--- a/docs/commands/run.rst
+++ b/docs/commands/run.rst
@@ -212,8 +212,9 @@ Planemo command for running tools and jobs.
       --galaxy_user_key TEXT          User key to use with external Galaxy engine.
       --history_name TEXT             Name to give a Galaxy history, if one is
                                       created.
-	  --history_id TEXT               Do not create a new history. Send the results 
-	  								  of the run in the history with the provided ID.
+      --history_id TEXT               Send the results of the run to the history
+                                      with the provided ID. A history with this ID
+                                      must exist.
       --no_wait                       After invoking a job or workflow, do not wait
                                       for completion.
       --paste_test_data_paths / --no_paste_test_data_paths

--- a/docs/commands/shed_lint.rst
+++ b/docs/commands/shed_lint.rst
@@ -38,10 +38,9 @@ help text for mentioned URLs and checks those.
                                       (e.g. passing --skip 'citations,xml_order'
                                       would skip linting of citations and best-
                                       practice XML ordering.
+      --skip_file FILE                File containing a list of lint tests to skip
       --tools                         Lint tools discovered in the process of
                                       linting repositories.
-      --xsd / --no_xsd                Include tool XSD validation in linting
-                                      process.
       --ensure_metadata               Ensure .shed.yml files contain enough metadata
                                       for each repository to allow automated
                                       creation and/or updates.

--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -245,6 +245,9 @@ please careful and do not try this against production Galaxy instances.
       --galaxy_user_key TEXT          User key to use with external Galaxy engine.
       --history_name TEXT             Name to give a Galaxy history, if one is
                                       created.
+      --history_id TEXT               Send the results of the run to the history
+                                      with the provided ID. A history with this ID
+                                      must exist.
       --no_wait                       After invoking a job or workflow, do not wait
                                       for completion.
       --help                          Show this message and exit.

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -523,6 +523,13 @@ def history_name():
         help="Name to give a Galaxy history, if one is created.",
     )
 
+def history_id():
+    return planemo_option(
+        "--history_id",
+        type=str,
+        help="Do not create a new history. Send the results of the run in the history with the provided ID.",
+    )
+
 
 def no_cache_galaxy_option():
     return planemo_option(
@@ -1495,6 +1502,7 @@ def engine_options():
         galaxy_admin_key_option(),
         galaxy_user_key_option(),
         history_name(),
+        history_id(),
         no_wait_option(),
     )
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -523,11 +523,12 @@ def history_name():
         help="Name to give a Galaxy history, if one is created.",
     )
 
+
 def history_id():
     return planemo_option(
         "--history_id",
         type=str,
-        help="Do not create a new history. Send the results of the run in the history with the provided ID.",
+        help="Send the results of the run to the history with the provided ID. A history with this ID must exist.",
     )
 
 


### PR DESCRIPTION
Option --history_id. If provided, planemo run send the output to the given history. 
Respond to issue https://github.com/galaxyproject/planemo/issues/1448
