### PR TITLE
Raise click exception where we don't need a full traceback

### DIFF
--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 
+import click
 from galaxy.util.commands import which
 from gxjobconfinit import (
     build_job_config,
@@ -56,7 +57,7 @@ def create_profile(ctx, profile_name, **kwds):
     profile_directory = _profile_directory(ctx, profile_name)
     if profile_exists(ctx, profile_name, **kwds):
         message = ALREADY_EXISTS_EXCEPTION % (profile_name, profile_directory)
-        raise Exception(message)
+        raise click.ClickException(message)
 
     os.makedirs(profile_directory)
 
@@ -177,7 +178,7 @@ def translate_alias(ctx, alias, profile_name):
 
 def _load_profile_to_json(ctx, profile_name):
     if not profile_exists(ctx, profile_name):
-        raise Exception("That profile does not exist. Create it with `planemo profile_create`")
+        raise click.ClickException("That profile does not exist. Create it with `planemo profile_create`")
     profile_directory = _profile_directory(ctx, profile_name)
     profile_options_path = _stored_profile_options_path(profile_directory)
     with open(profile_options_path) as f:
@@ -234,7 +235,7 @@ def initialize_job_config(ctx, profile_name, **kwds):
     profile_directory = _profile_directory(ctx, profile_name)
     job_config_path = os.path.join(profile_directory, "job_conf.yml")
     if os.path.exists(job_config_path):
-        raise Exception(f"File '{job_config_path}' already exists, exiting.")
+        raise click.ClickException(f"File '{job_config_path}' already exists, exiting.")
 
     init_config = ConfigArgs.from_dict(**kwds)
     job_config = build_job_config(init_config)


### PR DESCRIPTION
No point in getting the whole traceback:
```
❯ planemo profile_create usegalaxy --engine external_galaxy --galaxy_url https://usegalaxy.org --galaxy_user_key $(gopass show accounts/usegalaxy.org/m.vandenbeek@gmail.com/api_key)
Traceback (most recent call last):
  File "/Users/mvandenb/src/planemo/.venv/bin/planemo", line 10, in <module>
    sys.exit(planemo())
             ~~~~~~~^^
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/decorators.py", line 93, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/planemo/.venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/Users/mvandenb/src/planemo/planemo/cli.py", line 103, in handle_blended_options
    return f(*args, **kwds)
  File "/Users/mvandenb/src/planemo/planemo/commands/cmd_profile_create.py", line 21, in cli
    profiles.create_profile(ctx, profile_name, **kwds)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/planemo/planemo/galaxy/profiles.py", line 59, in create_profile
    raise Exception(message)
Exception: Cannot create profile with name [usegalaxy], directory [/Users/mvandenb/.planemo/profiles/usegalaxy] already exists.
```

this is better:

```
❯ planemo profile_create usegalaxy --engine external_galaxy --galaxy_url https://usegalaxy.org --galaxy_user_key $(gopass show accounts/usegalaxy.org/m.vandenbeek@gmail.com/api_key)
Error: Cannot create profile with name [usegalaxy], directory [/Users/mvandenb/.planemo/profiles/usegalaxy] already exists.
```