### PR TITLE
Escape rich markup in failed-job error reporting

### DIFF
--- a/planemo/galaxy/invocations/progress.py
+++ b/planemo/galaxy/invocations/progress.py
@@ -9,6 +9,7 @@ from typing import (
 
 from rich.console import Group
 from rich.live import Live
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import (
     BarColumn,
@@ -259,7 +260,7 @@ class WorkflowProgress(Progress):
                 workflow_progress_display.console.print("\n".join(new_error_lines))
 
         except Exception as e:
-            error_msg = "❌ Failed to collect failed job details: {}".format(e)
+            error_msg = "❌ Failed to collect failed job details: {}".format(escape(str(e)))
             workflow_progress_display.console.print(error_msg)
 
     def _format_job_error_details(self, job_id, job_details):
@@ -271,23 +272,23 @@ class WorkflowProgress(Progress):
         command_line = job_details.get("command_line")
         tool_id = job_details.get("tool_id")
 
-        error_lines.append("❌ Failed job {}:".format(job_id))
+        error_lines.append("❌ Failed job {}:".format(escape(str(job_id))))
         if tool_id:
-            error_lines.append("   Tool ID: {}".format(tool_id))
+            error_lines.append("   Tool ID: {}".format(escape(tool_id)))
         if exit_code is not None:
             error_lines.append("   Exit code: {}".format(exit_code))
         if command_line:
-            error_lines.append("   Command line: {}".format(command_line))
+            error_lines.append("   Command line: {}".format(escape(command_line)))
         if stdout:
             error_lines.append("   Stdout:")
             for line in stdout.split("\n"):
                 if line.strip():
-                    error_lines.append("     {}".format(line))
+                    error_lines.append("     {}".format(escape(line)))
         if stderr:
             error_lines.append("   Stderr:")
             for line in stderr.split("\n"):
                 if line.strip():
-                    error_lines.append("     {}".format(line))
+                    error_lines.append("     {}".format(escape(line)))
         error_lines.append("")  # Empty line for spacing
         return error_lines
 

--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -1,4 +1,7 @@
 import time
+from io import StringIO
+
+from rich.console import Console
 
 from planemo.galaxy.invocations.progress import (
     WorkflowProgress,
@@ -168,3 +171,37 @@ def test_workflow_progress_completed_step_state_counting():
             workflow_progress.step_states.get("completed") or 0
         )
         assert num_scheduled == 2
+
+
+def test_format_job_error_details_escapes_rich_markup():
+    # Regression: failed-job stderr containing strings like Java's Arrays.toString
+    # output (e.g. ImageJ --debug) starts with "[/tmp/..." which rich's markup parser
+    # treats as a closing tag and rejects with MarkupError, masking the real failure.
+    bracketed_argv = (
+        "[/tmp/shed_dir/toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_analyze_particles_binary/"
+        "862af85a50ec/imagej2_analyze_particles_binary/imagej2_analyze_particles_binary_jython_script.py, "
+        "/tmp/job/outputs/dataset_cc.dat, /tmp/files/dataset_99.dat, "
+        "yes, 50-Infinity, 0.0, 1.0, Outlines, no, no, no, output.tiff, tiff, ]"
+    )
+    job_details = {
+        "exit_code": 1,
+        "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_analyze_particles_binary/"
+        "imagej2_analyze_particles_binary/20240614+galaxy0",
+        "command_line": "ImageJ --jython /tmp/shed_dir/script.py /tmp/input.dat",
+        "stdout": "",
+        "stderr": bracketed_argv,
+    }
+
+    with WorkflowProgress(DisplayConfiguration()) as workflow_progress:
+        lines = workflow_progress._format_job_error_details("JOB_ID_42", job_details)
+
+    # Render through a Console with markup parsing on (the default) to ensure
+    # the assembled output does not blow up rich.
+    console = Console(file=StringIO(), force_terminal=False, width=200)
+    console.print("\n".join(lines))  # would raise MarkupError before the fix
+    output = console.file.getvalue()
+
+    # Content must be preserved verbatim, not stripped.
+    assert "/tmp/shed_dir/" in output
+    assert "output.tiff" in output
+    assert "20240614+galaxy0" in output


### PR DESCRIPTION
`WorkflowProgress._format_job_error_details` passes job stdout, stderr, command_line and tool_id straight into `console.print()`, which parses rich's `[tag]...[/tag]` markup. When a tool prints argv-style debug output beginning with `[/tmp/...` (e.g. ImageJ in `--debug` mode), rich interprets it as an unmatched closing tag and raises `MarkupError`, masking the underlying job failure and surfacing as the test's `execution_problem` instead.

Escape every untrusted field with `rich.markup.escape` before formatting, and add a regression test feeding the offending pattern through `_format_job_error_details` + `Console.print`.