### PR TITLE
Check for empty shed fields

### DIFF
--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -148,6 +148,8 @@ def lint_shed_metadata(realized_repository, lint_ctx):
         if key not in realized_repository.config:
             found_all = False
             lint_ctx.warn("Missing shed metadata field [%s] for repository" % key)
+        if realized_repository.config[key] is None:
+            lint_ctx.warn("shed metadata field [%s] was given, but is empty" % key)
     if found_all:
         lint_ctx.info("Found all shed metadata fields required for automated repository " "creation and/or updates.")
 


### PR DESCRIPTION
fixes https://github.com/galaxyproject/planemo/issues/1485

For instance if shed.yaml contains `categories:` without listing any, then in the update this gets `None`: https://github.com/galaxyproject/planemo/blob/d48552c700e511890bef6f7c8cd81f9fa20bd51e/planemo/shed/__init__.py#L683C35-L683C45

We could add a test for `None` there, and let it fail? 
