### PR TITLE
Add option to create a minimal markdown test report

### DIFF
--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -80,7 +80,7 @@ def handle_reports(ctx, structured_data, kwds):
         except Exception as e:
             exceptions.append(e)
 
-    for report_type in ["html", "markdown", "text", "xunit", "junit", "allure"]:
+    for report_type in ["html", "markdown", "markdown_minimal", "text", "xunit", "junit", "allure"]:
         try:
             _handle_test_output_file(ctx, report_type, structured_data, kwds)
         except Exception as e:

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1532,6 +1532,13 @@ def test_report_options():
             default=None,
         ),
         planemo_option(
+            "--test_output_markdown_minimal",
+            type=click.Path(file_okay=True, resolve_path=True),
+            use_global_config=True,
+            help=("Output test report (Minimal markdown style - jost the table)"),
+            default=None,
+        ),
+        planemo_option(
             "--test_output_xunit",
             type=click.Path(file_okay=True, resolve_path=True),
             use_global_config=True,

--- a/planemo/reports/report_markdown_minimal.tpl
+++ b/planemo/reports/report_markdown_minimal.tpl
@@ -1,0 +1,32 @@
+{% from 'macros.tmpl' import render_invocation_details, render_invocation_messages, render_job_parameters, render_steps %}
+{% if title %}
+# {{ execution_type }} {{ title }}
+
+{% endif %}
+## {{ execution_type }} Summary
+{% set state = namespace(found=false) %}
+{% set state.success = raw_data.results.total - raw_data.results.errors - raw_data.results.failures - raw_data.results.skips | default(0) %}
+{% set state.error = raw_data.results.errors | default(0) %}
+{% set state.failure = raw_data.results.failures | default(0) %}
+{% set state.skipped = raw_data.results.skipped | default(0) %}
+
+{% if raw_data.results.total %}
+<div class="progress">
+  <div class="progress-bar progress-bar-success" style="width: {{ (state.success / raw_data.results.total) * 100 }}%" aria-valuenow="{{ state.success }}" aria-valuemin="0" aria-valuemax="{{ raw_data.results.total }}" data-toggle="tooltip" title="{{state.success}} Passed">
+  </div>
+  <div class="progress-bar progress-bar-warning" style="width: {{ (state.skipped / raw_data.results.total) * 100 }}%" aria-valuenow="{{ state.skipped }}" aria-valuemin="0" aria-valuemax="{{ raw_data.results.total }}" data-toggle="tooltip" title="{{state.skipped}} Skipped">
+  </div>
+  <div class="progress-bar progress-bar-danger" style="width: {{ ((state.error + state.failure) / raw_data.results.total) * 100 }}%" aria-valuenow="{{ state.error + state.failure }}" aria-valuemin="0" aria-valuemax="{{ raw_data.results.total }}" title="{{state.error + state.failure}} Failed or Errored">
+  </div>
+</div>
+{% endif %}
+
+| {{ execution_type }} State | Count |
+| ---------- | ----- |
+| Total      | {{ raw_data.results.total | default(0)  }} |
+| Passed     | {{ state.success }} |
+| Error      | {{ state.error }} |
+| Failure    | {{ state.failure }} |
+| Skipped    | {{ state.skipped }} |
+
+

--- a/planemo/reports/report_markdown_minimal.tpl
+++ b/planemo/reports/report_markdown_minimal.tpl
@@ -30,3 +30,26 @@
 | Skipped    | {{ state.skipped }} |
 
 
+{% set display_job_attributes = {'command_line': 'Command Line', 'exit_code': 'Exit Code', 'stderr': 'Standard Error', 'stdout': 'Standard Output', 'traceback': 'Traceback'} %}
+{% for status, desc in {'error': 'Errored', 'failure': 'Failed', 'success': 'Passed'}.items() if state[status]%}
+{% set expanded = "open" if status in ("error", "failure") else "" %}
+<details {{ expanded }}><summary>{{ desc }} {{ execution_type }}s</summary>
+{%   for test in raw_data.tests %}
+{%     if test.data.status == status %}
+{%       if test.data.status == 'success' %}
+
+* <details class="rcorners light-green"><summary class="light-green">&#9989; {{ test.id|replace("#","# ") }}</summary>
+
+{%       else %}
+
+* <details class="rcorners light-red"><summary class="light-red">&#10060; {{ test.id|replace("#","# ") }}</summary>
+
+{%       endif %}
+
+    </details>
+
+{%     endif %}
+{%   endfor %}
+
+</details>
+{% endfor %}

--- a/planemo/reports/report_markdown_minimal.tpl
+++ b/planemo/reports/report_markdown_minimal.tpl
@@ -29,25 +29,16 @@
 | Failure    | {{ state.failure }} |
 | Skipped    | {{ state.skipped }} |
 
-
-{% set display_job_attributes = {'command_line': 'Command Line', 'exit_code': 'Exit Code', 'stderr': 'Standard Error', 'stdout': 'Standard Output', 'traceback': 'Traceback'} %}
 {% for status, desc in {'error': 'Errored', 'failure': 'Failed', 'success': 'Passed'}.items() if state[status]%}
 {% set expanded = "open" if status in ("error", "failure") else "" %}
 <details {{ expanded }}><summary>{{ desc }} {{ execution_type }}s</summary>
 {%   for test in raw_data.tests %}
 {%     if test.data.status == status %}
 {%       if test.data.status == 'success' %}
-
-* <details class="rcorners light-green"><summary class="light-green">&#9989; {{ test.id|replace("#","# ") }}</summary>
-
+* <summary class="light-green">&#9989; {{ test.id|replace("#","# ") }}</summary>
 {%       else %}
-
-* <details class="rcorners light-red"><summary class="light-red">&#10060; {{ test.id|replace("#","# ") }}</summary>
-
+* <summary class="light-red">&#10060; {{ test.id|replace("#","# ") }}</summary>
 {%       endif %}
-
-    </details>
-
 {%     endif %}
 {%   endfor %}
 

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -24,17 +24,13 @@ class CmdTestReportsTestCase(CliTestCase):
     def test_markdown(self):
         with self._isolate() as f:
             json_path = os.path.join(TEST_DATA_DIR, "issue381.json")
-            results_path = os.path.join(f, "minimal_markdown_results")
-            self._check_exit_code(["test_reports", "--test_output_minimal_markdown", results_path, json_path], exit_code=0)
+            results_path = os.path.join(f, "markdown_results")
+            self._check_exit_code(["test_reports", "--test_output_markdown", results_path, json_path], exit_code=0)
             assert os.path.exists(results_path)
-            assert os.path.isdir(results_path)
-            assert len(os.listdir(results_path))
 
+            # Run minimal version
             minimal_results_path = os.path.join(f, "minimal_markdown_results")
-            self._check_exit_code(["test_reports", "--test_output_minimal_markdown", minimal_results_path, json_path], exit_code=0)
+            self._check_exit_code(["test_reports", "--test_output_markdown_minimal", minimal_results_path, json_path], exit_code=0)
             assert os.path.exists(minimal_results_path)
-            assert os.path.isdir(minimal_results_path)
-            assert len(os.listdir(minimal_results_path))
-
-            minimal_markdown_results = os.path.join(minimal_results_path, "tool_test_output.md")
-            assert os.path.getsize(minimal_markdown_results) < os.path.getsize(markdown_results)
+            # Make sure minimal markdown is compacted
+            assert os.path.getsize(minimal_results_path) < os.path.getsize(results_path)

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -30,7 +30,9 @@ class CmdTestReportsTestCase(CliTestCase):
 
             # Run minimal version
             minimal_results_path = os.path.join(f, "minimal_markdown_results")
-            self._check_exit_code(["test_reports", "--test_output_markdown_minimal", minimal_results_path, json_path], exit_code=0)
+            self._check_exit_code(
+                ["test_reports", "--test_output_markdown_minimal", minimal_results_path, json_path], exit_code=0
+            )
             assert os.path.exists(minimal_results_path)
             # Make sure minimal markdown is compacted
             assert os.path.getsize(minimal_results_path) < os.path.getsize(results_path)

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -36,4 +36,5 @@ class CmdTestReportsTestCase(CliTestCase):
             assert os.path.isdir(minimal_results_path)
             assert len(os.listdir(minimal_results_path))
 
+            minimal_markdown_results = os.path.join(minimal_results_path, "tool_test_output.md")
             assert os.path.getsize(minimal_markdown_results) < os.path.getsize(markdown_results)

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -20,3 +20,20 @@ class CmdTestReportsTestCase(CliTestCase):
             assert os.path.exists(results_path)
             assert os.path.isdir(results_path)
             assert len(os.listdir(results_path))
+
+    def test_markdown(self):
+        with self._isolate() as f:
+            json_path = os.path.join(TEST_DATA_DIR, "issue381.json")
+            results_path = os.path.join(f, "minimal_markdown_results")
+            self._check_exit_code(["test_reports", "--test_output_minimal_markdown", results_path, json_path], exit_code=0)
+            assert os.path.exists(results_path)
+            assert os.path.isdir(results_path)
+            assert len(os.listdir(results_path))
+
+            minimal_results_path = os.path.join(f, "minimal_markdown_results")
+            self._check_exit_code(["test_reports", "--test_output_minimal_markdown", minimal_results_path, json_path], exit_code=0)
+            assert os.path.exists(minimal_results_path)
+            assert os.path.isdir(minimal_results_path)
+            assert len(os.listdir(minimal_results_path))
+
+            assert os.path.getsize(minimal_markdown_results) < os.path.getsize(markdown_results)


### PR DESCRIPTION
That is: only the table. Will be useful for large tests (e.g. weekly CI) where the size of the full report is to large for `GITHUB_STEP_SUMMARY`

fixes https://github.com/galaxyproject/planemo/issues/1456