### PR TITLE
Improve command not found handling

### DIFF
--- a/tests/test_planemo.py
+++ b/tests/test_planemo.py
@@ -42,3 +42,25 @@ class TestPlanemo(CliTestCase):
 
     def test_planemo_help_command(self):
         self._check_exit_code(["--help"])
+
+    def test_unknown_command_error(self):
+        """Test that unknown commands produce helpful error messages."""
+        result = self._check_exit_code(["profile_init", "--help"], exit_code=self.non_zero_exit_code)
+        # Should show error message
+        assert "No such command 'profile_init'" in result.output
+        # Should suggest similar commands
+        assert "Did you mean one of these?" in result.output
+        assert "profile_create" in result.output
+
+    def test_unknown_command_with_suggestions(self):
+        """Test that typos in commands suggest similar alternatives."""
+        result = self._check_exit_code(["workflow_tst", "--help"], exit_code=self.non_zero_exit_code)
+        assert "No such command 'workflow_tst'" in result.output
+        # Should suggest workflow commands since they start with "workflow_"
+        assert "Did you mean one of these?" in result.output
+
+    def test_completely_unknown_command(self):
+        """Test that completely invalid commands show basic error."""
+        result = self._check_exit_code(["foobar", "--help"], exit_code=self.non_zero_exit_code)
+        assert "No such command 'foobar'" in result.output
+        assert "planemo --help" in result.output


### PR DESCRIPTION
Closes https://github.com/galaxyproject/planemo/issues/1565

```
❯ planemo profile_init --help
Error: No such command 'profile_init'.

Did you mean one of these?
  - profile_create
  - profile_delete
  - profile_job_config_init
  - profile_list
  - project_init

Run 'planemo --help' to see all available commands.
```