### PR TITLE
Print job errors in workflow invocation as they occur

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -41,7 +41,10 @@ from planemo.galaxy.api import (
     retry_on_timeouts,
     summarize_history,
 )
-from planemo.galaxy.invocations.api import BioblendInvocationApi
+from planemo.galaxy.invocations.api import (
+    BioblendInvocationApi,
+    JOB_ERROR_STATES,
+)
 from planemo.galaxy.invocations.polling import PollingTrackerImpl
 from planemo.galaxy.invocations.polling import wait_for_invocation_and_jobs as polling_wait_for_invocation_and_jobs
 from planemo.galaxy.invocations.progress import WorkflowProgressDisplay
@@ -808,6 +811,10 @@ def wait_for_invocation_and_jobs(
                 invocation = invocation_api.get_invocation(invocation_id)
                 history_id = invocation["history_id"]
             summarize_history(ctx, user_gi, history_id)
+        elif job_state in JOB_ERROR_STATES:
+            workflow_progress_display.workflow_progress.print_job_errors_once(
+                ctx, invocation_api, invocation_id, workflow_progress_display=workflow_progress_display
+            )
         return final_invocation_state, job_state, error_message
 
 


### PR DESCRIPTION
```
❌ Failed job b995f64c35f91d99:
   Tool ID: job_properties
   Exit code: 127
   Command line: echo 'The bool is not true' && echo 'The bool is very not true' 1>&2 && echo
'This is a different line of text.' >
'/Users/mvandenb/src/galaxy/database/files/2/0/0/dataset_200fa717-91f3-4dba-bf12-2907afc5a5b8.d
at' && sleep 5 && sh -c 'exit 2' ; exit 127
   Stdout:
     The bool is not true
   Stderr:
     The bool is very not true

╭─────────────────────────────── Invocation <efde18c7bccf1a5f> ───────────────────────────────╮
│ Steps ◆ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ◆   0% ◆ Invocation cancelled              │
│ Jobs  ◆ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ◆ 100% ◆ 2/2 terminal                      │
│ Job States ◆ 🔴 2 ◆                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────╯
```

I think this brings us a step closer to disabling the full galaxy console output