### PR TITLE
fix lint_shed_version if there are no installable revisions

### DIFF
--- a/planemo/shed_lint.py
+++ b/planemo/shed_lint.py
@@ -163,6 +163,9 @@ def lint_shed_version(realized_repository: "RealizedRepository", lint_ctx):
         except ConnectionError:
             continue
 
+        if len(installable_revisions) == 0:
+            continue
+
         latest_installable_revision = installable_revisions[-1]
         repo_info, repo_metadata, _ = tsi.repositories.get_repository_revision_install_info(
             repo_name, repo_owner, latest_installable_revision


### PR DESCRIPTION
Happened here https://github.com/galaxyproject/tools-iuc/pull/6886 where we tried to fix a partial deployment, i.e. the toolshed repo was created, but no tool added. 