### PR TITLE
Add uvx_galaxy engine type

### DIFF
--- a/planemo/engine/factory.py
+++ b/planemo/engine/factory.py
@@ -10,6 +10,7 @@ from .galaxy import (
     ExternalGalaxyEngine,
     LocalManagedGalaxyEngine,
     LocalManagedGalaxyEngineWithSingularityDB,
+    UvxManagedGalaxyEngine,
 )
 from .toil import ToilEngine
 
@@ -19,7 +20,7 @@ UNKNOWN_ENGINE_TYPE_MESSAGE = "Unknown engine type specified [%s]."
 def is_galaxy_engine(**kwds):
     """Return True iff the engine configured is :class:`GalaxyEngine`."""
     engine_type_str = kwds.get("engine", "galaxy")
-    return engine_type_str in ["galaxy", "docker_galaxy", "external_galaxy"]
+    return engine_type_str in ["galaxy", "docker_galaxy", "external_galaxy", "uvx_galaxy"]
 
 
 def build_engine(ctx, **kwds):
@@ -34,6 +35,8 @@ def build_engine(ctx, **kwds):
         engine_type = DockerizedManagedGalaxyEngine
     elif engine_type_str == "external_galaxy":
         engine_type = ExternalGalaxyEngine
+    elif engine_type_str == "uvx_galaxy":
+        engine_type = UvxManagedGalaxyEngine
     elif engine_type_str == "cwltool":
         engine_type = CwlToolEngine
     elif engine_type_str == "toil":

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -205,17 +205,6 @@ class UvxManagedGalaxyEngine(LocalManagedGalaxyEngine):
         serve_kwds["uvx_galaxy"] = True
         return serve_kwds
 
-    @contextlib.contextmanager
-    def ensure_runnables_served(self, runnables):
-        """Ensure runnables are served using uvx Galaxy configuration."""
-        with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
-            if "install_args_list" in self._serve_kwds():
-                self.shed_install(config)
-            try:
-                yield config
-            finally:
-                config.kill()
-
 
 class ExternalGalaxyEngine(GalaxyEngine):
     """An :class:`Engine` implementation backed by an external Galaxy instance."""

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -145,7 +145,10 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
         with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
             if "install_args_list" in self._serve_kwds():
                 self.shed_install(config)
-            yield config
+            try:
+                yield config
+            finally:
+                config.kill()
 
     def shed_install(self, config):
         kwds = self._serve_kwds()
@@ -208,7 +211,10 @@ class UvxManagedGalaxyEngine(LocalManagedGalaxyEngine):
         with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
             if "install_args_list" in self._serve_kwds():
                 self.shed_install(config)
-            yield config
+            try:
+                yield config
+            finally:
+                config.kill()
 
 
 class ExternalGalaxyEngine(GalaxyEngine):

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -191,6 +191,26 @@ class DockerizedManagedGalaxyEngine(LocalManagedGalaxyEngine):
         return serve_kwds
 
 
+class UvxManagedGalaxyEngine(LocalManagedGalaxyEngine):
+    """An :class:`Engine` implementation backed by Galaxy running via uvx.
+
+    More information on Galaxy can be found at http://galaxyproject.org/.
+    """
+
+    def _serve_kwds(self):
+        serve_kwds = self._kwds.copy()
+        serve_kwds["uvx_galaxy"] = True
+        return serve_kwds
+
+    @contextlib.contextmanager
+    def ensure_runnables_served(self, runnables):
+        """Ensure runnables are served using uvx Galaxy configuration."""
+        with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
+            if "install_args_list" in self._serve_kwds():
+                self.shed_install(config)
+            yield config
+
+
 class ExternalGalaxyEngine(GalaxyEngine):
     """An :class:`Engine` implementation backed by an external Galaxy instance."""
 

--- a/planemo/galaxy/serve.py
+++ b/planemo/galaxy/serve.py
@@ -31,6 +31,8 @@ def _serve(ctx, runnables, **kwds):
     engine = kwds.get("engine", "galaxy")
     if engine == "docker_galaxy":
         kwds["dockerize"] = True
+    elif engine == "uvx_galaxy":
+        kwds["uvx_galaxy"] = True
 
     daemon = kwds.get("daemon", False)
     if daemon:

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -70,13 +70,13 @@ def run_engine_option():
     """Annotate click command as consume the --engine option."""
     return planemo_option(
         "--engine",
-        type=click.Choice(["galaxy", "docker_galaxy", "cwltool", "toil", "external_galaxy"]),
+        type=click.Choice(["galaxy", "docker_galaxy", "cwltool", "toil", "external_galaxy", "uvx_galaxy"]),
         default=None,
         use_global_config=True,
         help=(
             "Select an engine to run or test artifacts such as tools "
             "and workflows. Defaults to a local Galaxy, but running Galaxy within "
-            "a Docker container or the CWL reference implementation 'cwltool' and "
+            "a Docker container, via uvx, or the CWL reference implementation 'cwltool' and "
             "'toil' be selected."
         ),
     )
@@ -100,14 +100,14 @@ def serve_engine_option():
     """
     return planemo_option(
         "--engine",
-        type=click.Choice(["galaxy", "docker_galaxy", "external_galaxy"]),
+        type=click.Choice(["galaxy", "docker_galaxy", "external_galaxy", "uvx_galaxy"]),
         default="galaxy",
         use_global_config=True,
         use_env_var=True,
         help=(
             "Select an engine to serve artifacts such as tools "
             "and workflows. Defaults to a local Galaxy, but running Galaxy within "
-            "a Docker container."
+            "a Docker container or via uvx is also supported."
         ),
     )
 

--- a/planemo/shed/__init__.py
+++ b/planemo/shed/__init__.py
@@ -792,7 +792,7 @@ def shed_repo_type(config, name):
 
 def _shed_config_to_url(shed_config):
     url = shed_config["url"]
-    if not url.startswith("http"):
+    if url and not url.startswith("http"):
         message = f"Invalid shed url specified [{url}]. Please specify a valid HTTP address or one of {list(SHED_SHORT_NAMES.keys())}"
         raise ValueError(message)
     return url


### PR DESCRIPTION
Skips cloning and run.sh to go directly for the galaxy entrypoint. Is much faster and cleaner to boot, and you can follow along the invocation in the UI if you like.
~Does not yet install conditional dependencies.~