### PR TITLE
Harden gxformat2-normalized input/output handling

### DIFF
--- a/planemo/commands/cmd_workflow_job_init.py
+++ b/planemo/commands/cmd_workflow_job_init.py
@@ -64,6 +64,8 @@ def _build_commented_yaml(job, metadata):
                     input_format = ", ".join(input_format)
                 comment_parts.append(f"format: {input_format}")
             if input_doc:
+                if isinstance(input_doc, list):
+                    input_doc = " ".join(input_doc)
                 comment_parts.append(f"doc: {input_doc}")
             if is_optional:
                 comment_parts.append("optional: true")

--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -30,6 +30,10 @@ from ephemeris import (
     generate_tool_list_from_ga_workflow_files,
     shed_tools,
 )
+
+# Labels lives in a private gxformat2 module; reuse its canonical anonymous/
+# unlabeled predicates rather than re-deriving the sentinel conventions here.
+from gxformat2._labels import Labels
 from gxformat2.converter import python_to_workflow
 from gxformat2.interface import (
     BioBlendImporterGalaxyInterface,
@@ -621,7 +625,7 @@ def required_input_steps(workflow_path):
         raise Exception("Input workflow could not be successfully normalized - try linting with planemo workflow_lint.")
     required_steps = []
     for input_step in steps:
-        if input_step.get("optional", False) or input_step.get("default"):
+        if input_step.get("optional", False) or input_step.get("default") is not None:
             continue
         required_steps.append(input_step)
     return required_steps
@@ -632,7 +636,12 @@ def required_input_labels(workflow_path):
 
 
 def input_label(input_step):
-    """Get the normalized label of a step returned from inputs_normalized."""
+    """Get the normalized label of a step returned from inputs_normalized.
+
+    Relies on gxformat2's canonical id contract: every normalized input has a
+    stable ``id`` (including synthetic ``_unlabeled_input_*`` sentinels for
+    unlabeled inputs), so no anonymity heuristic is re-derived here.
+    """
     step_id = input_step.get("id") or input_step.get("label")
     return step_id
 
@@ -650,7 +659,7 @@ def output_stubs_for_workflow(workflow_path, **kwds):
         return _job_outputs_template_from_invocation(workflow_path, kwds["galaxy_url"], kwds["galaxy_user_key"])
     outputs = {}
     for label in output_labels(workflow_path):
-        if not label.startswith("_anonymous_"):
+        if not Labels.is_anonymous_output_label(label):
             outputs[label] = {"class": ""}
     return outputs
 

--- a/tests/data/wf_empty_output_label.gxwf.yml
+++ b/tests/data/wf_empty_output_label.gxwf.yml
@@ -1,0 +1,12 @@
+class: GalaxyWorkflow
+inputs:
+  x:
+    type: data
+outputs:
+  "":
+    outputSource: cat/out_file1
+steps:
+  cat:
+    tool_id: cat1
+    in:
+      input1: x

--- a/tests/data/wf_list_doc.gxwf.yml
+++ b/tests/data/wf_list_doc.gxwf.yml
@@ -1,0 +1,9 @@
+class: GalaxyWorkflow
+inputs:
+  the_input:
+    type: data
+    doc:
+      - First line of docs.
+      - Second line of docs.
+outputs: {}
+steps: {}

--- a/tests/data/wf_required_defaults.gxwf.yml
+++ b/tests/data/wf_required_defaults.gxwf.yml
@@ -1,0 +1,12 @@
+class: GalaxyWorkflow
+inputs:
+  needs_value:
+    type: data
+  bool_default_false:
+    type: boolean
+    default: false
+  int_default_zero:
+    type: int
+    default: 0
+outputs: {}
+steps: {}

--- a/tests/test_cmd_workflow_job_init.py
+++ b/tests/test_cmd_workflow_job_init.py
@@ -179,3 +179,16 @@ class CmdWorkflowJobInitTestCase(CliTestCase):
             nested_identifiers = [e["identifier"] for e in nested["elements"]]
             assert "forward" in nested_identifiers
             assert "reverse" in nested_identifiers
+
+    def test_list_doc(self):
+        """A list-valued input ``doc`` is joined for the comment, not rendered as a Python list."""
+        with self._isolate_with_test_data("") as f:
+            init_cmd = ["workflow_job_init", "wf_list_doc.gxwf.yml"]
+            self._check_exit_code(init_cmd)
+            job_path = os.path.join(f, "wf_list_doc.gxwf_job.yml")
+            assert os.path.exists(job_path)
+
+            with open(job_path) as stream:
+                content = stream.read()
+            assert "doc: First line of docs. Second line of docs." in content
+            assert "doc: ['First line of docs." not in content

--- a/tests/test_galaxy_workflow_utils.py
+++ b/tests/test_galaxy_workflow_utils.py
@@ -2,7 +2,11 @@
 
 import os
 
-from planemo.galaxy.workflows import describe_outputs
+from planemo.galaxy.workflows import (
+    describe_outputs,
+    output_stubs_for_workflow,
+    required_input_labels,
+)
 from planemo.runnable import for_path
 from .test_utils import TEST_DATA_DIR
 
@@ -16,3 +20,19 @@ def test_describe_outputs():
     assert output.order_index == 1
     assert output.output_name == "out_file1"
     assert output.label == "wf_output_1"
+
+
+def test_required_input_steps_excludes_falsy_defaults():
+    """Inputs with a default are not required, even when the default is falsy (boolean false, int 0)."""
+    wf_path = os.path.join(TEST_DATA_DIR, "wf_required_defaults.gxwf.yml")
+    required = set(required_input_labels(wf_path))
+    assert "needs_value" in required
+    assert "bool_default_false" not in required
+    assert "int_default_zero" not in required
+
+
+def test_output_stubs_skip_anonymous_and_empty_labels():
+    """Empty/anonymous output labels are filtered via gxformat2's canonical predicate."""
+    wf_path = os.path.join(TEST_DATA_DIR, "wf_empty_output_label.gxwf.yml")
+    stubs = output_stubs_for_workflow(wf_path)
+    assert stubs == {}


### PR DESCRIPTION
- _build_commented_yaml: join list-valued input doc (parity with format)
- required_input_steps: falsy defaults (false/0/"") count as a default, so those inputs aren't misclassified as required
- output_stubs_for_workflow: use gxformat2 Labels.is_anonymous_output_label instead of a hand-rolled _anonymous_ check (also filters empty labels)
- Document input_label's reliance on gxformat2's canonical id contract

Pre-existing latent issues (not 0.25 regressions); red->green tests added.