### PR TITLE
create provided output_directory if it doesn't exist

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -459,7 +459,10 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
         # TODO: rather than creating a directory just use
         # Galaxy paths if they are available in this
         # configuration.
-        output_directory = output_directory or tempfile.mkdtemp()
+        if output_directory:
+            os.makedirs(output_directory, exist_ok=True)
+        else:
+            output_directory = tempfile.mkdtemp()
 
         self._ctx.log("collecting outputs to directory %s" % output_directory)
 


### PR DESCRIPTION
Planemo currently fails with an error if the specified output directory does not exist, instead of creating it automatically.