### PR TITLE
shift the index to 1-based

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -24,8 +24,8 @@ from planemo.runnable_resolve import for_runnable_identifiers
     "--test_index",
     type=int,
     multiple=True,
-    help="Index(es) of specific test(s) to run (0-based). "
-    "Can be specified multiple times (e.g., --test_index 0 --test_index 2) "
+    help="Index(es) of specific test(s) to run (1-based). "
+    "Can be specified multiple times (e.g., --test_index 1 --test_index 3) "
     "to run specific tests. If not specified, all tests are run.",
     default=(),
 )

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -81,9 +81,7 @@ class BaseEngine(Engine):
         # Filter test cases by specified indices if provided
         test_indices = self._kwds.get("test_index", ())
         if test_indices:
-            filtered_test_cases = [
-                tc for i, tc in enumerate(test_cases) if (i + 1) in test_indices
-            ]
+            filtered_test_cases = [tc for i, tc in enumerate(test_cases) if (i + 1) in test_indices]
             if filtered_test_cases:
                 test_cases = filtered_test_cases
             else:

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -81,7 +81,9 @@ class BaseEngine(Engine):
         # Filter test cases by specified indices if provided
         test_indices = self._kwds.get("test_index", ())
         if test_indices:
-            filtered_test_cases = [tc for i, tc in enumerate(test_cases) if i in test_indices]
+            filtered_test_cases = [
+                tc for i, tc in enumerate(test_cases) if (i + 1) in test_indices
+            ]
             if filtered_test_cases:
                 test_cases = filtered_test_cases
             else:

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -146,7 +146,7 @@ class CmdTestTestCase(CliTestCase):
             test_command += [
                 "--no_dependency_resolution",
                 "--test_index",
-                "0",
+                "1",
                 test_artifact,
             ]
             self._check_exit_code(test_command, exit_code=0)


### PR DESCRIPTION
When planemo test is finished, the report is in 1-based index. So I think the `--test_index` should also be 1-based.