### PR TITLE
Add postgres singularity option

### DIFF
--- a/planemo/database/factory.py
+++ b/planemo/database/factory.py
@@ -5,6 +5,7 @@ from galaxy.util.commands import which
 from .interface import DatabaseSource
 from .postgres import LocalPostgresDatabaseSource
 from .postgres_docker import DockerPostgresDatabaseSource
+from .postgres_singularity import SingularityPostgresDatabaseSource
 
 
 def create_database_source(**kwds) -> DatabaseSource:
@@ -15,6 +16,8 @@ def create_database_source(**kwds) -> DatabaseSource:
             database_type = "postgres"
         elif which("docker"):
             database_type = "postgres_docker"
+        elif which("singularity"):
+            database_type = "postgres_singularity"
         else:
             raise Exception("Cannot find executables for psql or docker, cannot configure a database source.")
 
@@ -22,6 +25,8 @@ def create_database_source(**kwds) -> DatabaseSource:
         return LocalPostgresDatabaseSource(**kwds)
     elif database_type == "postgres_docker":
         return DockerPostgresDatabaseSource(**kwds)
+    elif database_type == "postgres_singularity":
+        return SingularityPostgresDatabaseSource(**kwds)
     # TODO
     # from .sqlite import SqliteDatabaseSource
     # elif database_type == "sqlite":

--- a/planemo/database/postgres_singularity.py
+++ b/planemo/database/postgres_singularity.py
@@ -1,0 +1,140 @@
+"""Module describes a :class:`DatabaseSource` for managed, dockerized postgres databases."""
+
+import os
+import subprocess
+import time
+
+from galaxy.tool_util.deps import (
+    singularity_util,
+)
+from galaxy.util.commands import execute
+
+from .interface import DatabaseSource
+from tempfile import mkdtemp
+from planemo.io import (
+    info,
+)
+from .postgres import (
+    ExecutesPostgresSqlMixin,
+)
+
+
+DEFAULT_CONTAINER_NAME = "planemopostgres"
+DEFAULT_POSTGRES_DATABASE_NAME = "galaxy"
+DEFAULT_POSTGRES_USER = "galaxy"
+DEFAULT_POSTGRES_PASSWORD = "mysecretpassword"
+DEFAULT_POSTGRES_PORT_EXPOSE = 15432
+DEFAULT_DOCKERIMAGE = "postgres:14.2-alpine3.15"
+
+
+def singularity_fetch_image():
+    fetch_command = singularity_util.pull_singularity_command(DEFAULT_DOCKERIMAGE, "./SINGULARITY_CACHE")
+    execute(fetch_command)
+
+
+def start_postgres_singularity(
+    singularity_path, container_instance_name, database_location, databasename=DEFAULT_POSTGRES_DATABASE_NAME, user=DEFAULT_POSTGRES_USER, password=DEFAULT_POSTGRES_PASSWORD, port=DEFAULT_POSTGRES_PORT_EXPOSE, **kwds
+):
+    info(f"Postgres database stored at: {database_location}")
+    pgdata_path = os.path.join(database_location, 'pgdata')
+    pgrun_path = os.path.join(database_location, 'pgrun')
+
+    if not os.path.exists(pgdata_path):
+        os.makedirs(pgdata_path)
+    if not os.path.exists(pgrun_path):
+        os.makedirs(pgrun_path)
+
+    if not os.path.exists(os.path.join(pgdata_path, 'PG_VERSION')):
+        # Run container for a short while to initialize the database
+        init_database_command = [
+            singularity_path,
+            'run',
+            '-B', f'{pgdata_path}:/var/lib/postgresql/data',
+            '-B', f'{pgrun_path}:/var/run/postgresql',
+            '-e',
+            '-C',
+            '--env', f'POSTGRES_DB={databasename}',
+            '--env', f'POSTGRES_USER={user}',
+            '--env', f'POSTGRES_PASSWORD={password}',
+            '--env', f'POSTGRES_PORT_EXPOSE={port}',
+            '--env', 'POSTGRES_INITDB_ARGS=\'--encoding=UTF-8\'',
+            f'docker://{DEFAULT_DOCKERIMAGE}',
+        ]
+
+        info(f"Initilizing postgres database in folder: {pgdata_path}")
+        process = subprocess.Popen(init_database_command,
+                                   shell=False,
+                                   stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        # Give the container time to initialize the database
+        time.sleep(10)
+        process.terminate()
+
+    # Start the singularity instance, assumes the database is
+    # already initialized since the entrypoint will not be run
+    # when starting a instance of the container.
+    run_command = [
+        singularity_path,
+        'instance',
+        'start',
+        '-B', f'{pgdata_path}:/var/lib/postgresql/data',
+        '-B', f'{pgrun_path}:/var/run/postgresql',
+        '-e',
+        '-C',
+        f'docker://{DEFAULT_DOCKERIMAGE}',
+        f'{container_instance_name}',
+    ]
+    info(f"Starting singularity instance named: {container_instance_name}")
+    execute(run_command)
+
+
+def stop_postgress_singularity(container_instance_name, **kwds):
+    info(f"Stopping singularity instance named: {container_instance_name}")
+    execute(["singularity", "instance", "stop", container_instance_name])
+
+
+class SingularityPostgresDatabaseSource(ExecutesPostgresSqlMixin, DatabaseSource):
+    """
+    Postgres database running inside a Singularity container. Should be used with
+    "with" statements to automatically start and stop the container.
+    """
+
+    def __init__(self, **kwds):
+        """Construct a postgres database source from planemo configuration."""
+
+        self.singularity_path = "singularity"
+        self.database_user = DEFAULT_POSTGRES_USER
+        self.database_password = DEFAULT_POSTGRES_PASSWORD
+        self.database_host = "localhost"  # TODO: Make docker host
+        self.database_port = DEFAULT_POSTGRES_PORT_EXPOSE
+        if 'postgres_storage_location' in kwds and kwds['postgres_storage_location'] is not None:
+            self.database_location = kwds['postgres_storage_location']
+        else:
+            self.database_location = os.path.join(mkdtemp(suffix='_planemo_postgres_db'))
+        self.container_instance_name = f'{DEFAULT_CONTAINER_NAME}-{int(time.time()*1000000)}'
+        self._kwds = kwds
+
+    def __enter__(self):
+        start_postgres_singularity(singularity_path=self.singularity_path,
+                                   database_location=self.database_location,
+                                   user=self.database_user,
+                                   password=self.database_password,
+                                   container_instance_name=self.container_instance_name,
+                                   **self._kwds)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        stop_postgress_singularity(self.container_instance_name)
+
+    def sqlalchemy_url(self, identifier):
+        """Return URL or form postgresql://username:password@localhost/mydatabase."""
+        return "postgresql://%s:%s@%s:%d/%s" % (
+            self.database_user,
+            self.database_password,
+            self.database_host,
+            self.database_port,
+            identifier,
+        )
+
+
+__all__ = ("SingularityPostgresDatabaseSource",)

--- a/planemo/database/postgres_singularity.py
+++ b/planemo/database/postgres_singularity.py
@@ -3,21 +3,13 @@
 import os
 import subprocess
 import time
+from tempfile import mkdtemp
 
-from galaxy.tool_util.deps import (
-    singularity_util,
-)
 from galaxy.util.commands import execute
 
+from planemo.io import info
 from .interface import DatabaseSource
-from tempfile import mkdtemp
-from planemo.io import (
-    info,
-)
-from .postgres import (
-    ExecutesPostgresSqlMixin,
-)
-
+from .postgres import ExecutesPostgresSqlMixin
 
 DEFAULT_CONTAINER_NAME = "planemopostgres"
 DEFAULT_POSTGRES_DATABASE_NAME = "galaxy"
@@ -27,43 +19,53 @@ DEFAULT_POSTGRES_PORT_EXPOSE = 5432
 DEFAULT_DOCKERIMAGE = "postgres:14.2-alpine3.15"
 DEFAULT_SIF_NAME = "postgres_14_2-alpine3_15.sif"
 
-DEFAULT_CONNECTION_STRING = f"postgresql://{DEFAULT_POSTGRES_USER}:{DEFAULT_POSTGRES_PASSWORD}@localhost:{DEFAULT_POSTGRES_PORT_EXPOSE}/{DEFAULT_POSTGRES_DATABASE_NAME}"   
+DEFAULT_CONNECTION_STRING = f"postgresql://{DEFAULT_POSTGRES_USER}:{DEFAULT_POSTGRES_PASSWORD}@localhost:{DEFAULT_POSTGRES_PORT_EXPOSE}/{DEFAULT_POSTGRES_DATABASE_NAME}"
 
 
 def start_postgres_singularity(
-    singularity_path, container_instance_name, database_location, databasename=DEFAULT_POSTGRES_DATABASE_NAME, user=DEFAULT_POSTGRES_USER, password=DEFAULT_POSTGRES_PASSWORD, **kwds
+    singularity_path,
+    container_instance_name,
+    database_location,
+    databasename=DEFAULT_POSTGRES_DATABASE_NAME,
+    user=DEFAULT_POSTGRES_USER,
+    password=DEFAULT_POSTGRES_PASSWORD,
+    **kwds,
 ):
     info(f"Postgres database stored at: {database_location}")
-    pgdata_path = os.path.join(database_location, 'pgdata')
-    pgrun_path = os.path.join(database_location, 'pgrun')
+    pgdata_path = os.path.join(database_location, "pgdata")
+    pgrun_path = os.path.join(database_location, "pgrun")
 
     if not os.path.exists(pgdata_path):
         os.makedirs(pgdata_path)
     if not os.path.exists(pgrun_path):
         os.makedirs(pgrun_path)
 
-    version_file = os.path.join(pgdata_path, 'PG_VERSION')
+    version_file = os.path.join(pgdata_path, "PG_VERSION")
     if not os.path.exists(version_file):
         # Run container for a short while to initialize the database
         # The database will not be initilizaed during a
-        # 'singularity instance start' command
+        # "singularity instance start" command
         init_database_command = [
             singularity_path,
-            'run',
-            '-B', f'{pgdata_path}:/var/lib/postgresql/data',
-            '-B', f'{pgrun_path}:/var/run/postgresql',
-            '-e',
-            '-C',
-            '--env', f'POSTGRES_DB={databasename}',
-            '--env', f'POSTGRES_USER={user}',
-            '--env', f'POSTGRES_PASSWORD={password}',
-            '--env', 'POSTGRES_INITDB_ARGS=\'--encoding=UTF-8\'',
+            "run",
+            "-B",
+            f"{pgdata_path}:/var/lib/postgresql/data",
+            "-B",
+            f"{pgrun_path}:/var/run/postgresql",
+            "-e",
+            "-C",
+            "--env",
+            f"POSTGRES_DB={databasename}",
+            "--env",
+            f"POSTGRES_USER={user}",
+            "--env",
+            f"POSTGRES_PASSWORD={password}",
+            "--env",
+            "POSTGRES_INITDB_ARGS='--encoding=UTF-8'",
             f"docker://{DEFAULT_DOCKERIMAGE}",
         ]
         info(f"Initilizing postgres database in folder: {pgdata_path}")
-        process = subprocess.Popen(init_database_command,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+        process = subprocess.Popen(init_database_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # Give the container time to initialize the database
         for _ in range(10):
             if os.path.exists(version_file):
@@ -80,12 +82,14 @@ def start_postgres_singularity(
     # when starting a instance of the container.
     run_command = [
         singularity_path,
-        'instance',
-        'start',
-        '-B', f'{pgdata_path}:/var/lib/postgresql/data',
-        '-B', f'{pgrun_path}:/var/run/postgresql',
-        '-e',
-        '-C',
+        "instance",
+        "start",
+        "-B",
+        f"{pgdata_path}:/var/lib/postgresql/data",
+        "-B",
+        f"{pgrun_path}:/var/run/postgresql",
+        "-e",
+        "-C",
         f"docker://{DEFAULT_DOCKERIMAGE}",
         container_instance_name,
     ]
@@ -112,20 +116,22 @@ class SingularityPostgresDatabaseSource(ExecutesPostgresSqlMixin, DatabaseSource
         self.database_password = DEFAULT_POSTGRES_PASSWORD
         self.database_host = "localhost"  # TODO: Make docker host
         self.database_port = DEFAULT_POSTGRES_PORT_EXPOSE
-        if 'postgres_storage_location' in kwds and kwds['postgres_storage_location'] is not None:
-            self.database_location = kwds['postgres_storage_location']
+        if "postgres_storage_location" in kwds and kwds["postgres_storage_location"] is not None:
+            self.database_location = kwds["postgres_storage_location"]
         else:
-            self.database_location = os.path.join(mkdtemp(suffix='_planemo_postgres_db'))
-        self.container_instance_name = f'{DEFAULT_CONTAINER_NAME}-{int(time.time()*1000000)}'
+            self.database_location = os.path.join(mkdtemp(suffix="_planemo_postgres_db"))
+        self.container_instance_name = f"{DEFAULT_CONTAINER_NAME} - {int(time.time()*1000000)}"
         self._kwds = kwds
 
     def __enter__(self):
-        start_postgres_singularity(singularity_path=self.singularity_path,
-                                   database_location=self.database_location,
-                                   user=self.database_user,
-                                   password=self.database_password,
-                                   container_instance_name=self.container_instance_name,
-                                   **self._kwds)
+        start_postgres_singularity(
+            singularity_path=self.singularity_path,
+            database_location=self.database_location,
+            user=self.database_user,
+            password=self.database_password,
+            container_instance_name=self.container_instance_name,
+            **self._kwds,
+        )
 
     def __exit__(self, exc_type, exc_value, traceback):
         stop_postgress_singularity(self.container_instance_name)

--- a/planemo/engine/factory.py
+++ b/planemo/engine/factory.py
@@ -26,7 +26,7 @@ def build_engine(ctx, **kwds):
     """Build an engine from the supplied planemo configuration."""
     engine_type_str = kwds.get("engine", "galaxy")
     if engine_type_str == "galaxy":
-        if 'database_type' in kwds and kwds['database_type'] == 'postgres_singularity':
+        if "database_type" in kwds and kwds["database_type"] == "postgres_singularity":
             engine_type = LocalManagedGalaxyEngineWithSingularityDB
         else:
             engine_type = LocalManagedGalaxyEngine

--- a/planemo/engine/factory.py
+++ b/planemo/engine/factory.py
@@ -9,6 +9,7 @@ from .galaxy import (
     DockerizedManagedGalaxyEngine,
     ExternalGalaxyEngine,
     LocalManagedGalaxyEngine,
+    LocalManagedGalaxyEngineWithSingularityDB,
 )
 from .toil import ToilEngine
 
@@ -25,7 +26,10 @@ def build_engine(ctx, **kwds):
     """Build an engine from the supplied planemo configuration."""
     engine_type_str = kwds.get("engine", "galaxy")
     if engine_type_str == "galaxy":
-        engine_type = LocalManagedGalaxyEngine
+        if 'database_type' in kwds and kwds['database_type'] == 'postgres_singularity':
+            engine_type = LocalManagedGalaxyEngineWithSingularityDB
+        else:
+            engine_type = LocalManagedGalaxyEngine
     elif engine_type_str == "docker_galaxy":
         engine_type = DockerizedManagedGalaxyEngine
     elif engine_type_str == "external_galaxy":

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -26,6 +26,7 @@ from planemo.runnable import (
     Rerunnable,
     RunnableType,
 )
+from planemo.database.postgres_singularity import SingularityPostgresDatabaseSource
 from .interface import BaseEngine
 
 if TYPE_CHECKING:
@@ -171,6 +172,13 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
         return self._kwds.copy()
 
 
+class LocalManagedGalaxyEngineWithSingularityDB(LocalManagedGalaxyEngine):
+    def run(self, runnables, job_paths, output_collectors: Optional[List[Callable]] = None):
+        with SingularityPostgresDatabaseSource(**self._kwds.copy()):
+            run_responses = super().run(runnables, job_paths, output_collectors)
+        return run_responses
+
+
 class DockerizedManagedGalaxyEngine(LocalManagedGalaxyEngine):
     """An :class:`Engine` implementation backed by Galaxy running in Docker.
 
@@ -225,4 +233,5 @@ __all__ = (
     "DockerizedManagedGalaxyEngine",
     "ExternalGalaxyEngine",
     "LocalManagedGalaxyEngine",
+    "LocalManagedGalaxyEngineWithSingularityDB",
 )

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -12,6 +12,7 @@ from typing import (
 from galaxy.tool_util.verify import interactor
 
 from planemo import io
+from planemo.database.postgres_singularity import SingularityPostgresDatabaseSource
 from planemo.galaxy.activity import (
     execute,
     execute_rerun,
@@ -26,7 +27,6 @@ from planemo.runnable import (
     Rerunnable,
     RunnableType,
 )
-from planemo.database.postgres_singularity import SingularityPostgresDatabaseSource
 from .interface import BaseEngine
 
 if TYPE_CHECKING:

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -33,8 +33,8 @@ from packaging.version import parse as parse_version
 
 from planemo import git
 from planemo.config import OptionSource
-from planemo.deps import ensure_dependency_resolvers_conf_configured
 from planemo.database import postgres_singularity
+from planemo.deps import ensure_dependency_resolvers_conf_configured
 from planemo.docker import docker_host_args
 from planemo.galaxy.workflows import (
     get_toolshed_url_for_tool_id,
@@ -1136,7 +1136,7 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
 
 
 def _database_connection(database_location, **kwds):
-    if 'database_type' in kwds and kwds['database_type'] == 'postgres_singularity':
+    if "database_type" in kwds and kwds["database_type"] == "postgres_singularity":
         default_connection = postgres_singularity.DEFAULT_CONNECTION_STRING
     else:
         default_connection = DATABASE_LOCATION_TEMPLATE % database_location

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -34,6 +34,7 @@ from packaging.version import parse as parse_version
 from planemo import git
 from planemo.config import OptionSource
 from planemo.deps import ensure_dependency_resolvers_conf_configured
+from planemo.database import postgres_singularity
 from planemo.docker import docker_host_args
 from planemo.galaxy.workflows import (
     get_toolshed_url_for_tool_id,
@@ -1135,7 +1136,10 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
 
 
 def _database_connection(database_location, **kwds):
-    default_connection = DATABASE_LOCATION_TEMPLATE % database_location
+    if 'database_type' in kwds and kwds['database_type'] == 'postgres_singularity':
+        default_connection = postgres_singularity.DEFAULT_CONNECTION_STRING
+    else:
+        default_connection = DATABASE_LOCATION_TEMPLATE % database_location
     database_connection = kwds.get("database_connection") or default_connection
     return database_connection
 

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -85,16 +85,20 @@ def _create_profile_local(ctx, profile_directory, profile_name, kwds):
             database_type = "postgres"
         elif which("docker"):
             database_type = "postgres_docker"
+        elif which("singularity"):
+            database_type = "postgres_singularity"
         else:
             database_type = "sqlite"
 
-    if database_type != "sqlite":
+    if database_type not in ["sqlite", "postgres_singularity"]:
         database_source = create_database_source(**kwds)
         database_identifier = _profile_to_database_identifier(profile_name)
         database_source.create_database(
             database_identifier,
         )
         database_connection = database_source.sqlalchemy_url(database_identifier)
+    elif database_type == "postgres_singularity":
+        database_connection + database_source.sqlalchemy_url(database_identifier)
     else:
         database_location = os.path.join(profile_directory, "galaxy.sqlite")
         database_connection = DATABASE_LOCATION_TEMPLATE % database_location

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1222,6 +1222,7 @@ def galaxy_config_options():
         profile_database_options(),
         file_path_option(),
         database_connection_option(),
+        postgres_database_storage_location_option(),
         shed_tools_conf_option(),
         shed_tools_directory_option(),
         single_user_mode_option(),
@@ -1587,6 +1588,16 @@ def postgres_datatype_type_option():
     )
 
 
+def postgres_database_storage_location_option():
+    return planemo_option(
+        "--postgres-storage-location",
+        type=str,
+        help="storage path for postgres database, used for local singularity postgres.",
+        default=None,
+        use_global_config=True,
+    )
+
+
 def no_wait_option():
     return planemo_option(
         "--no_wait",
@@ -1605,6 +1616,7 @@ def database_type_option():
             [
                 "postgres",
                 "postgres_docker",
+                "postgres_singularity",
                 "sqlite",
                 "auto",
             ]
@@ -1612,10 +1624,11 @@ def database_type_option():
         use_global_config=True,
         help=(
             "Type of database to use for profile - "
-            "'auto', 'sqlite', 'postgres', and 'postgres_docker' are available options. "
+            "'auto', 'sqlite', 'postgres', 'postgres_docker' , and postgres_singularity are available options. "
             "Use postgres to use an existing postgres server you user can "
             "access without a password via the psql command. Use postgres_docker "
-            "to have Planemo manage a docker container running postgres. "
+            "to have Planemo manage a docker container running postgres. . Use "
+            " postgres_singularity to have Planemo run postgres using singularity/apptainer. "
             "Data with postgres_docker is not yet persisted past when you restart "
             "the docker container launched by Planemo so be careful with this option."
         ),


### PR DESCRIPTION
Hi!

I’ve been experimenting with running Planemo on the TACC server using SLURM, and I ran into an issue where more complex workflows would fail due to the SQLite database being locked.

Since I don’t have the ability to launch a Docker container for database access on TACC, nor access to an external database, I developed a solution: running a PostgreSQL database within a Singularity container. However, I wanted to avoid manually starting the Singularity container each time. This pull request introduces functionality that allows Planemo to automatically launch a Singularity instance for the PostgreSQL database and stop it once the workflow completes (or fails).

While I’m unsure if this feature will be useful to others, it was extremely helpful during my testing with Planemo.