### PR TITLE
Update Python support docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,8 +106,8 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
-2. The pull request should work for Python >=3.7. Check
-   https://travis-ci.org/galaxyproject/planemo/pull_requests
+2. The pull request should work for Python >=3.10. Check
+   https://github.com/galaxyproject/planemo/actions
    and make sure that the tests pass for all supported Python versions.
 
 Tips
@@ -115,15 +115,15 @@ Tips
 
 To run a subset of tests::
 
-    % make tox ENV=py37-unit ARGS='--tests tests/test_shed_upload.py'
+    % make tox ENV=py310-unit ARGS='--tests tests/test_shed_upload.py'
 
-This will use Tox_ to run the specified tests using Python 3.7. ``ENV`` here
-can be used to specify different Python version (e.g. ``py36`` or
-``py37``).
+This will use Tox_ to run the specified tests using Python 3.10. ``ENV`` here
+can be used to specify a different supported Python version (e.g. ``py311`` or
+``py312``).
 
 Even more granularity is also possible by specifying specific test methods.::
 
-    make tox ENV=py37-unit ARGS='--tests tests/test_shed_upload.py:ShedUploadTestCase.test_tar_from_git'
+    make tox ENV=py310-unit ARGS='--tests tests/test_shed_upload.py:ShedUploadTestCase.test_tar_from_git'
 
 
 ``tox`` can be used to run tests directly also (use ``. .venv/bin/activate``
@@ -131,10 +131,10 @@ to ensure it is on your ``PATH``).
 
 ::
 
-    tox -e py37-unit -- --tests tests/test_shed_upload.py
+    tox -e py310-unit -- --tests tests/test_shed_upload.py
 
-Tox_ itself is configured to wrap nose_. One can skip Tox_ and run
-``nosetests`` directly.
+Tox_ itself is configured to wrap pytest_. One can skip Tox_ and run
+``pytest`` directly.
 
 ::
 
@@ -147,33 +147,33 @@ Tox_ is a tool to automate testing across different Python versions. The
 ``tox`` executable can be supplied with a ``-e`` argument to specify a
 testing environment. Planemo defines the following environments:
 
-``py37-lint``
-    Lint the planemo code using Python 3.7.
+``py310-lint``
+    Lint the planemo code using Python 3.10.
 
-``py37-lint_docs``
+``py310-lint_docs``
     Lint the docs reStructuredText.
 
-``py37-lint_docstrings``
+``py310-lint_docstrings``
     Lint the project Python docstrings (doesn't pass currently).
 
-``py37-unit-quick``
-    Run the fastest unit tests (with least external dependencies) on Python 3.7.
+``py310-unit-quick``
+    Run the fastest unit tests (with least external dependencies) on Python 3.10.
 
-``py37-unit-nonredundant-noclientbuild-gx-2005``
-    Run tests that are marked as targeting a Galaxy branch and test against Galaxy 20.05.
+``py310-unit-nonredundant-noclientbuild-gx-250``
+    Run tests that are marked as targeting a Galaxy branch and test against Galaxy 25.0.
     Skip tests that are marked as redundant or that require a Galaxy client build.
 
-``py37-unit-gx-dev``
+``py310-unit-gx-dev``
     Run tests that are marked as targeting a Galaxy branch and test against Galaxy's dev branch.
 
 Pre-commit Hooks
 ~~~~~~~~~~~~~~~~~~~~~
 
-Planemo pull requests are automatically linted and tested using `TravisCI
-<https://travis-ci.org/galaxyproject/planemo>`__. A git pre-commit `hook
+Planemo pull requests are automatically linted and tested using `GitHub Actions
+<https://github.com/galaxyproject/planemo/actions>`__. A git pre-commit `hook
 <http://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`__ can be setup
 to lint and/or test Planemo before committing to catch problems that would
-be detected by TravisCI as early as possible.
+be detected by GitHub Actions as early as possible.
 
 The following command will install a pre-commit hook that lints the Planemo
 code::
@@ -186,4 +186,4 @@ setup a more rigorous pre-commit hook::
     make setup-git-hook-lint-and-test
 
 .. _Tox: https://tox.readthedocs.org/en/latest/
-.. _nose: https://nose.readthedocs.org/en/latest/
+.. _pytest: https://docs.pytest.org/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Obtaining
 
 For a traditional Python installation of Planemo, first set up a virtualenv
 for ``planemo`` (this example creates a new one in ``.venv``) containing
-Python 3.8 or newer and then install with ``pip``. Planemo must be installed
+Python 3.10 or newer and then install with ``pip``. Planemo must be installed
 with pip 7.0 or newer.
 
 ::
@@ -202,7 +202,6 @@ scientific workflows. Check out the `Galaxy <http://planemo.readthedocs.io/en/la
 .. _Conda: http://conda.pydata.org/
 .. _Docker: https://www.docker.com/
 .. _Vagrant: https://www.vagrantup.com/
-.. _Travis CI: http://travis-ci.org/
 .. _`tools-devteam`: https://github.com/galaxyproject/tools-devteam
 .. _`tools-iuc`: https://github.com/galaxyproject/tools-iuc
 .. _Building Galaxy Tools Using Planemo: http://planemo.readthedocs.io/en/latest/writing_standalone.html

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,7 +32,7 @@ use the following ``pip install`` idiom instead:
 If your ``PATH`` contains a Python installed through Conda it should likely not be used to run Planemo,
 please consider using a tool such uv_ to manage native Python installations and environments.
 
-Planemo runs on Python 3.8 or newer. Planemo can be used to run multiple versions of Galaxy,
+Planemo runs on Python 3.10 or newer. Planemo can be used to run multiple versions of Galaxy,
 but please note that the last Galaxy release that fully supports Python 2.7 is 19.09.
 
 Conda_ (Experimental)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37}-lint, py37-mypy, py37-unit-quick, py37-lint_docstrings, py37-lint_docs, py{37}-unit, py37-gxwf_test_test
+envlist = py{310}-lint, py310-mypy, py310-unit-quick, py310-lint_docstrings, py310-lint_docs, py{310}-unit, py310-gxwf_test_test
 source_dir = planemo
 test_dir = tests
 


### PR DESCRIPTION
## Summary
- Align README and installation docs with `requires-python >=3.10`
- Refresh contributor tox examples from `py37`/nose/Travis references to current Python, pytest, and GitHub Actions wording
- Update default tox envlist to `py310` to match supported Python range

## Testing
- `git diff --check`
- `make lint-docs` (fails on pre-existing Sphinx warnings: missing `standards/docs/best_practices` toctree target and ambiguous `type` cross-reference)