### PR TITLE
Allow structured reasoning of Planemo command-line interface and certain outputs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ History
 0.75.42.dev0
 ---------------------
 
+* Add structured CLI metadata and output schema exports, validate Planemo JSON
+  outputs, and write full merged test reports.
 
 ---------------------
 0.75.41 (2026-03-19)

--- a/docs/_running_external.rst
+++ b/docs/_running_external.rst
@@ -313,8 +313,20 @@ You can specify a different location with the ``--output_directory`` option:
 
     $ planemo invocation_download INVOCATION_ID --profile tutorial_profile --output_directory ./my_outputs
 
-The command also supports ``--output_json`` to write a JSON file containing
-metadata about the downloaded outputs.
+The command also supports ``--output_json`` to write a JSON manifest containing
+metadata about the downloaded outputs:
+
+::
+
+    $ planemo invocation_download INVOCATION_ID --profile tutorial_profile --output_directory ./my_outputs --output_json ./my_outputs/manifest.json
+
+The manifest includes the invocation ID, output directory, downloaded outputs,
+and outputs that were not downloaded. Optional workflow outputs that are absent
+are reported as ``skipped``; required outputs that are absent while missing
+outputs are ignored are reported as ``missing``. Paths in the manifest are
+relative to ``--output_directory`` by default. Use
+``--output_json_path_type absolute`` when absolute paths are more useful for
+automation.
 
 
 Exporting invocations as archives

--- a/docs/_writing_test_reports.rst
+++ b/docs/_writing_test_reports.rst
@@ -5,4 +5,12 @@ in certain `continuous integration`_ environments. See ``planemo test --help`` f
 more options, as well as the ``test_reports`` `command
 <http://planemo.readthedocs.io/en/latest/commands.html#test-reports-command>`__.
 
+The machine-readable JSON report written by ``--test_output_json`` uses the
+Planemo test report shape: a top-level ``version``, ``tests``, optional
+``summary``, and optional ``exit_code``. ``test_reports`` validates this JSON
+before rendering derived reports. ``merge_test_reports`` also validates each
+input report and writes the same full report shape, including recalculated
+``summary`` and ``exit_code`` fields. Older reports without ``summary`` are
+still accepted and summarized during rendering.
+
 .. _continuous integration: https://en.wikipedia.org/wiki/Continuous_integration

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -11,6 +11,7 @@ documentation describes these commands.
 .. include:: commands/ci_find_repos.rst
 .. include:: commands/ci_find_tools.rst
 .. include:: commands/ci_setup.rst
+.. include:: commands/cli_metadata.rst
 .. include:: commands/clone.rst
 .. include:: commands/conda_build.rst
 .. include:: commands/conda_env.rst
@@ -41,6 +42,7 @@ documentation describes these commands.
 .. include:: commands/mulled_init.rst
 .. include:: commands/normalize.rst
 .. include:: commands/open.rst
+.. include:: commands/output_schema.rst
 .. include:: commands/profile_create.rst
 .. include:: commands/profile_delete.rst
 .. include:: commands/profile_job_config_init.rst

--- a/docs/commands/cli_metadata.rst
+++ b/docs/commands/cli_metadata.rst
@@ -1,0 +1,23 @@
+
+``cli_metadata`` command
+========================================
+
+This section is auto-generated from the help text for the planemo command
+``cli_metadata``. This help message can be generated with ``planemo cli_metadata
+--help``.
+
+**Usage**::
+
+    planemo cli_metadata [OPTIONS]
+
+**Help**
+
+Export structured metadata for Planemo CLI commands.
+**Options**::
+
+
+      --format [json]     [default: json]
+      --command TEXT      Only export metadata for the selected command.
+      --include-internal  Include internal commands not documented as public API.
+      --help              Show this message and exit.
+    

--- a/docs/commands/invocation_download.rst
+++ b/docs/commands/invocation_download.rst
@@ -28,12 +28,16 @@ through Galaxy's web interface or through planemo.
                                       Where to store outputs of a 'run' task.
       --output_json FILE              Where to store JSON dictionary describing
                                       outputs of a 'run' task.
+      --output_json_path_type [relative|absolute]
+                                      Path style to use in the output JSON manifest.
+                                      [default: relative]
       --profile TEXT                  Name of profile (created with the
                                       profile_create command) to use with this
                                       command.
       --galaxy_url TEXT               Remote Galaxy URL to use with external Galaxy
                                       engine.
       --galaxy_user_key TEXT          User key to use with external Galaxy engine.
-      --ignore_missing_output         Ignore missing output files
+      --ignore_missing_output / --no_ignore_missing_output
+                                      Ignore missing output files
       --help                          Show this message and exit.
     

--- a/docs/commands/output_schema.rst
+++ b/docs/commands/output_schema.rst
@@ -1,0 +1,23 @@
+
+``output_schema`` command
+========================================
+
+This section is auto-generated from the help text for the planemo command
+``output_schema``. This help message can be generated with ``planemo output_schema
+--help``.
+
+**Usage**::
+
+    planemo output_schema [OPTIONS]
+
+**Help**
+
+Export JSON Schemas for Planemo machine-readable outputs.
+**Options**::
+
+
+      --format [json]                 [default: json]
+      --schema [invocation-download-manifest|run-outputs|test-report]
+                                      Only export one schema.
+      --help                          Show this message and exit.
+    

--- a/docs/commands/output_schema.rst
+++ b/docs/commands/output_schema.rst
@@ -13,11 +13,18 @@ This section is auto-generated from the help text for the planemo command
 **Help**
 
 Export JSON Schemas for Planemo machine-readable outputs.
+
+Available schemas:
+
+cli-command-metadata: output from `planemo cli_metadata --command NAME`.
+cli-metadata: output from `planemo cli_metadata`.
+invocation-download-manifest: output from `planemo invocation_download --output_json PATH`.
+run-outputs: output from `planemo run --output_json PATH`.
+test-report: output from test report JSON writers such as `planemo test --test_output_json PATH`.
 **Options**::
 
 
-      --format [json]                 [default: json]
-      --schema [invocation-download-manifest|run-outputs|test-report]
+      --schema [cli-command-metadata|cli-metadata|invocation-download-manifest|run-outputs|test-report]
                                       Only export one schema.
       --help                          Show this message and exit.
     

--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -48,8 +48,8 @@ please careful and do not try this against production Galaxy instances.
                                       produced with the same set of tool ids
                                       previously.
       --test_index INTEGER            Index(es) of specific test(s) to run
-                                      (0-based). Can be specified multiple times
-                                      (e.g., --test_index 0 --test_index 2) to run
+                                      (1-based). Can be specified multiple times
+                                      (e.g., --test_index 1 --test_index 3) to run
                                       specific tests. If not specified, all tests
                                       are run.
       --polling_backoff INTEGER       Poll resources with an increasing interval

--- a/docs/planemo.commands.rst
+++ b/docs/planemo.commands.rst
@@ -36,6 +36,14 @@ planemo.commands.cmd\_ci\_setup module
    :show-inheritance:
    :undoc-members:
 
+planemo.commands.cmd\_cli\_metadata module
+------------------------------------------
+
+.. automodule:: planemo.commands.cmd_cli_metadata
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 planemo.commands.cmd\_clone module
 ----------------------------------
 
@@ -280,6 +288,14 @@ planemo.commands.cmd\_open module
 ---------------------------------
 
 .. automodule:: planemo.commands.cmd_open
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+planemo.commands.cmd\_output\_schema module
+-------------------------------------------
+
+.. automodule:: planemo.commands.cmd_output_schema
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/planemo.rst
+++ b/docs/planemo.rst
@@ -48,6 +48,14 @@ planemo.cli module
    :show-inheritance:
    :undoc-members:
 
+planemo.cli\_metadata module
+----------------------------
+
+.. automodule:: planemo.cli_metadata
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 planemo.conda module
 --------------------
 
@@ -156,6 +164,22 @@ planemo.options module
 ----------------------
 
 .. automodule:: planemo.options
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+planemo.output\_models module
+-----------------------------
+
+.. automodule:: planemo.output_models
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+planemo.output\_schemas module
+------------------------------
+
+.. automodule:: planemo.output_schemas
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/planemo.test.rst
+++ b/docs/planemo.test.rst
@@ -12,6 +12,14 @@ planemo.test.data module
    :show-inheritance:
    :undoc-members:
 
+planemo.test.models module
+--------------------------
+
+.. automodule:: planemo.test.models
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 planemo.test.results module
 ---------------------------
 

--- a/planemo/cli.py
+++ b/planemo/cli.py
@@ -32,6 +32,10 @@ COMMAND_ALIASES = {
     "t": "test",
     "s": "serve",
 }
+INTERNAL_COMMANDS = [
+    "create_gist",
+    "shed_download",
+]
 
 
 class PlanemoCliContext(PlanemoContext):
@@ -186,6 +190,7 @@ def planemo(ctx, config, directory, verbose, configure_logging=True):
 
 __all__ = (
     "command_function",
+    "INTERNAL_COMMANDS",
     "list_cmds",
     "name_to_command",
     "planemo",

--- a/planemo/cli_metadata.py
+++ b/planemo/cli_metadata.py
@@ -1,0 +1,125 @@
+"""Structured metadata for Planemo's Click command tree."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import click
+
+from planemo import __version__
+from planemo.cli import (
+    COMMAND_ALIASES,
+    INTERNAL_COMMANDS,
+    list_cmds,
+    name_to_command,
+)
+
+SCHEMA_VERSION = "0.1"
+
+
+def iter_command_names(include_internal: bool = False) -> list[str]:
+    """Return command names included in public CLI metadata."""
+    commands = list_cmds()
+    if not include_internal:
+        commands = [command for command in commands if command not in INTERNAL_COMMANDS]
+    return commands
+
+
+def load_command_metadata(command_name: str) -> dict[str, Any]:
+    """Load metadata for one Planemo command."""
+    return serialize_click_command(command_name, name_to_command(command_name))
+
+
+def load_planemo_metadata(include_internal: bool = False) -> dict[str, Any]:
+    """Load metadata for the Planemo command line interface."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "program": "planemo",
+        "planemo_version": __version__,
+        "commands": [load_command_metadata(command_name) for command_name in iter_command_names(include_internal)],
+        "aliases": dict(sorted(COMMAND_ALIASES.items())),
+    }
+
+
+def serialize_click_command(command_name: str, command: click.Command) -> dict[str, Any]:
+    """Serialize one Click command into JSON-compatible metadata."""
+    context = click.Context(command, info_name=command_name)
+    return {
+        "name": command_name,
+        "module": f"planemo.commands.cmd_{command_name}",
+        "help": command.help,
+        "short_help": command.short_help,
+        "usage": command.get_usage(context).removeprefix("Usage: "),
+        "internal": command_name in INTERNAL_COMMANDS,
+        "hidden": getattr(command, "hidden", False),
+        "params": [serialize_click_param(param) for param in command.params],
+    }
+
+
+def serialize_click_param(param: click.Parameter) -> dict[str, Any]:
+    """Serialize one Click parameter into JSON-compatible metadata."""
+    planemo_config = getattr(param, "planemo_config", {})
+    metadata = {
+        "kind": "option" if isinstance(param, click.Option) else "argument",
+        "name": param.name,
+        "opts": list(getattr(param, "opts", [])),
+        "secondary_opts": list(getattr(param, "secondary_opts", [])),
+        "help": getattr(param, "help", None),
+        "required": param.required,
+        "human_readable_name": param.human_readable_name,
+        "multiple": param.multiple,
+        "nargs": param.nargs,
+        "type": serialize_click_type(param.type),
+        "default": _json_value(planemo_config.get("declared_default", getattr(param, "default", None))),
+        "is_flag": getattr(param, "is_flag", False),
+        "flag_value": _json_value(getattr(param, "flag_value", None)),
+        "envvar": _json_value(getattr(param, "envvar", None)),
+        "hidden": getattr(param, "hidden", False),
+        "prompt": getattr(param, "prompt", None),
+        "planemo_config": _json_value(planemo_config),
+    }
+    if isinstance(param, click.Option):
+        metadata["is_bool_flag"] = param.is_bool_flag
+    return metadata
+
+
+def serialize_click_type(param_type: click.ParamType) -> dict[str, Any]:
+    """Serialize Click parameter type details where Click exposes them."""
+    metadata: dict[str, Any] = {"name": param_type.name}
+    if isinstance(param_type, click.Choice):
+        metadata["choices"] = list(param_type.choices)
+        metadata["case_sensitive"] = param_type.case_sensitive
+    elif isinstance(param_type, click.IntRange):
+        metadata.update(
+            {
+                "min": param_type.min,
+                "max": param_type.max,
+                "min_open": param_type.min_open,
+                "max_open": param_type.max_open,
+            }
+        )
+    elif isinstance(param_type, click.FloatRange):
+        metadata.update(
+            {
+                "min": param_type.min,
+                "max": param_type.max,
+                "min_open": param_type.min_open,
+                "max_open": param_type.max_open,
+            }
+        )
+    elif isinstance(param_type, click.Path):
+        for attr in ("exists", "file_okay", "dir_okay", "writable", "readable", "resolve_path", "allow_dash"):
+            if hasattr(param_type, attr):
+                metadata[attr] = getattr(param_type, attr)
+    return _json_value(metadata)
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(nested_value) for key, nested_value in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_value(nested_value) for nested_value in value]
+    return repr(value)

--- a/planemo/cli_metadata.py
+++ b/planemo/cli_metadata.py
@@ -6,6 +6,11 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 import click
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+)
 
 from planemo import __version__
 from planemo.cli import (
@@ -18,6 +23,57 @@ from planemo.cli import (
 SCHEMA_VERSION = "0.1"
 
 
+class PlanemoClickTypeMetadata(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+
+
+class PlanemoCliParamMetadata(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    kind: str
+    name: str | None
+    opts: list[str] = Field(default_factory=list)
+    secondary_opts: list[str] = Field(default_factory=list)
+    help: str | None = None
+    required: bool
+    human_readable_name: str
+    multiple: bool
+    nargs: int
+    type: PlanemoClickTypeMetadata
+    default: Any = None
+    is_flag: bool = False
+    flag_value: Any = None
+    envvar: Any = None
+    hidden: bool = False
+    prompt: str | bool | None = None
+    planemo_config: dict[str, Any] = Field(default_factory=dict)
+
+
+class PlanemoCommandMetadata(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    module: str
+    help: str | None = None
+    short_help: str | None = None
+    usage: str
+    internal: bool
+    hidden: bool = False
+    params: list[PlanemoCliParamMetadata] = Field(default_factory=list)
+
+
+class PlanemoCliMetadata(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    schema_version: str = SCHEMA_VERSION
+    program: str = "planemo"
+    planemo_version: str
+    commands: list[PlanemoCommandMetadata] = Field(default_factory=list)
+    aliases: dict[str, str] = Field(default_factory=dict)
+
+
 def iter_command_names(include_internal: bool = False) -> list[str]:
     """Return command names included in public CLI metadata."""
     commands = list_cmds()
@@ -26,38 +82,36 @@ def iter_command_names(include_internal: bool = False) -> list[str]:
     return commands
 
 
-def load_command_metadata(command_name: str) -> dict[str, Any]:
+def load_command_metadata(command_name: str) -> PlanemoCommandMetadata:
     """Load metadata for one Planemo command."""
     return serialize_click_command(command_name, name_to_command(command_name))
 
 
-def load_planemo_metadata(include_internal: bool = False) -> dict[str, Any]:
+def load_planemo_metadata(include_internal: bool = False) -> PlanemoCliMetadata:
     """Load metadata for the Planemo command line interface."""
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "program": "planemo",
-        "planemo_version": __version__,
-        "commands": [load_command_metadata(command_name) for command_name in iter_command_names(include_internal)],
-        "aliases": dict(sorted(COMMAND_ALIASES.items())),
-    }
+    return PlanemoCliMetadata(
+        planemo_version=__version__,
+        commands=[load_command_metadata(command_name) for command_name in iter_command_names(include_internal)],
+        aliases=dict(sorted(COMMAND_ALIASES.items())),
+    )
 
 
-def serialize_click_command(command_name: str, command: click.Command) -> dict[str, Any]:
+def serialize_click_command(command_name: str, command: click.Command) -> PlanemoCommandMetadata:
     """Serialize one Click command into JSON-compatible metadata."""
     context = click.Context(command, info_name=command_name)
-    return {
-        "name": command_name,
-        "module": f"planemo.commands.cmd_{command_name}",
-        "help": command.help,
-        "short_help": command.short_help,
-        "usage": command.get_usage(context).removeprefix("Usage: "),
-        "internal": command_name in INTERNAL_COMMANDS,
-        "hidden": getattr(command, "hidden", False),
-        "params": [serialize_click_param(param) for param in command.params],
-    }
+    return PlanemoCommandMetadata(
+        name=command_name,
+        module=f"planemo.commands.cmd_{command_name}",
+        help=command.help,
+        short_help=command.short_help,
+        usage=command.get_usage(context).removeprefix("Usage: "),
+        internal=command_name in INTERNAL_COMMANDS,
+        hidden=getattr(command, "hidden", False),
+        params=[serialize_click_param(param) for param in command.params],
+    )
 
 
-def serialize_click_param(param: click.Parameter) -> dict[str, Any]:
+def serialize_click_param(param: click.Parameter) -> PlanemoCliParamMetadata:
     """Serialize one Click parameter into JSON-compatible metadata."""
     planemo_config = getattr(param, "planemo_config", {})
     metadata = {
@@ -81,10 +135,10 @@ def serialize_click_param(param: click.Parameter) -> dict[str, Any]:
     }
     if isinstance(param, click.Option):
         metadata["is_bool_flag"] = param.is_bool_flag
-    return metadata
+    return PlanemoCliParamMetadata.model_validate(metadata)
 
 
-def serialize_click_type(param_type: click.ParamType) -> dict[str, Any]:
+def serialize_click_type(param_type: click.ParamType) -> PlanemoClickTypeMetadata:
     """Serialize Click parameter type details where Click exposes them."""
     metadata: dict[str, Any] = {"name": param_type.name}
     if isinstance(param_type, click.Choice):
@@ -112,7 +166,7 @@ def serialize_click_type(param_type: click.ParamType) -> dict[str, Any]:
         for attr in ("exists", "file_okay", "dir_okay", "writable", "readable", "resolve_path", "allow_dash"):
             if hasattr(param_type, attr):
                 metadata[attr] = getattr(param_type, attr)
-    return _json_value(metadata)
+    return PlanemoClickTypeMetadata.model_validate(_json_value(metadata))
 
 
 def _json_value(value: Any) -> Any:

--- a/planemo/cli_metadata.py
+++ b/planemo/cli_metadata.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import (
+    Mapping,
+    Sequence,
+)
 from typing import Any
 
 import click

--- a/planemo/commands/cmd_cli_metadata.py
+++ b/planemo/commands/cmd_cli_metadata.py
@@ -1,0 +1,23 @@
+"""Module describing the planemo ``cli_metadata`` command."""
+
+import json
+
+import click
+
+from planemo.cli_metadata import (
+    load_command_metadata,
+    load_planemo_metadata,
+)
+
+
+@click.command("cli_metadata")
+@click.option("--format", "output_format", default="json", type=click.Choice(["json"]), show_default=True)
+@click.option("--command", "command_name", help="Only export metadata for the selected command.")
+@click.option("--include-internal", is_flag=True, help="Include internal commands not documented as public API.")
+def cli(output_format, command_name, include_internal):
+    """Export structured metadata for Planemo CLI commands."""
+    if command_name:
+        metadata = load_command_metadata(command_name)
+    else:
+        metadata = load_planemo_metadata(include_internal=include_internal)
+    click.echo(json.dumps(metadata, indent=2, sort_keys=True))

--- a/planemo/commands/cmd_cli_metadata.py
+++ b/planemo/commands/cmd_cli_metadata.py
@@ -20,4 +20,4 @@ def cli(output_format, command_name, include_internal):
         metadata = load_command_metadata(command_name)
     else:
         metadata = load_planemo_metadata(include_internal=include_internal)
-    click.echo(json.dumps(metadata, indent=2, sort_keys=True))
+    click.echo(json.dumps(metadata.model_dump(mode="json"), indent=2, sort_keys=True))

--- a/planemo/commands/cmd_database_list.py
+++ b/planemo/commands/cmd_database_list.py
@@ -7,7 +7,7 @@ from planemo.cli import command_function
 from planemo.database import create_database_source
 
 
-@click.command("database_create")
+@click.command("database_list")
 @options.profile_database_options()
 @options.docker_config_options()
 @command_function

--- a/planemo/commands/cmd_invocation_download.py
+++ b/planemo/commands/cmd_invocation_download.py
@@ -1,5 +1,6 @@
 """Module describing the planemo ``invocation_download`` command."""
 
+import json
 import os
 
 import click
@@ -10,19 +11,90 @@ from planemo.cli import command_function
 from planemo.galaxy import profiles
 from planemo.galaxy.activity import invocation_to_run_response
 from planemo.io import info
+from planemo.output_models import PlanemoInvocationDownloadManifest
+from planemo.runnable import get_outputs
 from planemo.runnable_resolve import for_runnable_identifier
+
+
+def invocation_download_manifest(
+    invocation_id,
+    output_directory,
+    outputs_dict,
+    output_json=None,
+    path_type="relative",
+    missing_output_reasons=None,
+):
+    """Build the machine-readable manifest for ``invocation_download``."""
+    output_directory = os.path.abspath(output_directory)
+    missing_output_reasons = missing_output_reasons or {}
+    outputs = {}
+    missing_outputs = []
+    for output_id, output_value in outputs_dict.items():
+        if output_value is None:
+            missing_outputs.append({"id": output_id, "reason": missing_output_reasons.get(output_id, "missing")})
+        else:
+            outputs[output_id] = _manifest_output_value(output_value, output_directory, path_type)
+
+    manifest = {
+        "invocation_id": invocation_id,
+        "output_directory": _manifest_path(output_directory, output_directory, path_type),
+        "path_type": path_type,
+        "outputs": outputs,
+        "missing_outputs": missing_outputs,
+    }
+    if output_json is not None:
+        manifest["output_json"] = _manifest_path(output_json, output_directory, path_type)
+    return manifest
+
+
+def _manifest_output_value(value, output_directory, path_type):
+    if isinstance(value, dict):
+        output_value = {}
+        for key, item in value.items():
+            if key == "path":
+                output_value[key] = _manifest_path(item, output_directory, path_type)
+            else:
+                output_value[key] = _manifest_output_value(item, output_directory, path_type)
+        return output_value
+    elif isinstance(value, list):
+        return [_manifest_output_value(item, output_directory, path_type) for item in value]
+    else:
+        return value
+
+
+def _manifest_path(path, output_directory, path_type):
+    if path_type == "absolute":
+        return os.path.abspath(path)
+    else:
+        return os.path.relpath(path, output_directory)
+
+
+def _missing_output_reasons(runnable, gi):
+    reasons = {}
+    for runnable_output in get_outputs(runnable, gi=gi):
+        output_id = runnable_output.get_id()
+        if output_id:
+            reasons[output_id] = "skipped" if runnable_output.is_optional() else "missing"
+    return reasons
 
 
 @click.command("invocation_download")
 @options.run_output_directory_option()
 @options.run_output_json_option()
+@click.option(
+    "--output_json_path_type",
+    type=click.Choice(["relative", "absolute"]),
+    default="relative",
+    show_default=True,
+    help="Path style to use in the output JSON manifest.",
+)
 @options.profile_option()
 @options.galaxy_url_option()
 @options.galaxy_user_key_option()
 @click.argument("invocation_id", type=click.STRING)
-@click.option("--ignore_missing_output", is_flag=True, default=True, help="Ignore missing output files")
+@click.option("--ignore_missing_output/--no_ignore_missing_output", default=True, help="Ignore missing output files")
 @command_function
-def cli(ctx, invocation_id, output_directory, ignore_missing_output, **kwds):
+def cli(ctx, invocation_id, output_directory, output_json_path_type, ignore_missing_output, **kwds):
     """Download output files from a completed Galaxy workflow invocation.
 
     This command allows downloading output files after a workflow has been executed
@@ -52,3 +124,16 @@ def cli(ctx, invocation_id, output_directory, ignore_missing_output, **kwds):
         os.makedirs(output_directory, exist_ok=True)
         info(f"No output_directory provided, saving to {output_directory}")
     run_response.collect_outputs(output_directory, ignore_missing_output=ignore_missing_output)
+    output_json = kwds.get("output_json")
+    if output_json:
+        manifest = invocation_download_manifest(
+            invocation_id,
+            output_directory,
+            run_response.outputs_dict,
+            output_json=output_json,
+            path_type=output_json_path_type,
+            missing_output_reasons=_missing_output_reasons(runnable, gi),
+        )
+        manifest = PlanemoInvocationDownloadManifest.model_validate(manifest).model_dump(mode="json")
+        with open(output_json, "w") as f:
+            json.dump(manifest, f, ensure_ascii=False)

--- a/planemo/commands/cmd_output_schema.py
+++ b/planemo/commands/cmd_output_schema.py
@@ -5,8 +5,8 @@ import json
 import click
 
 from planemo.output_schemas import (
-    SCHEMA_MODELS,
     load_output_schemas,
+    SCHEMA_MODELS,
 )
 
 

--- a/planemo/commands/cmd_output_schema.py
+++ b/planemo/commands/cmd_output_schema.py
@@ -1,0 +1,18 @@
+"""Module describing the planemo ``output_schema`` command."""
+
+import json
+
+import click
+
+from planemo.output_schemas import (
+    SCHEMA_MODELS,
+    load_output_schemas,
+)
+
+
+@click.command("output_schema")
+@click.option("--format", "output_format", default="json", type=click.Choice(["json"]), show_default=True)
+@click.option("--schema", "schema_name", type=click.Choice(sorted(SCHEMA_MODELS)), help="Only export one schema.")
+def cli(output_format, schema_name):
+    """Export JSON Schemas for Planemo machine-readable outputs."""
+    click.echo(json.dumps(load_output_schemas(schema_name), indent=2, sort_keys=True))

--- a/planemo/commands/cmd_output_schema.py
+++ b/planemo/commands/cmd_output_schema.py
@@ -11,8 +11,17 @@ from planemo.output_schemas import (
 
 
 @click.command("output_schema")
-@click.option("--format", "output_format", default="json", type=click.Choice(["json"]), show_default=True)
 @click.option("--schema", "schema_name", type=click.Choice(sorted(SCHEMA_MODELS)), help="Only export one schema.")
-def cli(output_format, schema_name):
-    """Export JSON Schemas for Planemo machine-readable outputs."""
+def cli(schema_name):
+    """Export JSON Schemas for Planemo machine-readable outputs.
+
+    Available schemas:
+
+    \b
+    cli-command-metadata: output from `planemo cli_metadata --command NAME`.
+    cli-metadata: output from `planemo cli_metadata`.
+    invocation-download-manifest: output from `planemo invocation_download --output_json PATH`.
+    run-outputs: output from `planemo run --output_json PATH`.
+    test-report: output from test report JSON writers such as `planemo test --test_output_json PATH`.
+    """
     click.echo(json.dumps(load_output_schemas(schema_name), indent=2, sort_keys=True))

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -13,6 +13,7 @@ from planemo.io import (
     info,
     warn,
 )
+from planemo.output_models import validated_run_outputs
 from planemo.runnable import RunnableType
 from planemo.runnable_resolve import for_runnable_identifier
 from planemo.test.results import StructuredData
@@ -67,6 +68,7 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
         output_json = kwds.get("output_json", None)
         outputs_dict = run_result.outputs_dict
         if output_json:
+            outputs_dict = validated_run_outputs(outputs_dict)
             with open(output_json, "w") as f:
                 json.dump(outputs_dict, f, ensure_ascii=False)
         info("Run completed successfully.")

--- a/planemo/commands/cmd_test_reports.py
+++ b/planemo/commands/cmd_test_reports.py
@@ -1,6 +1,7 @@
 """Module describing the planemo ``test_reports`` command."""
 
 import datetime
+import json
 import pathlib
 
 import click
@@ -12,8 +13,9 @@ from planemo import (
 from planemo.cli import command_function
 from planemo.galaxy.test import (
     handle_reports,
-    StructuredData,
 )
+from planemo.output_models import PlanemoTestReport
+from planemo.test.results import StructuredData
 
 
 @click.command("test_reports")
@@ -31,8 +33,15 @@ def cli(ctx, path, **kwds):
         io.error("Failed to tool test json file at %s" % path)
         return 1
 
-    test_data = StructuredData(path)
-    test_data.calculate_summary_data_if_needed()
+    try:
+        with open(path, encoding="utf-8") as f:
+            report_data = json.load(f)
+        PlanemoTestReport.model_validate(report_data)
+    except (OSError, ValueError) as e:
+        raise click.ClickException("Invalid Planemo test report JSON at %s: %s" % (path, e)) from e
+
+    test_data = StructuredData(data=report_data)
+    test_data.calculate_summary_data()
     file_modication_datatime = datetime.datetime.fromtimestamp(fname.stat().st_mtime)
     kwds["file_modication_datatime"] = file_modication_datatime
     handle_reports(ctx, test_data.structured_data, kwds)

--- a/planemo/config.py
+++ b/planemo/config.py
@@ -124,8 +124,22 @@ def planemo_option(*args, **kwargs) -> Callable:
         assert name
         kwargs["envvar"] = f"PLANEMO_{name.upper()}"
 
+    planemo_config = {
+        "use_global_config": use_global_config,
+        "extra_global_config_vars": extra_global_config_vars,
+        "use_env_var": use_env_var,
+    }
+    if default_specified:
+        planemo_config["declared_default"] = default
+
     option = click.option(*args, **kwargs)
-    return option
+
+    def decorator(f):
+        f = option(f)
+        f.__click_params__[-1].planemo_config = planemo_config
+        return f
+
+    return decorator
 
 
 def global_config_path(config_path: Optional[str] = None) -> str:

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -14,11 +14,18 @@ from planemo.io import (
     info,
     warn,
 )
+from planemo.output_models import (
+    PlanemoTestReport,
+    validated_test_report,
+)
 from planemo.reports import (
     allure,
     build_report,
 )
-from planemo.test.results import get_dict_value
+from planemo.test.results import (
+    StructuredData,
+    get_dict_value,
+)
 from . import structures as test_structures
 
 NO_XUNIT_REPORT_MESSAGE = (
@@ -58,15 +65,23 @@ def handle_reports_and_summary(ctx, structured_data, exit_code=None, kwds=None):
 def merge_reports(input_paths, output_path):
     reports = []
     for path in input_paths:
-        with open(path, encoding="utf-8") as f:
-            reports.append(json.load(f))
+        try:
+            with open(path, encoding="utf-8") as f:
+                reports.append(PlanemoTestReport.model_validate(json.load(f)).model_dump(mode="json"))
+        except (OSError, ValueError) as e:
+            raise click.ClickException("Invalid Planemo test report JSON at %s: %s" % (path, e)) from e
     tests = []
     for report in reports:
         tests.extend(report["tests"])
     tests = sorted(tests, key=lambda k: k["id"])
-    merged_report = {"tests": tests}
+    merged_data = StructuredData(data={"version": "0.1", "tests": tests})
+    merged_data.calculate_summary_data()
+    summary = merged_data.structured_data["summary"]
+    exit_code = EXIT_CODE_GENERIC_FAILURE if summary["num_failures"] or summary["num_errors"] else EXIT_CODE_OK
+    merged_data.set_exit_code(exit_code)
+    merged_report = PlanemoTestReport.model_validate(merged_data.structured_data).model_dump(mode="json")
     with open(output_path, mode="w", encoding="utf-8") as out:
-        out.write(unicodify(json.dumps(merged_report)))
+        out.write(unicodify(json.dumps(merged_report, indent=4, sort_keys=True)))
 
 
 def handle_reports(ctx, structured_data, kwds):
@@ -75,8 +90,9 @@ def handle_reports(ctx, structured_data, kwds):
     structured_report_file = kwds.get("test_output_json", None)
     if structured_report_file:
         try:
+            validated_structured_data = validated_test_report(structured_data)
             with open(structured_report_file, mode="w", encoding="utf-8") as f:
-                f.write(unicodify(json.dumps(structured_data, indent=4, sort_keys=True)))
+                f.write(unicodify(json.dumps(validated_structured_data, indent=4, sort_keys=True)))
         except Exception as e:
             exceptions.append(e)
 

--- a/planemo/galaxy/test/actions.py
+++ b/planemo/galaxy/test/actions.py
@@ -23,8 +23,8 @@ from planemo.reports import (
     build_report,
 )
 from planemo.test.results import (
-    StructuredData,
     get_dict_value,
+    StructuredData,
 )
 from . import structures as test_structures
 

--- a/planemo/output_models.py
+++ b/planemo/output_models.py
@@ -1,0 +1,19 @@
+"""Pydantic models for Planemo machine-readable outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import RootModel
+
+from planemo.test.models import PlanemoTestReport
+
+
+class PlanemoRunOutputs(RootModel[dict[str, Any]]):
+    """Permissive model for ``planemo run --output_json`` outputs."""
+
+
+__all__ = (
+    "PlanemoRunOutputs",
+    "PlanemoTestReport",
+)

--- a/planemo/output_models.py
+++ b/planemo/output_models.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import (
+    Any,
+    Literal,
+)
 
-from pydantic import RootModel
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+)
 
 from planemo.test.models import PlanemoTestReport
 
@@ -13,7 +21,37 @@ class PlanemoRunOutputs(RootModel[dict[str, Any]]):
     """Permissive model for ``planemo run --output_json`` outputs."""
 
 
+def validated_run_outputs(data):
+    return PlanemoRunOutputs.model_validate(data).model_dump(mode="json")
+
+
+def validated_test_report(data):
+    return PlanemoTestReport.model_validate(data).model_dump(mode="json")
+
+
+class PlanemoInvocationDownloadMissingOutput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    reason: Literal["missing", "skipped"] = "missing"
+
+
+class PlanemoInvocationDownloadManifest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    invocation_id: str
+    output_directory: str
+    path_type: Literal["relative", "absolute"] = "relative"
+    outputs: dict[str, Any]
+    missing_outputs: list[PlanemoInvocationDownloadMissingOutput] = Field(default_factory=list)
+    output_json: str | None = None
+
+
 __all__ = (
+    "PlanemoInvocationDownloadManifest",
+    "PlanemoInvocationDownloadMissingOutput",
     "PlanemoRunOutputs",
     "PlanemoTestReport",
+    "validated_run_outputs",
+    "validated_test_report",
 )

--- a/planemo/output_schemas.py
+++ b/planemo/output_schemas.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from planemo import __version__
+from planemo.cli_metadata import (
+    PlanemoCliMetadata,
+    PlanemoCommandMetadata,
+)
 from planemo.output_models import (
     PlanemoInvocationDownloadManifest,
     PlanemoRunOutputs,
@@ -14,6 +18,8 @@ from planemo.output_models import (
 SCHEMA_VERSION = "0.1"
 
 SCHEMA_MODELS = {
+    "cli-command-metadata": PlanemoCommandMetadata,
+    "cli-metadata": PlanemoCliMetadata,
     "invocation-download-manifest": PlanemoInvocationDownloadManifest,
     "run-outputs": PlanemoRunOutputs,
     "test-report": PlanemoTestReport,

--- a/planemo/output_schemas.py
+++ b/planemo/output_schemas.py
@@ -1,0 +1,42 @@
+"""JSON Schema exports for Planemo machine-readable outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from planemo import __version__
+from planemo.output_models import (
+    PlanemoRunOutputs,
+    PlanemoTestReport,
+)
+
+SCHEMA_VERSION = "0.1"
+
+SCHEMA_MODELS = {
+    "run-outputs": PlanemoRunOutputs,
+    "test-report": PlanemoTestReport,
+}
+
+
+def load_output_schemas(schema_name: str | None = None) -> dict[str, Any]:
+    """Return Planemo output JSON Schemas."""
+    schemas = {}
+    for name, model in SCHEMA_MODELS.items():
+        if schema_name is None or name == schema_name:
+            schema = model.model_json_schema()
+            schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+            schemas[name] = schema
+    if schema_name is not None and schema_name not in schemas:
+        raise KeyError(schema_name)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "planemo_version": __version__,
+        "schemas": schemas,
+    }
+
+
+__all__ = (
+    "SCHEMA_MODELS",
+    "SCHEMA_VERSION",
+    "load_output_schemas",
+)

--- a/planemo/output_schemas.py
+++ b/planemo/output_schemas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import BaseModel
+
 from planemo import __version__
 from planemo.cli_metadata import (
     PlanemoCliMetadata,
@@ -17,7 +19,7 @@ from planemo.output_models import (
 
 SCHEMA_VERSION = "0.1"
 
-SCHEMA_MODELS = {
+SCHEMA_MODELS: dict[str, type[BaseModel]] = {
     "cli-command-metadata": PlanemoCommandMetadata,
     "cli-metadata": PlanemoCliMetadata,
     "invocation-download-manifest": PlanemoInvocationDownloadManifest,

--- a/planemo/output_schemas.py
+++ b/planemo/output_schemas.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from planemo import __version__
 from planemo.output_models import (
+    PlanemoInvocationDownloadManifest,
     PlanemoRunOutputs,
     PlanemoTestReport,
 )
@@ -13,6 +14,7 @@ from planemo.output_models import (
 SCHEMA_VERSION = "0.1"
 
 SCHEMA_MODELS = {
+    "invocation-download-manifest": PlanemoInvocationDownloadManifest,
     "run-outputs": PlanemoRunOutputs,
     "test-report": PlanemoTestReport,
 }

--- a/planemo/reports/build_report.py
+++ b/planemo/reports/build_report.py
@@ -7,6 +7,8 @@ from jinja2 import (
     PackageLoader,
 )
 
+from planemo.test.results import normalize_test_status
+
 TITLE = "Results (powered by Planemo)"
 
 cancel_fragment = "Invocation scheduling cancelled because"
@@ -111,12 +113,13 @@ def __inject_summary(environment):
         total += 1
         test_data = execution.get("data")
         if test_data:
-            status = test_data.get("status")
+            status = normalize_test_status(test_data.get("status"))
+            test_data["status"] = status
             if status == "error":
                 errors += 1
             elif status == "failure":
                 failures += 1
-            elif status == "skipped":
+            elif status == "skip":
                 skips += 1
     environment["raw_data"]["results"] = {
         "total": total,

--- a/planemo/reports/report_markdown.tpl
+++ b/planemo/reports/report_markdown.tpl
@@ -8,7 +8,7 @@
 {% set state.success = raw_data.results.total - raw_data.results.errors - raw_data.results.failures - raw_data.results.skips | default(0) %}
 {% set state.error = raw_data.results.errors | default(0) %}
 {% set state.failure = raw_data.results.failures | default(0) %}
-{% set state.skipped = raw_data.results.skipped | default(0) %}
+{% set state.skipped = raw_data.results.skips | default(0) %}
 
 {% if raw_data.results.total %}
 <div class="progress">

--- a/planemo/reports/report_markdown_minimal.tpl
+++ b/planemo/reports/report_markdown_minimal.tpl
@@ -8,7 +8,7 @@
 {% set state.success = raw_data.results.total - raw_data.results.errors - raw_data.results.failures - raw_data.results.skips | default(0) %}
 {% set state.error = raw_data.results.errors | default(0) %}
 {% set state.failure = raw_data.results.failures | default(0) %}
-{% set state.skipped = raw_data.results.skipped | default(0) %}
+{% set state.skipped = raw_data.results.skips | default(0) %}
 
 {% if raw_data.results.total %}
 <div class="progress">

--- a/planemo/test/models.py
+++ b/planemo/test/models.py
@@ -29,7 +29,7 @@ class PlanemoTestSummary(BaseModel):
 class PlanemoTestCaseData(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    status: PlanemoTestStatus | None = None
+    status: PlanemoTestStatus
     inputs: dict[str, Any] | None = None
     job: dict[str, Any] | None = None
     invocation_details: dict[str, Any] | None = None

--- a/planemo/test/models.py
+++ b/planemo/test/models.py
@@ -1,0 +1,81 @@
+"""Pydantic models for Planemo machine-readable test outputs."""
+
+from __future__ import annotations
+
+from typing import (
+    Any,
+    Literal,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    field_validator,
+    model_validator,
+)
+
+PlanemoTestStatus = Literal["success", "failure", "error", "skip"]
+
+
+class PlanemoTestSummary(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    num_tests: int
+    num_failures: int
+    num_skips: int
+    num_errors: int
+
+
+class PlanemoTestCaseData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    status: PlanemoTestStatus | None = None
+    inputs: dict[str, Any] | None = None
+    job: dict[str, Any] | None = None
+    invocation_details: dict[str, Any] | None = None
+    problem_log: str | None = None
+    output_problems: list[str] | None = None
+    execution_problem: str | None = None
+    start_datetime: str | None = None
+    end_datetime: str | None = None
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def normalize_legacy_status(cls, value):
+        if value == "skipped":
+            return "skip"
+        return value
+
+
+class PlanemoTestCase(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    has_data: bool
+    data: PlanemoTestCaseData | None = None
+    doc: str | None = None
+    test_type: str | None = None
+
+    @model_validator(mode="after")
+    def require_data_when_present(self):
+        if self.has_data and self.data is None:
+            raise ValueError("data is required when has_data is true")
+        return self
+
+
+class PlanemoTestReport(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    version: str = "0.1"
+    tests: list[PlanemoTestCase]
+    summary: PlanemoTestSummary | None = None
+    exit_code: int | None = None
+
+
+__all__ = (
+    "PlanemoTestCase",
+    "PlanemoTestCaseData",
+    "PlanemoTestReport",
+    "PlanemoTestStatus",
+    "PlanemoTestSummary",
+)

--- a/planemo/test/results.py
+++ b/planemo/test/results.py
@@ -70,8 +70,11 @@ class StructuredData:
 
         for test in self.structured_data_tests:
             test_data = get_dict_value("data", test)
-            status = get_dict_value("status", test_data)
             num_tests += 1
+            if test_data is None:
+                continue
+            status = normalize_test_status(get_dict_value("status", test_data))
+            test_data["status"] = status
             if status == "skip":
                 num_skips += 1
             elif status == "failure":
@@ -122,7 +125,14 @@ def get_dict_value(key, data):
         raise KeyError(f"No key [{key}] in [{data}]")
 
 
+def normalize_test_status(status):
+    if status == "skipped":
+        return "skip"
+    return status
+
+
 __all__ = (
     "StructuredData",
     "get_dict_value",
+    "normalize_test_status",
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ lxml
 oyaml
 packaging
 pathvalidate
+pydantic>=2
 pyyaml
 ruamel.yaml
 virtualenv

--- a/scripts/commands_to_rst.py
+++ b/scripts/commands_to_rst.py
@@ -10,17 +10,13 @@ project_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_dir)
 
 from planemo import cli  # noqa: E402
-from planemo.cli import list_cmds  # noqa: E402
+from planemo.cli import (  # noqa: E402
+    INTERNAL_COMMANDS,
+    list_cmds,
+)
 
 planemo_cli = cli.planemo
 runner = CliRunner()
-
-# Don't document the following commands - they should not be considered part
-# of the planemo API.
-INTERNAL_COMMANDS = [
-    "create_gist",
-    "shed_download",
-]
 
 COMMAND_TEMPLATE = Template("""
 ``${command}`` command

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import json
+
+from planemo.cli import INTERNAL_COMMANDS
+
+from .test_utils import CliTestCase
+
+
+class TestCliMetadata(CliTestCase):
+    def test_command_names_match_modules(self):
+        for command_name in self._cli.list_cmds():
+            command = self._cli.name_to_command(command_name)
+            assert command.name == command_name
+
+    def test_internal_command_policy(self):
+        assert INTERNAL_COMMANDS == ["create_gist", "shed_download"]
+
+    def test_cli_metadata_outputs_json(self):
+        result = self._check_exit_code(["cli_metadata", "--format", "json"])
+        metadata = json.loads(result.output)
+
+        assert metadata["schema_version"] == "0.1"
+        assert metadata["program"] == "planemo"
+        assert metadata["aliases"] == {"l": "lint", "o": "open", "s": "serve", "t": "test"}
+
+        command_names = {command["name"] for command in metadata["commands"]}
+        assert "test" in command_names
+        assert "run" in command_names
+        assert "workflow_test_init" in command_names
+        assert "workflow_test_on_invocation" in command_names
+        assert "invocation_download" in command_names
+        assert "create_gist" not in command_names
+        assert "shed_download" not in command_names
+
+    def test_cli_metadata_includes_internal_when_requested(self):
+        result = self._check_exit_code(["cli_metadata", "--format", "json", "--include-internal"])
+        metadata = json.loads(result.output)
+        command_names = {command["name"] for command in metadata["commands"]}
+
+        assert "create_gist" in command_names
+        assert "shed_download" in command_names
+
+    def test_cli_metadata_for_test_command(self):
+        result = self._check_exit_code(["cli_metadata", "--format", "json", "--command", "test"])
+        metadata = json.loads(result.output)
+
+        assert metadata["name"] == "test"
+        params = {param["name"]: param for param in metadata["params"]}
+        assert "failed" in params
+        assert "test_index" in params
+        assert params["test_output_json"]["default"] == "tool_test_output.json"
+        assert "--test_output_json" in params["test_output_json"]["opts"]
+        assert "cwltool" in params["engine"]["type"]["choices"]
+
+    def test_cli_metadata_for_run_command(self):
+        result = self._check_exit_code(["cli_metadata", "--format", "json", "--command", "run"])
+        metadata = json.loads(result.output)
+
+        params = {param["name"]: param for param in metadata["params"]}
+        assert "runnable_identifier" in params
+        assert "job_path" in params
+        assert "export_format" in params
+        assert "engine" in params
+        assert "output_json" in params
+        assert "--output_json" in params["output_json"]["opts"]
+
+    def test_cli_metadata_for_workflow_test_on_invocation_command(self):
+        result = self._check_exit_code(
+            ["cli_metadata", "--format", "json", "--command", "workflow_test_on_invocation"]
+        )
+        metadata = json.loads(result.output)
+
+        arguments = [param for param in metadata["params"] if param["kind"] == "argument"]
+        assert [argument["name"] for argument in arguments] == ["path", "invocation_id"]
+        assert [argument["human_readable_name"] for argument in arguments] == ["TEST.YML", "INVOCATION_ID"]

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -65,10 +65,19 @@ class TestCliMetadata(CliTestCase):
         assert "output_json" in params
         assert "--output_json" in params["output_json"]["opts"]
 
+    def test_cli_metadata_for_invocation_download_command(self):
+        result = self._check_exit_code(["cli_metadata", "--format", "json", "--command", "invocation_download"])
+        metadata = json.loads(result.output)
+
+        params = {param["name"]: param for param in metadata["params"]}
+        assert "invocation_id" in params
+        assert "output_json" in params
+        assert "output_json_path_type" in params
+        assert params["output_json_path_type"]["type"]["choices"] == ["relative", "absolute"]
+        assert "--no_ignore_missing_output" in params["ignore_missing_output"]["secondary_opts"]
+
     def test_cli_metadata_for_workflow_test_on_invocation_command(self):
-        result = self._check_exit_code(
-            ["cli_metadata", "--format", "json", "--command", "workflow_test_on_invocation"]
-        )
+        result = self._check_exit_code(["cli_metadata", "--format", "json", "--command", "workflow_test_on_invocation"])
         metadata = json.loads(result.output)
 
         arguments = [param for param in metadata["params"] if param["kind"] == "argument"]

--- a/tests/test_cli_metadata.py
+++ b/tests/test_cli_metadata.py
@@ -3,7 +3,6 @@
 import json
 
 from planemo.cli import INTERNAL_COMMANDS
-
 from .test_utils import CliTestCase
 
 

--- a/tests/test_cmd_download_invocation_export.py
+++ b/tests/test_cmd_download_invocation_export.py
@@ -1,10 +1,13 @@
 """Module contains :class:`CmdTestTestCase` - integration tests for the ``test`` command."""
 
+import json
 import os
 import tempfile
 import time
 
 from planemo import network_util
+from planemo.output_models import PlanemoInvocationDownloadManifest
+
 from .test_cmd_serve import UsesServeCommand
 from .test_utils import (
     CliTestCase,
@@ -59,6 +62,7 @@ class CmdTestTestCase(CliTestCase, UsesServeCommand):
             output_path_download = os.path.join(f, "output_download")
             if not os.path.exists(output_path_download):
                 os.makedirs(output_path_download)
+            output_json = os.path.join(output_path_download, "manifest.json")
             run_workflow_cmd = [
                 "--verbose",
                 "run",
@@ -88,11 +92,15 @@ class CmdTestTestCase(CliTestCase, UsesServeCommand):
                 user_gi.key,
                 "--output_directory",
                 output_path_download,
+                "--output_json",
+                output_json,
+                "--output_json_path_type",
+                "absolute",
                 invocations[0]["id"],
             ]
             self._check_exit_code(download_outputs_cmd)
 
-            output_download_run_files = os.listdir(output_path_download)
+            output_download_run_files = [path for path in os.listdir(output_path_download) if path != "manifest.json"]
             output_run_files = os.listdir(output_path_org)
 
             # Compare downloading result at runtime with download the output
@@ -100,3 +108,12 @@ class CmdTestTestCase(CliTestCase, UsesServeCommand):
             assert len(output_download_run_files) == len(output_run_files)
             for i in range(len(output_download_run_files)):
                 assert output_download_run_files[i] == output_run_files[i]
+
+            with open(output_json) as f:
+                manifest = PlanemoInvocationDownloadManifest.model_validate(json.load(f))
+
+            assert manifest.invocation_id == invocations[0]["id"]
+            assert manifest.output_directory == os.path.realpath(output_path_download)
+            assert manifest.path_type == "absolute"
+            assert manifest.outputs
+            assert not manifest.missing_outputs

--- a/tests/test_cmd_download_invocation_export.py
+++ b/tests/test_cmd_download_invocation_export.py
@@ -7,7 +7,6 @@ import time
 
 from planemo import network_util
 from planemo.output_models import PlanemoInvocationDownloadManifest
-
 from .test_cmd_serve import UsesServeCommand
 from .test_utils import (
     CliTestCase,

--- a/tests/test_cmd_merge_reports.py
+++ b/tests/test_cmd_merge_reports.py
@@ -2,7 +2,6 @@ import json
 import os
 
 from planemo.test.models import PlanemoTestReport
-
 from .test_utils import (
     CliTestCase,
     TEST_DATA_DIR,

--- a/tests/test_cmd_merge_reports.py
+++ b/tests/test_cmd_merge_reports.py
@@ -1,4 +1,7 @@
+import json
 import os
+
+from planemo.test.models import PlanemoTestReport
 
 from .test_utils import (
     CliTestCase,
@@ -11,3 +14,45 @@ class CmdMergeReportsTestCase(CliTestCase):
         with self._isolate():
             json_path = os.path.join(TEST_DATA_DIR, "issue381.json")
             self._check_exit_code(["merge_test_reports", json_path, json_path, json_path, "out.json"], exit_code=0)
+
+            with open("out.json") as f:
+                merged_report = PlanemoTestReport.model_validate(json.load(f))
+
+            assert merged_report.version == "0.1"
+            assert merged_report.summary is not None
+            assert merged_report.summary.num_tests == 12
+            assert merged_report.exit_code == 1
+
+    def test_merge_reports_normalizes_legacy_skipped_status(self):
+        with self._isolate():
+            report = {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "skipped-test",
+                        "has_data": True,
+                        "data": {"status": "skipped"},
+                    }
+                ],
+            }
+            with open("skipped.json", "w") as f:
+                json.dump(report, f)
+
+            self._check_exit_code(["merge_test_reports", "skipped.json", "out.json"], exit_code=0)
+
+            with open("out.json") as f:
+                merged_report = PlanemoTestReport.model_validate(json.load(f))
+
+            assert merged_report.tests[0].data.status == "skip"
+            assert merged_report.summary.num_skips == 1
+            assert merged_report.exit_code == 0
+
+    def test_merge_reports_invalid_report_fails_with_friendly_error(self):
+        with self._isolate():
+            with open("invalid.json", "w") as f:
+                json.dump({"version": "0.1", "tests": [{"id": "bad", "has_data": True, "data": None}]}, f)
+
+            result = self._check_exit_code(["merge_test_reports", "invalid.json", "out.json"], exit_code=1)
+
+            assert "Invalid Planemo test report JSON" in result.output
+            assert "invalid.json" in result.output

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -10,6 +10,7 @@ from tempfile import (
 from unittest import skip
 
 from planemo import cli
+from planemo.test.models import PlanemoTestReport
 from .test_utils import (
     assert_exists,
     CliTestCase,
@@ -272,7 +273,10 @@ class CmdTestTestCase(CliTestCase):
             test_artifact = os.path.join(TEST_DATA_DIR, "int_tool.cwl")
             test_command = self._test_command(test_artifact)
             self._check_exit_code(test_command, exit_code=0)
-            assert_exists(os.path.join(f, "tool_test_output.json"))
+            output_json_path = os.path.join(f, "tool_test_output.json")
+            assert_exists(output_json_path)
+            with open(output_json_path) as test_json:
+                PlanemoTestReport.model_validate(json.load(test_json))
 
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_cwltool_tool_url_inputs_test(self):

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from .test_utils import (
@@ -36,3 +37,58 @@ class CmdTestReportsTestCase(CliTestCase):
             assert os.path.exists(minimal_results_path)
             # Make sure minimal markdown is compacted
             assert os.path.getsize(minimal_results_path) < os.path.getsize(results_path)
+
+    def test_markdown_counts_skip_status(self):
+        with self._isolate() as f:
+            json_path = os.path.join(f, "skipped.json")
+            markdown_path = os.path.join(f, "markdown_results")
+            report = {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "skipped-test",
+                        "has_data": True,
+                        "data": {"status": "skip"},
+                    }
+                ],
+            }
+            with open(json_path, "w") as handle:
+                json.dump(report, handle)
+
+            self._check_exit_code(["test_reports", "--test_output_markdown", markdown_path, json_path], exit_code=0)
+
+            with open(markdown_path) as handle:
+                markdown = handle.read()
+
+            assert "| Skipped    | 1 |" in markdown
+
+    def test_allure_normalizes_legacy_skipped_status(self):
+        with self._isolate() as f:
+            json_path = os.path.join(f, "skipped.json")
+            results_path = os.path.join(f, "allure_results")
+            report = {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "skipped-test",
+                        "has_data": True,
+                        "data": {"status": "skipped"},
+                    }
+                ],
+            }
+            with open(json_path, "w") as handle:
+                json.dump(report, handle)
+
+            self._check_exit_code(["test_reports", "--test_output_allure", results_path, json_path], exit_code=0)
+
+            assert os.path.exists(results_path)
+
+    def test_invalid_report_fails_with_friendly_error(self):
+        with self._isolate() as f:
+            json_path = os.path.join(f, "invalid.json")
+            with open(json_path, "w") as handle:
+                json.dump({"version": "0.1", "tests": [{"id": "bad", "has_data": True, "data": None}]}, handle)
+
+            result = self._check_exit_code(["test_reports", json_path], exit_code=1)
+
+            assert "Invalid Planemo test report JSON" in result.output

--- a/tests/test_cmds_with_workflow_id.py
+++ b/tests/test_cmds_with_workflow_id.py
@@ -5,6 +5,7 @@ import time
 
 from planemo import network_util
 from planemo.galaxy import api
+from planemo.test.models import PlanemoTestReport
 from .test_cmd_serve import UsesServeCommand
 from .test_utils import (
     CliTestCase,
@@ -94,3 +95,5 @@ class CmdsWithWorkflowIdTestCase(CliTestCase, UsesServeCommand):
                 invocation_id,
             ]
             self._check_exit_code(workflow_test_on_invocation_command, exit_code=0)
+            with open(output_json_path) as f:
+                PlanemoTestReport.model_validate(json.load(f))

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -3,12 +3,20 @@
 import json
 import os
 
+from planemo.commands.cmd_invocation_download import invocation_download_manifest
+from planemo.output_models import PlanemoInvocationDownloadManifest
+from planemo.galaxy.test.actions import handle_reports
 from planemo.test.models import PlanemoTestReport
 
 from .test_utils import (
     CliTestCase,
     TEST_DATA_DIR,
 )
+
+
+class DummyContext:
+    def vlog(self, message, exception=False):
+        pass
 
 
 class TestOutputSchema(CliTestCase):
@@ -26,6 +34,59 @@ class TestOutputSchema(CliTestCase):
 
         assert list(metadata["schemas"]) == ["run-outputs"]
         assert metadata["schemas"]["run-outputs"]["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_output_schema_exports_invocation_download_manifest_schema(self):
+        result = self._check_exit_code(
+            ["output_schema", "--format", "json", "--schema", "invocation-download-manifest"]
+        )
+        metadata = json.loads(result.output)
+
+        assert list(metadata["schemas"]) == ["invocation-download-manifest"]
+        assert (
+            metadata["schemas"]["invocation-download-manifest"]["$schema"]
+            == "https://json-schema.org/draft/2020-12/schema"
+        )
+
+    def test_invocation_download_manifest_relative_paths(self):
+        output_directory = os.path.join(os.getcwd(), "outputs")
+        output_path = os.path.join(output_directory, "answer.txt")
+        manifest = invocation_download_manifest(
+            "invocation123",
+            output_directory,
+            {
+                "answer": {"path": output_path, "basename": "answer.txt", "class": "File"},
+                "optional": None,
+            },
+            output_json=os.path.join(output_directory, "manifest.json"),
+            missing_output_reasons={"optional": "skipped"},
+        )
+
+        parsed_manifest = PlanemoInvocationDownloadManifest.model_validate(manifest)
+
+        assert parsed_manifest.path_type == "relative"
+        assert parsed_manifest.output_directory == "."
+        assert parsed_manifest.outputs["answer"]["path"] == "answer.txt"
+        assert parsed_manifest.output_json == "manifest.json"
+        assert parsed_manifest.missing_outputs[0].id == "optional"
+        assert parsed_manifest.missing_outputs[0].reason == "skipped"
+
+    def test_invocation_download_manifest_absolute_paths(self):
+        output_directory = os.path.join(os.getcwd(), "outputs")
+        output_path = os.path.join(output_directory, "answer.txt")
+        manifest = invocation_download_manifest(
+            "invocation123",
+            output_directory,
+            {"answer": {"path": output_path, "basename": "answer.txt", "class": "File"}},
+            output_json=os.path.join(output_directory, "manifest.json"),
+            path_type="absolute",
+        )
+
+        parsed_manifest = PlanemoInvocationDownloadManifest.model_validate(manifest)
+
+        assert parsed_manifest.path_type == "absolute"
+        assert parsed_manifest.output_directory == output_directory
+        assert parsed_manifest.outputs["answer"]["path"] == output_path
+        assert parsed_manifest.output_json == os.path.join(output_directory, "manifest.json")
 
     def test_issue381_validates_as_test_report(self):
         path = os.path.join(TEST_DATA_DIR, "issue381.json")
@@ -54,3 +115,45 @@ class TestOutputSchema(CliTestCase):
         )
 
         assert parsed_report.tests[0].data.status == "skip"
+
+    def test_handle_reports_validates_test_output_json_before_writing(self):
+        with self._isolate() as f:
+            output_path = os.path.join(f, "invalid.json")
+            invalid_report = {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "invalid",
+                        "has_data": True,
+                        "data": None,
+                    }
+                ],
+            }
+
+            try:
+                handle_reports(DummyContext(), invalid_report, {"test_output_json": output_path})
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("Invalid test report was written without validation error")
+
+            assert not os.path.exists(output_path)
+
+    def test_test_report_requires_status_when_data_present(self):
+        try:
+            PlanemoTestReport.model_validate(
+                {
+                    "version": "0.1",
+                    "tests": [
+                        {
+                            "id": "invalid",
+                            "has_data": True,
+                            "data": {},
+                        }
+                    ],
+                }
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Test report with data but no status validated")

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -21,7 +21,7 @@ class DummyContext:
 
 class TestOutputSchema(CliTestCase):
     def test_output_schema_exports_test_report_schema(self):
-        result = self._check_exit_code(["output_schema", "--format", "json", "--schema", "test-report"])
+        result = self._check_exit_code(["output_schema", "--schema", "test-report"])
         metadata = json.loads(result.output)
 
         assert metadata["schema_version"] == "0.1"
@@ -29,7 +29,7 @@ class TestOutputSchema(CliTestCase):
         assert metadata["schemas"]["test-report"]["$schema"] == "https://json-schema.org/draft/2020-12/schema"
 
     def test_output_schema_exports_run_outputs_schema(self):
-        result = self._check_exit_code(["output_schema", "--format", "json", "--schema", "run-outputs"])
+        result = self._check_exit_code(["output_schema", "--schema", "run-outputs"])
         metadata = json.loads(result.output)
 
         assert list(metadata["schemas"]) == ["run-outputs"]
@@ -37,7 +37,7 @@ class TestOutputSchema(CliTestCase):
 
     def test_output_schema_exports_invocation_download_manifest_schema(self):
         result = self._check_exit_code(
-            ["output_schema", "--format", "json", "--schema", "invocation-download-manifest"]
+            ["output_schema", "--schema", "invocation-download-manifest"]
         )
         metadata = json.loads(result.output)
 
@@ -46,6 +46,13 @@ class TestOutputSchema(CliTestCase):
             metadata["schemas"]["invocation-download-manifest"]["$schema"]
             == "https://json-schema.org/draft/2020-12/schema"
         )
+
+    def test_output_schema_exports_cli_metadata_schema(self):
+        result = self._check_exit_code(["output_schema", "--schema", "cli-metadata"])
+        metadata = json.loads(result.output)
+
+        assert list(metadata["schemas"]) == ["cli-metadata"]
+        assert metadata["schemas"]["cli-metadata"]["$schema"] == "https://json-schema.org/draft/2020-12/schema"
 
     def test_invocation_download_manifest_relative_paths(self):
         output_directory = os.path.join(os.getcwd(), "outputs")

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import json
+import os
+
+from planemo.test.models import PlanemoTestReport
+
+from .test_utils import (
+    CliTestCase,
+    TEST_DATA_DIR,
+)
+
+
+class TestOutputSchema(CliTestCase):
+    def test_output_schema_exports_test_report_schema(self):
+        result = self._check_exit_code(["output_schema", "--format", "json", "--schema", "test-report"])
+        metadata = json.loads(result.output)
+
+        assert metadata["schema_version"] == "0.1"
+        assert list(metadata["schemas"]) == ["test-report"]
+        assert metadata["schemas"]["test-report"]["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_output_schema_exports_run_outputs_schema(self):
+        result = self._check_exit_code(["output_schema", "--format", "json", "--schema", "run-outputs"])
+        metadata = json.loads(result.output)
+
+        assert list(metadata["schemas"]) == ["run-outputs"]
+        assert metadata["schemas"]["run-outputs"]["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    def test_issue381_validates_as_test_report(self):
+        path = os.path.join(TEST_DATA_DIR, "issue381.json")
+        with open(path) as f:
+            report = json.load(f)
+
+        parsed_report = PlanemoTestReport.model_validate(report)
+
+        assert parsed_report.summary is not None
+        assert parsed_report.summary.num_tests == 4
+        assert parsed_report.tests[2].has_data is False
+        assert parsed_report.tests[2].data is None
+
+    def test_legacy_skipped_status_normalizes_to_skip(self):
+        parsed_report = PlanemoTestReport.model_validate(
+            {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "example",
+                        "has_data": True,
+                        "data": {"status": "skipped"},
+                    }
+                ],
+            }
+        )
+
+        assert parsed_report.tests[0].data.status == "skip"

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -4,10 +4,9 @@ import json
 import os
 
 from planemo.commands.cmd_invocation_download import invocation_download_manifest
-from planemo.output_models import PlanemoInvocationDownloadManifest
 from planemo.galaxy.test.actions import handle_reports
+from planemo.output_models import PlanemoInvocationDownloadManifest
 from planemo.test.models import PlanemoTestReport
-
 from .test_utils import (
     CliTestCase,
     TEST_DATA_DIR,
@@ -36,9 +35,7 @@ class TestOutputSchema(CliTestCase):
         assert metadata["schemas"]["run-outputs"]["$schema"] == "https://json-schema.org/draft/2020-12/schema"
 
     def test_output_schema_exports_invocation_download_manifest_schema(self):
-        result = self._check_exit_code(
-            ["output_schema", "--schema", "invocation-download-manifest"]
-        )
+        result = self._check_exit_code(["output_schema", "--schema", "invocation-download-manifest"])
         metadata = json.loads(result.output)
 
         assert list(metadata["schemas"]) == ["invocation-download-manifest"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,7 +7,6 @@ import pytest
 
 from planemo.output_models import PlanemoRunOutputs
 from planemo.test.models import PlanemoTestReport
-
 from .test_utils import (
     CliTestCase,
     CWL_DRAFT3_DIR,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,8 +1,11 @@
 """The module contains a class to test the ``cwl_run`` command."""
 
+import json
 import os
 
 import pytest
+
+from planemo.output_models import PlanemoRunOutputs
 
 from .test_utils import (
     CliTestCase,
@@ -32,12 +35,16 @@ class RunTestCase(CliTestCase):
                 "--engine",
                 "cwltool",
                 "--no_container",
+                "--output_json",
+                "run_outputs.json",
                 tool_path,
                 job_path,
             ]
             self._check_exit_code(test_cmd)
             assert os.path.exists(os.path.join(f, "tool_test_output.html"))
             assert os.path.exists(os.path.join(f, "tool_test_output.json"))
+            with open(os.path.join(f, "run_outputs.json")) as run_outputs:
+                PlanemoRunOutputs.model_validate(json.load(run_outputs))
 
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
     def test_run_cat_cwltool_more_options(self):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from planemo.output_models import PlanemoRunOutputs
+from planemo.test.models import PlanemoTestReport
 
 from .test_utils import (
     CliTestCase,
@@ -43,6 +44,8 @@ class RunTestCase(CliTestCase):
             self._check_exit_code(test_cmd)
             assert os.path.exists(os.path.join(f, "tool_test_output.html"))
             assert os.path.exists(os.path.join(f, "tool_test_output.json"))
+            with open(os.path.join(f, "tool_test_output.json")) as test_report:
+                PlanemoTestReport.model_validate(json.load(test_report))
             with open(os.path.join(f, "run_outputs.json")) as run_outputs:
                 PlanemoRunOutputs.model_validate(json.load(run_outputs))
 


### PR DESCRIPTION
- Implementing a dump of the CLI  interface as JSON allows more easy programatic and agentic reasoning of the command-line interface to Planemo.
- Defining schemas for the outputs of Planemo commands allows dumping JSON schema for these outputs. Again this allows more principled reasoning about Planemo outputs and validation in programatic and agentic pipelines. 