### PR TITLE
Fix job handler setup

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -341,6 +341,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         pid_file = f"{server_name}.pid"
         ensure_dependency_resolvers_conf_configured(ctx, kwds, os.path.join(config_directory, "resolvers_conf.xml"))
         all_tool_paths = _all_tool_paths(runnables, galaxy_root=galaxy_root, extra_tools=kwds.get("extra_tools"))
+        kwds["all_in_one_handling"] = True
         _handle_job_config_file(config_directory, server_name, test_data_dir, all_tool_paths, kwds)
         _handle_job_metrics(config_directory, kwds)
         _handle_file_sources(config_directory, test_data_dir, kwds)
@@ -1345,7 +1346,7 @@ def _handle_job_config_file(
     if not job_config_file:
         dev_context = DevelopmentContext(
             test_data_dir,
-            all_tool_paths,
+            list(all_tool_paths),
         )
         init_config = ConfigArgs.from_dict(**kwds)
         conf_contents = build_job_config(init_config, dev_context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ bioblend>=1.0.0
 click!=8.0.2
 cwltool>=1.0.20191225192155
 ephemeris>=0.10.3
-galaxy-job-config-init>=0.1.1
+galaxy-job-config-init>=0.1.3
 galaxy-tool-util[edam,extended-assertions]>=24.1,<25.0
 galaxy-util[template]>=24.1,<25.0
 glob2


### PR DESCRIPTION
Previous version of galaxy-job-config-init wrote out a job config with an explicit handler section, which means the web process won't handle jobs, but in planemo we don't start job handling processes.