### PR TITLE
Print stdout stderr if install command fails

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1326,9 +1326,7 @@ def _install_with_command(ctx, galaxy_root, env, kwds):
         setup_venv_command,
         COMMAND_STARTUP_COMMAND,
     )
-    exit_code = shell(install_cmd, cwd=galaxy_root, env=env)
-    if exit_code != 0:
-        raise Exception(f"Failed to install Galaxy via command [{install_cmd}]")
+    communicate(install_cmd, default_err_msg="Failed to install Galaxy via command", cwd=galaxy_root, env=env)
     if not os.path.exists(galaxy_root):
         raise Exception(f"Failed to create Galaxy directory [{galaxy_root}]")
     if not os.path.exists(os.path.join(galaxy_root, "lib")):

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -33,7 +33,7 @@ def args_to_str(args):
         return commands.argv_to_str(args)
 
 
-def communicate(cmds, **kwds):
+def communicate(cmds, default_err_msg: str = "Problem executing commands", **kwds):
     """Execute shell command and wait for output.
 
     With click-aware I/O handling, pretty display of the command being executed,
@@ -48,7 +48,7 @@ def communicate(cmds, **kwds):
         output = p.communicate()
 
     if p.returncode != 0:
-        msg = f"Problem executing commands {cmd_string} - ({output[0]}, {output[1]})"
+        msg = f"{default_err_msg} [{cmd_string}] - ({output[0]}, {output[1]})"
         raise RuntimeError(msg)
     return output
 

--- a/tests/test_github_create_release.py
+++ b/tests/test_github_create_release.py
@@ -76,7 +76,7 @@ def test_add_dir_contents_to_repo():
                 notes="The big release!",
                 dry_run=False,
             )
-        assert "Problem executing commands git push" in str(excinfo.value)
+        assert "Problem executing commands [git push" in str(excinfo.value)
 
 
 def test_add_dir_contents_to_repo_dry_run():


### PR DESCRIPTION
This is more helpful than `Failed to install Galaxy via command [{command}]`.