### PR TITLE
Adjust test_index indexing

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -24,8 +24,8 @@ from planemo.runnable_resolve import for_runnable_identifiers
     "--test_index",
     type=int,
     multiple=True,
-    help="Index(es) of specific test(s) to run (0-based). "
-    "Can be specified multiple times (e.g., --test_index 0 --test_index 2) "
+    help="Index(es) of specific test(s) to run (1-based). "
+    "Can be specified multiple times (e.g., --test_index 1 --test_index 3) "
     "to run specific tests. If not specified, all tests are run.",
     default=(),
 )

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -80,8 +80,10 @@ class BaseEngine(Engine):
 
         # Filter test cases by specified indices if provided
         test_indices = self._kwds.get("test_index", ())
+        if any(i < 1 for i in test_indices):
+            raise ValueError("test_index must be 1-based (>= 1)")
         if test_indices:
-            filtered_test_cases = [tc for i, tc in enumerate(test_cases) if i in test_indices]
+            filtered_test_cases = [tc for i, tc in enumerate(test_cases, start=1) if i in test_indices]
             if filtered_test_cases:
                 test_cases = filtered_test_cases
             else:

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -146,7 +146,7 @@ class CmdTestTestCase(CliTestCase):
             test_command += [
                 "--no_dependency_resolution",
                 "--test_index",
-                "0",
+                "1",
                 test_artifact,
             ]
             self._check_exit_code(test_command, exit_code=0)


### PR DESCRIPTION
In order to avoid confusion and keep inline with the `planemo test` stdout 1-based indexing, Changed test_index indexing from 0-based to 1-based.