### PR TITLE
Enable dependabot version updates for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -1706,12 +1706,18 @@ def database_identifier_argument():
     )
 
 
+def postgres_option_callback(ctx, param, value):
+    if value:
+        ctx.fail("The `--postgres` option is deprecated, use `--database_type postgres` instead.")
+    return value
+
+
 def postgres_datatype_type_option():
-    return planemo_option(
+    return click.option(
         "--postgres",
-        "database_type",
-        flag_value="postgres",
-        help=("Use postgres database type."),
+        is_flag=True,
+        hidden=True,
+        callback=postgres_option_callback,
     )
 
 


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot