### PR TITLE
Fixing 429 url error

### DIFF
--- a/planemo/lint.py
+++ b/planemo/lint.py
@@ -148,7 +148,7 @@ def lint_urls(root, lint_ctx):
                 if r is not None and r.status_code == 429:
                     # too many requests
                     pass
-                if r is not None and r.status_code in [403, 503] and "cloudflare" in r.text:
+                elif r is not None and r.status_code in [403, 503] and "cloudflare" in r.text:
                     # CloudFlare protection block
                     pass
                 else:


### PR DESCRIPTION
This pull request includes a minor change to the `validate_url` function in `planemo/lint.py`. The change ensures that the else will not run when the first if has been passed.