### PR TITLE
Add switch to prevent early termination of workflow runs

### DIFF
--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -30,6 +30,7 @@ from planemo.test.results import StructuredData
 @options.run_download_outputs_option()
 @options.engine_options()
 @options.test_options()
+@options.no_early_termination_option()
 @command_function
 def cli(ctx, runnable_identifier, job_path, **kwds):
     """Planemo command for running tools and jobs.

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -241,7 +241,15 @@ def _execute(  # noqa C901
 
 
 def invocation_to_run_response(
-    ctx, user_gi, runnable, invocation, polling_backoff=0, no_wait=False, start_datetime=None, log=None, early_termination=True
+    ctx,
+    user_gi,
+    runnable,
+    invocation,
+    polling_backoff=0,
+    no_wait=False,
+    start_datetime=None,
+    log=None,
+    early_termination=True,
 ):
     start_datetime = start_datetime or datetime.now()
     invocation_id = invocation["id"]
@@ -766,7 +774,13 @@ def _history_id(gi, **kwds) -> str:
 
 
 def wait_for_invocation_and_jobs(
-    ctx, invocation_id: str, history_id: str, user_gi: GalaxyInstance, no_wait: bool, polling_backoff: int, early_termination: bool
+    ctx,
+    invocation_id: str,
+    history_id: str,
+    user_gi: GalaxyInstance,
+    no_wait: bool,
+    polling_backoff: int,
+    early_termination: bool,
 ):
     ctx.vlog("Waiting for invocation [%s]" % invocation_id)
     final_invocation_state = "new"
@@ -865,17 +879,17 @@ def _wait_for_invocation_jobs(ctx, gi, invocation_id, polling_backoff=0, early_t
     def state_func():
         return _retry_on_timeouts(ctx, gi, lambda gi: gi.jobs.get_jobs(invocation_id=invocation_id))
 
-    return _wait_on_state(ctx, state_func, polling_backoff, early_termination=early_termination)
+    return _wait_on_state(state_func, polling_backoff, early_termination=early_termination)
 
 
 def _wait_for_job(gi, job_id, timeout=None):
     def state_func():
         return gi.jobs.show_job(job_id, full_details=True)
 
-    return _wait_on_state(ctx, state_func, timeout=timeout)
+    return _wait_on_state(state_func, timeout=timeout)
 
 
-def _wait_on_state(ctx, state_func, polling_backoff=0, timeout=None, early_termination=True):
+def _wait_on_state(state_func, polling_backoff=0, timeout=None, early_termination=True):
     def get_state():
         response = state_func()
         if not isinstance(response, list):
@@ -902,7 +916,6 @@ def _wait_on_state(ctx, state_func, polling_backoff=0, timeout=None, early_termi
         for terminal_state in hierarchical_fail_states:
             if terminal_state in current_states:
                 # If we got here something has failed and we can return (early)
-                ctx.log(f"Early termination.")
                 return terminal_state
         if current_non_terminal_states:
             return None

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -215,7 +215,7 @@ def _execute(  # noqa C901
             no_wait=kwds.get("no_wait", False),
             start_datetime=start_datetime,
             log=log_contents_str(config),
-            early_termination=kwds.get("no_early_termination", False),
+            early_termination=not kwds.get("no_early_termination", False),
         )
 
     else:

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -828,7 +828,7 @@ def _wait_for_invocation(ctx, gi, invocation_id, polling_backoff=0):
     def state_func():
         return _retry_on_timeouts(ctx, gi, lambda gi: gi.invocations.show_invocation(invocation_id))
 
-    return _wait_on_state(ctx, state_func, polling_backoff)
+    return _wait_on_state(state_func, polling_backoff)
 
 
 def _retry_on_timeouts(ctx, gi, f):
@@ -866,7 +866,7 @@ def _wait_for_history(ctx, gi, history_id, polling_backoff=0):
     def state_func():
         return _retry_on_timeouts(ctx, gi, lambda gi: gi.histories.show_history(history_id))
 
-    return _wait_on_state(ctx, state_func, polling_backoff)
+    return _wait_on_state(state_func, polling_backoff)
 
 
 def _wait_for_invocation_jobs(ctx, gi, invocation_id, polling_backoff=0, early_termination=True):

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -897,7 +897,7 @@ def _wait_on_state(state_func, polling_backoff=0, timeout=None, early_terminatio
             "cancelled",
             "failed",
         ]
-        if early_termination:
+        if early_termination or len(current_states & non_terminal_states) == 0:
             for terminal_state in hierarchical_fail_states:
                 if terminal_state in current_states:
                     # If we got here something has failed and we can return (early)

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -2073,10 +2073,7 @@ def no_early_termination_option():
         is_flag=True,
         default=False,
         prompt=False,
-        help=(
-            "Do not terminate when a job of a workflow fails, but other "
-            "jobs are still queued or running."
-        ),
+        help="Wait until all jobs terminate, even if some jobs have failed",
     )
 
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -2067,6 +2067,19 @@ def tool_init_example_command_option(help=EXAMPLE_COMMAND_HELP):
     )
 
 
+def no_early_termination_option():
+    return planemo_option(
+        "--no_early_termination",
+        is_flag=True,
+        default=False,
+        prompt=False,
+        help=(
+            "Do not terminate when a job of a workflow fails, but other "
+            "jobs are still queued or running."
+        ),
+    )
+
+
 def mulled_conda_option():
     return planemo_option(
         "--mulled_conda_version",


### PR DESCRIPTION
Add the `--no_early_termination` switch to prevent early termination of workflow runs.

I needed such behavior, so I implemented the switch. I'm not really familiar with the internals of planemo, so maybe it's not the best implementation, but it would be nice to work this towards getting it merged.