### PR TITLE
Overhaul Galaxy job config handling.

### DIFF
--- a/planemo/commands/cmd_config_init.py
+++ b/planemo/commands/cmd_config_init.py
@@ -12,6 +12,7 @@ from planemo import (
 from planemo.cli import command_function
 from planemo.io import (
     info,
+    launch_if_open_flagged,
     warn,
 )
 
@@ -44,6 +45,7 @@ SUCCESS_MESSAGE = "Wrote configuration template to %s, please open with editor a
 
 @click.command("config_init")
 @options.optional_project_arg(exists=None)
+@options.open_file_option()
 @click.option("--template", default=None)
 @command_function
 def cli(ctx, path, template=None, **kwds):
@@ -59,3 +61,4 @@ def cli(ctx, path, template=None, **kwds):
     with open(config_path, "w") as f:
         f.write(CONFIG_TEMPLATE)
         info(SUCCESS_MESSAGE % config_path)
+    launch_if_open_flagged(config_path, **kwds)

--- a/planemo/commands/cmd_dockstore_init.py
+++ b/planemo/commands/cmd_dockstore_init.py
@@ -6,6 +6,7 @@ import click
 
 from planemo import options
 from planemo.cli import command_function
+from planemo.io import launch_if_open_flagged
 from planemo.workflow_lint import (
     DOCKSTORE_REGISTRY_CONF,
     generate_dockstore_yaml,
@@ -15,6 +16,7 @@ from planemo.workflow_lint import (
 @click.command("dockstore_init")
 @options.optional_project_arg()
 @options.publish_dockstore_option()
+@options.open_file_option()
 @command_function
 def cli(ctx, path=".", **kwds):
     """Initialize a .dockstore.yml configuration file for workflows in directory.
@@ -32,3 +34,4 @@ def cli(ctx, path=".", **kwds):
     contents = generate_dockstore_yaml(path, kwds["publish"])
     with open(dockstore_path, "w") as f:
         f.write(contents)
+    launch_if_open_flagged(dockstore_path, **kwds)

--- a/planemo/commands/cmd_job_config_init.py
+++ b/planemo/commands/cmd_job_config_init.py
@@ -1,0 +1,51 @@
+"""Module describing the planemo ``project_init`` command."""
+
+import os
+import sys
+
+import click
+from gxjobconfinit import (
+    build_job_config,
+    ConfigArgs,
+)
+from gxjobconfinit.generate import DevelopmentContext
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy.config import get_all_tool_path_from_kwds
+from planemo.io import (
+    info,
+    launch_if_open_flagged,
+    warn,
+)
+from planemo.runnable import for_paths
+from planemo.tools import uris_to_paths
+
+SUCCESS_MESSAGE = "Wrote configuration template to %s, please open with editor to customize if needed."
+
+
+@click.command("job_config_init")
+@options.optional_tools_arg(multiple=True, allow_uris=True)
+@options.open_file_option()
+@options.job_config_init_options()
+@command_function
+def cli(ctx, uris, **kwds):
+    """Initialize an small Galaxy job config file for hosted workflow runs."""
+    config_path = "job_conf.yml"
+    if os.path.exists(config_path):
+        warn(f"File '{config_path}' already exists, exiting.")
+        sys.exit(1)
+
+    paths = uris_to_paths(ctx, uris)
+    runnables = for_paths(paths)
+    tool_paths = get_all_tool_path_from_kwds(runnables, **kwds)
+    dev_context = DevelopmentContext(
+        kwds.get("test_data", None),
+        tool_paths,
+    )
+    init_config = ConfigArgs.from_dict(**kwds)
+    job_config = build_job_config(init_config, dev_context)
+    with open(config_path, "w") as f:
+        f.write(job_config)
+        info(SUCCESS_MESSAGE % config_path)
+    launch_if_open_flagged(config_path, **kwds)

--- a/planemo/commands/cmd_open.py
+++ b/planemo/commands/cmd_open.py
@@ -5,7 +5,7 @@ import click
 from planemo.cli import command_function
 
 
-@click.command("docs")
+@click.command("open")
 @click.argument(
     "path",
     metavar="PATH",

--- a/planemo/commands/cmd_profile_job_config_init.py
+++ b/planemo/commands/cmd_profile_job_config_init.py
@@ -1,0 +1,30 @@
+"""Module describing the planemo ``project_init`` command."""
+
+import click
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy import profiles
+from planemo.io import (
+    info,
+    launch_if_open_flagged,
+    warn,
+)
+
+SUCCESS_MESSAGE = "Wrote configuration template to %s for your profile, please open with editor to customize if needed."
+
+
+@click.command("profile_job_config_init")
+@options.profile_name_argument()
+@options.open_file_option()
+@options.job_config_init_options()
+@command_function
+def cli(ctx, profile_name, **kwds):
+    """Initialize a Galaxy job configuration for specified profile."""
+    if not profiles.profile_exists(ctx, profile_name, **kwds):
+        warn(f"Profile '{profile_name}' does not exist, exiting.")
+        pass
+
+    config_path = profiles.initialize_job_config(ctx, profile_name, **kwds)
+    info(SUCCESS_MESSAGE % config_path)
+    launch_if_open_flagged(config_path, **kwds)

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -425,3 +425,8 @@ def coalesce_return_codes(ret_codes, assert_at_least_one=False):
         coalesced_return_code = 255 + coalesced_return_code
 
     return coalesced_return_code
+
+
+def launch_if_open_flagged(file, **kwd):
+    if kwd.get("open"):
+        click.launch(file)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -4,8 +4,12 @@ import functools
 import os
 
 import click
-from galaxy.tool_util.deps import docker_util
+from galaxy.tool_util.deps import (
+    docker_util,
+    singularity_util,
+)
 from galaxy.tool_util.verify.interactor import DEFAULT_TOOL_TEST_WAIT
+from gxjobconfinit.types import Runner
 
 from .config import planemo_option
 
@@ -17,6 +21,14 @@ def force_option(what="files"):
         "--force",
         is_flag=True,
         help="Overwrite existing %s if present." % what,
+    )
+
+
+def open_file_option():
+    return planemo_option(
+        "--open",
+        is_flag=True,
+        help="Open the file in your default editor after creation.",
     )
 
 
@@ -177,7 +189,7 @@ def galaxy_python_version():
         "--galaxy_python_version",
         use_global_config=True,
         default=None,
-        type=click.Choice(["3", "3.7", "3.8", "3.9", "3.10", "3.11"]),
+        type=click.Choice(["3", "3.8", "3.9", "3.10", "3.11", "3.12"]),
         help="Python version to start Galaxy under",
     )
 
@@ -190,6 +202,27 @@ def galaxy_root_option():
         use_env_var=True,
         type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
         help="Root of development galaxy directory to execute command with.",
+    )
+
+
+def galaxy_version_option():
+    return planemo_option(
+        "--galaxy_version",
+        type=str,
+        default="24.2",
+        help="Version of Galaxy to target for configuration (default 24.2).",
+    )
+
+
+def tpv_option():
+    return planemo_option(
+        "--tpv/--no_tpv",
+        is_flag=True,
+        default=False,
+        help=(
+            "Include TPV (Total Perspective Vortex) configuration and shared usegalaxy* "
+            "database of tool cores and memory for allocation purposes. "
+        ),
     )
 
 
@@ -415,6 +448,25 @@ def job_config_option():
     )
 
 
+class EnumType(click.Choice):
+    def __init__(self, enum):
+        self._enum = enum
+        super().__init__([e.value for e in enum])
+
+    def convert(self, value, param, ctx):
+        return self._enum(super().convert(value, param, ctx))
+
+
+def runner_target_option():
+    return planemo_option(
+        "--runner",
+        type=EnumType(Runner),
+        help="Galaxy runner (e.g. DRM) to target.",
+        default=Runner.LOCAL,
+        use_global_config=False,
+    )
+
+
 def tool_data_path_option():
     return planemo_option(
         "--tool_data_path",
@@ -478,6 +530,24 @@ def docker_extra_volume_option():
         use_global_config=True,
         multiple=True,
         help=("Extra path to mount if --engine docker or `--biocontainers` or `--docker`."),
+    )
+
+
+def singularity_extra_volume_option():
+    arg_type = click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        resolve_path=True,
+    )
+    return planemo_option(
+        "--singularity_extra_volume",
+        type=arg_type,
+        default=None,
+        use_global_config=True,
+        multiple=True,
+        help=("Extra path to mount if --engine docker or `--biocontainers` or `--singularity`."),
     )
 
 
@@ -948,6 +1018,12 @@ def docker_enable_option():
     return planemo_option("--docker/--no_docker", default=False, help=("Run Galaxy tools in Docker if enabled."))
 
 
+def singularity_enable_option():
+    return planemo_option(
+        "--singularity/--no_singularity", default=False, help=("Run Galaxy tools in Singularity if enabled.")
+    )
+
+
 def docker_cmd_option():
     return planemo_option(
         "--docker_cmd",
@@ -956,8 +1032,22 @@ def docker_cmd_option():
     )
 
 
+def singularity_cmd_option():
+    return planemo_option(
+        "--singularity_cmd",
+        default=singularity_util.DEFAULT_SINGULARITY_COMMAND,
+        help="Command used to execute singularity (defaults to 'singularity').",
+    )
+
+
 def docker_sudo_option():
     return planemo_option("--docker_sudo/--no_docker_sudo", is_flag=True, help="Flag to use sudo when running docker.")
+
+
+def singularity_sudo_option():
+    return planemo_option(
+        "--singularity_sudo/--no_singularity_sudo", is_flag=True, help="Flag to use sudo when running docker."
+    )
 
 
 def docker_sudo_cmd_option():
@@ -965,6 +1055,15 @@ def docker_sudo_cmd_option():
         "--docker_sudo_cmd",
         help="sudo command to use when --docker_sudo is enabled " + "(defaults to sudo).",
         default=docker_util.DEFAULT_SUDO_COMMAND,
+        use_global_config=True,
+    )
+
+
+def singularity_sudo_cmd_option():
+    return planemo_option(
+        "--singularity_sudo_cmd",
+        help="sudo command to use when --singularity_sudo is enabled " + "(defaults to sudo).",
+        default=singularity_util.DEFAULT_SUDO_COMMAND,
         use_global_config=True,
     )
 
@@ -994,6 +1093,14 @@ def docker_config_options():
         docker_host_option(),
         docker_sudo_cmd_option(),
         docker_run_extra_arguments_option(),
+    )
+
+
+def singularity_config_options():
+    return _compose(
+        singularity_cmd_option(),
+        singularity_sudo_option(),
+        singularity_sudo_cmd_option(),
     )
 
 
@@ -2108,4 +2215,18 @@ def mulled_options():
         mulled_conda_option(),
         mulled_namespace_option(),
         mulled_action_option(),
+    )
+
+
+def job_config_init_options():
+    return _compose(
+        docker_enable_option(),
+        docker_config_options(),
+        singularity_enable_option(),
+        singularity_config_options(),
+        extra_tools_option(),
+        test_data_option(),
+        tpv_option(),
+        runner_target_option(),
+        galaxy_version_option(),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bioblend>=1.0.0
 click!=8.0.2
 cwltool>=1.0.20191225192155
 ephemeris>=0.10.3
+galaxy-job-config-init>=0.1.1
 galaxy-tool-util[edam,extended-assertions]>=24.1,<25.0
 galaxy-util[template]>=24.1,<25.0
 glob2

--- a/tests/test_cmd_job_config_init.py
+++ b/tests/test_cmd_job_config_init.py
@@ -1,0 +1,57 @@
+"""Tests for the ``job_config_init`` command."""
+
+import os
+
+import yaml
+
+from .test_utils import CliTestCase
+
+
+class CmdJobConfigInitTestCase(CliTestCase):
+    def test_job_config_init_simple(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
+            init_cmd = ["job_config_init", "--tpv"]
+            self._check_exit_code(init_cmd)
+            assert os.path.exists("job_conf.yml")
+            with open("job_conf.yml") as fh:
+                config = yaml.safe_load(fh)
+            assert config["execution"]["default"] == "tpv"
+
+    def test_job_config_singularity(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
+            init_cmd = ["job_config_init", "--tpv", "--singularity"]
+            self._check_exit_code(init_cmd)
+            assert os.path.exists("job_conf.yml")
+            with open("job_conf.yml") as fh:
+                config = yaml.safe_load(fh)
+            assert config["execution"]["default"] == "tpv"
+            assert config["execution"]["environments"]["local"]["singularity_enabled"] is True
+
+    def test_job_config_init_slurm(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
+            init_cmd = ["job_config_init", "--runner", "slurm"]
+            self._check_exit_code(init_cmd)
+            assert os.path.exists("job_conf.yml")
+            with open("job_conf.yml") as fh:
+                config = yaml.safe_load(fh)
+            assert config["execution"]["default"] == "slurm"
+
+    def test_job_config_init_25_0(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
+            init_cmd = ["job_config_init", "--tpv", "--runner", "drmaa", "--galaxy_version", "25.0"]
+            self._check_exit_code(init_cmd)
+            assert os.path.exists("job_conf.yml")
+            with open("job_conf.yml") as fh:
+                config = yaml.safe_load(fh)
+            assert config["execution"]["default"] == "tpv"
+            assert config["execution"]["environments"]["tpv"]["runner"] == "dynamic_tpv"
+
+    def test_job_config_init_24_2(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
+            init_cmd = ["job_config_init", "--tpv", "--runner", "drmaa", "--galaxy_version", "24.2"]
+            self._check_exit_code(init_cmd)
+            assert os.path.exists("job_conf.yml")
+            with open("job_conf.yml") as fh:
+                config = yaml.safe_load(fh)
+            assert config["execution"]["default"] == "tpv"
+            assert config["execution"]["environments"]["tpv"]["runner"] == "dynamic"

--- a/tests/test_cmd_profile_job_config_init.py
+++ b/tests/test_cmd_profile_job_config_init.py
@@ -1,0 +1,14 @@
+"""Tests for the ``job_config_init`` command."""
+
+from .test_utils import CliTestCase
+
+TEST_PROFILE_NAME = "profilejobtest"
+
+
+class CmdJobConfigInitTestCase(CliTestCase):
+    def test_job_config_init_simple(self):
+        with self._isolate():
+            self._check_exit_code(["profile_create", TEST_PROFILE_NAME])
+            init_cmd = ["profile_job_config_init", TEST_PROFILE_NAME]
+            self._check_exit_code(init_cmd)
+            self._check_exit_code(["profile_delete", TEST_PROFILE_NAME])


### PR DESCRIPTION
- More options from the command-line - multiple runners, TPV shared database, singularity, etc...
- Switch from job conf via XML to job conf via YAML.
- Bring in dependency on galaxy-job-config-init to handle a lot of that logic.
- Commands to assign binding a job config to a created Planemo profile.