### PR TITLE
Pin galaxy-tool-util to >=24.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ bioblend>=1.0.0
 click!=8.0.2
 cwltool>=1.0.20191225192155
 ephemeris>=0.10.3
-galaxy-tool-util[edam]>=23.1,!=24.0.0,!=24.0.1,<24.2
-galaxy-util[template]>=23.1,<24.2
+galaxy-tool-util[edam]>=24.0.2,<24.2
+galaxy-util[template]>=24.0,<24.2
 glob2
 gxformat2>=0.14.0
 h5py


### PR DESCRIPTION
Follow-up on https://github.com/galaxyproject/planemo/pull/1420 which should have included these version bumps.