### PR TITLE
Check lint skip types only for tool linting

### DIFF
--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -4,10 +4,13 @@ import click
 
 from planemo import options
 from planemo.cli import command_function
+from planemo.io import error
 from planemo.tool_lint import (
     build_tool_lint_args,
     lint_tools_on_path,
 )
+
+from galaxy.tool_util.lint import Linter
 
 
 @click.command("lint")
@@ -46,6 +49,12 @@ from planemo.tool_lint import (
 def cli(ctx, uris, **kwds):
     """Check for common errors and best practices."""
     lint_args = build_tool_lint_args(ctx, **kwds)
+
+    linters = Linter.list_linters()
+    invalid_skip_types = list(set(lint_args["skip_types"]) - set(linters))
+    if len(invalid_skip_types):
+        error(f"Unknown linter type(s) {invalid_skip_types} in list of linters to be skipped. Known linters {linters}")
+
     exit_code = lint_tools_on_path(ctx, uris, lint_args, recursive=kwds["recursive"])
 
     # TODO: rearchitect XUnit.

--- a/planemo/commands/cmd_lint.py
+++ b/planemo/commands/cmd_lint.py
@@ -1,6 +1,7 @@
 """Module describing the planemo ``lint`` command."""
 
 import click
+from galaxy.tool_util.lint import Linter
 
 from planemo import options
 from planemo.cli import command_function
@@ -9,8 +10,6 @@ from planemo.tool_lint import (
     build_tool_lint_args,
     lint_tools_on_path,
 )
-
-from galaxy.tool_util.lint import Linter
 
 
 @click.command("lint")

--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -4,10 +4,7 @@ import os
 from urllib.request import urlopen
 
 import requests
-from galaxy.tool_util.lint import (
-    LintContext,
-    Linter,
-)
+from galaxy.tool_util.lint import LintContext
 
 from planemo.io import error
 from planemo.shed import find_urls_for_xml
@@ -33,11 +30,6 @@ def build_lint_args(ctx, **kwds):
                 if not line or line.startswith("#"):
                     continue
                 skip_types.append(line)
-
-    linters = Linter.list_linters()
-    invalid_skip_types = list(set(skip_types) - set(linters))
-    if len(invalid_skip_types):
-        error(f"Unknown linter type(s) {invalid_skip_types} in list of linters to be skipped. Known linters {linters}")
 
     lint_args = dict(
         level=report_level,


### PR DESCRIPTION
the `Linter.list_linters` function only lists tool linters.