### PR TITLE
Update pin of gxformat2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ galaxy-job-config-init>=0.1.4
 galaxy-tool-util[edam,extended-assertions]>=25.1,<26.0
 galaxy-util[template]>=24.1,<26.0
 glob2
-gxformat2>=0.14.0
+gxformat2==0.23.0
 h5py
 jinja2
 lxml


### PR DESCRIPTION
seems that the latest version breaks planemo

```
Traceback (most recent call last):
  File "/home/runner/.local/bin/planemo", line 4, in <module>
    from planemo.cli import planemo
  File "/home/runner/.local/share/uv/tools/planemo/lib/python3.10/site-packages/planemo/cli.py", line 25, in <module>
    from planemo.galaxy import profiles
  File "/home/runner/.local/share/uv/tools/planemo/lib/python3.10/site-packages/planemo/galaxy/__init__.py", line 3, in <module>
    from .config import galaxy_config
  File "/home/runner/.local/share/uv/tools/planemo/lib/python3.10/site-packages/planemo/galaxy/config.py", line 48, in <module>
    from planemo.galaxy.workflows import (
  File "/home/runner/.local/share/uv/tools/planemo/lib/python3.10/site-packages/planemo/galaxy/workflows.py", line 34, in <module>
    from gxformat2.interface import (
ModuleNotFoundError: No module named 'gxformat2.interface'
```

using the same as in the galaxy pinned requirements