### PR TITLE
Display last lines of logs

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -205,13 +205,13 @@ def read_log(ctx, log_path, e: threading.Event):
                     log_fh = open(log_path, "a+")
                 log_lines = log_fh.read()
                 if log_lines:
-                    ctx.log(log_lines)
+                    ctx.log(log_lines.rstrip())
             e.wait(1)
     finally:
         if log_fh:
             log_lines = log_fh.read()
             if log_lines:
-                ctx.log(log_lines)
+                ctx.log(log_lines.rstrip())
             log_fh.close()
 
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -209,6 +209,9 @@ def read_log(ctx, log_path, e: threading.Event):
             e.wait(1)
     finally:
         if log_fh:
+            log_lines = log_fh.read()
+            if log_lines:
+                ctx.log(log_lines)
             log_fh.close()
 
 


### PR DESCRIPTION
This is especially painful if you have a cheetah templating error, and we stop the log stream before we actually printed the templating exception.

To test this run `planemo test test/functional/tools/cheetah_problem_unbound_var.xml` within Galaxy's codebase. The shutdown message and the templating exception are only visible with this PR.