### PR TITLE
add --port to planemo test

### DIFF
--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -103,6 +103,7 @@ please careful and do not try this against production Galaxy instances.
       --galaxy_startup_timeout INTEGER RANGE
                                       Wait for galaxy to start before assuming
                                       Galaxy did not start.  [x>=1]
+      --port INTEGER                  Port to serve Galaxy on (default is 9090).
       --job_config_file FILE          Job configuration file for Galaxy to target.
       --job_workers INTEGER           Number of workers for the local job runner
                                       (default 1).

--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -38,6 +38,7 @@ from planemo.runnable_resolve import for_runnable_identifiers
     default="0",
 )
 @options.galaxy_target_options()
+@options.galaxy_port_option()
 @options.galaxy_config_options()
 @options.test_options()
 @options.engine_options()

--- a/tests/test_cmd_test.py
+++ b/tests/test_cmd_test.py
@@ -42,6 +42,27 @@ class CmdTestTestCase(CliTestCase):
             )
             self._check_exit_code(test_command, exit_code=1)
 
+    def test_port_option_is_passed_to_test_runnables(self):
+        """Test --port is accepted by test and forwarded to the Galaxy engine."""
+        import planemo.commands.cmd_test as cmd_test
+
+        captured_ports = []
+        original_test_runnables = cmd_test.test_runnables
+
+        def capture_test_runnables(ctx, runnables, original_paths=None, **kwds):
+            captured_ports.append(kwds["port"])
+            return 0
+
+        try:
+            cmd_test.test_runnables = capture_test_runnables
+            test_artifact = os.path.join(TEST_TOOLS_DIR, "ok_test_assert_command.xml")
+            self._check_exit_code(self._test_command(test_artifact), exit_code=0)
+            self._check_exit_code(self._test_command("--port", "12345", test_artifact), exit_code=0)
+        finally:
+            cmd_test.test_runnables = original_test_runnables
+
+        assert captured_ports == [9090, 12345]
+
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     def test_tool_in_directory(self):
         """Test with (single) tool in directory."""


### PR DESCRIPTION
Useful if you or some agent wants to run multiple tests in parallel. 