### PR TITLE
Make report templates resilient to typed-model null defaults

### DIFF
--- a/planemo/reports/report_junit.tpl
+++ b/planemo/reports/report_junit.tpl
@@ -7,7 +7,7 @@
               skipped="{{ raw_data.results.skips }}">
         {% for testcase in raw_data.tests %}
         <testcase classname="{{ testcase.id }}" name="{{ testcase.data.test_index }}" time="{{ testcase.data.time_seconds }}">
-            {% if 'job' in testcase.data %}
+            {% if testcase.data.job %}
                 {% if testcase.data.status != 'success' %}
                     <failure message="Tool exit code: {{ testcase.data.job.exit_code }}"><![CDATA[
                         {{ testcase.data | tojson(indent=True)| strip_control_characters }}

--- a/planemo/reports/report_markdown.tpl
+++ b/planemo/reports/report_markdown.tpl
@@ -47,12 +47,12 @@
 {%       endif %}
 {%       if test.data.output_problems %}
     **Problems**:
-{%       endif %}
-{%       for problem in test.data.output_problems %}
+{%         for problem in test.data.output_problems %}
     * ```
       {{problem|indent(6)}}
       ```
-{%       endfor %}
+{%         endfor %}
+{%       endif %}
 {%       if test.data.execution_problem %}
     **Execution Problem:**
     * ```

--- a/planemo/reports/report_xunit.tpl
+++ b/planemo/reports/report_xunit.tpl
@@ -6,7 +6,7 @@
            skip="{{ raw_data.results.skips }}">
     {% for testcase in raw_data.tests %}
     <testcase classname="{{ testcase.id }}" name="{{ testcase.data.test_index }}" time="{{ testcase.data.time_seconds }}">
-        {% if 'job' in testcase.data %}
+        {% if testcase.data.job %}
             {% if testcase.data.status != 'success' %}
                 <error type="error" message="Tool exit code: {{ testcase.data.job.exit_code }}"><![CDATA[
                     {{ testcase.data | tojson(indent=True)| strip_control_characters }}

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -112,6 +112,53 @@ class CmdTestReportsTestCase(CliTestCase):
             assert "passing-test" in markdown
             assert "**Problems**" not in markdown
 
+    def test_junit_xunit_errored_test_without_job_uses_execution_problem(self):
+        # Regression: report_junit.tpl and report_xunit.tpl gated on
+        # `'job' in testcase.data` to decide whether to emit a per-job failure
+        # or fall back to a per-test execution_problem failure. After typed-
+        # model round-trip, `job` is always present (as None for tests with no
+        # job), so the guard was always true and the execution_problem branch
+        # became unreachable -- producing JUnit/xUnit reports with an empty
+        # "Tool exit code: " message instead of the real failure reason.
+        with self._isolate() as f:
+            json_path = os.path.join(f, "errored.json")
+            junit_path = os.path.join(f, "junit.xml")
+            xunit_path = os.path.join(f, "xunit.xml")
+            report = {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "errored-test",
+                        "has_data": True,
+                        "data": {
+                            "status": "error",
+                            "execution_problem": "input staging failed: boom",
+                            "job": None,
+                        },
+                    }
+                ],
+            }
+            with open(json_path, "w") as handle:
+                json.dump(report, handle)
+
+            self._check_exit_code(
+                [
+                    "test_reports",
+                    "--test_output_junit",
+                    junit_path,
+                    "--test_output_xunit",
+                    xunit_path,
+                    json_path,
+                ],
+                exit_code=0,
+            )
+
+            for path in (junit_path, xunit_path):
+                with open(path) as handle:
+                    xml = handle.read()
+                assert "input staging failed: boom" in xml, path
+                assert "Tool exit code:" not in xml, path
+
     def test_invalid_report_fails_with_friendly_error(self):
         with self._isolate() as f:
             json_path = os.path.join(f, "invalid.json")

--- a/tests/test_cmd_test_reports.py
+++ b/tests/test_cmd_test_reports.py
@@ -83,6 +83,35 @@ class CmdTestReportsTestCase(CliTestCase):
 
             assert os.path.exists(results_path)
 
+    def test_markdown_passing_test_with_null_output_problems(self):
+        # Regression: report_markdown.tpl iterated test.data.output_problems
+        # outside its `if`-guard, so a passing test (where the typed model
+        # leaves output_problems as None) crashed the Jinja render with
+        # "TypeError: 'NoneType' object is not iterable".
+        with self._isolate() as f:
+            json_path = os.path.join(f, "passing.json")
+            markdown_path = os.path.join(f, "markdown_results")
+            report = {
+                "version": "0.1",
+                "tests": [
+                    {
+                        "id": "passing-test",
+                        "has_data": True,
+                        "data": {"status": "success", "output_problems": None},
+                    }
+                ],
+            }
+            with open(json_path, "w") as handle:
+                json.dump(report, handle)
+
+            self._check_exit_code(["test_reports", "--test_output_markdown", markdown_path, json_path], exit_code=0)
+
+            with open(markdown_path) as handle:
+                markdown = handle.read()
+
+            assert "passing-test" in markdown
+            assert "**Problems**" not in markdown
+
     def test_invalid_report_fails_with_friendly_error(self):
         with self._isolate() as f:
             json_path = os.path.join(f, "invalid.json")


### PR DESCRIPTION
## Summary

Two report templates in `planemo/reports/` made assumptions about the JSON test-report shape that no longer hold after `a0d765fd57` ("Add structured CLI and output schemas") introduced typed Pydantic models. `merge_test_reports` now round-trips reports through `PlanemoTestReport.model_validate(...).model_dump(mode=\"json\")`, and `mode=\"json\"` serialises unset Optional fields as explicit `null` instead of omitting them. Templates that previously relied on Jinja's silent-empty behaviour for *Undefined* attribute lookups break when they receive real *None* values.

This PR fixes two distinct user-visible symptoms of that shape mismatch:

1. **`report_markdown.tpl` crashes rendering any report that contains a passing test.**
   The `{% for problem in test.data.output_problems %}` loop sat outside its `{% if test.data.output_problems %}` guard. `output_problems` is `Optional[list[str]] = None`, so post-round-trip it is `null` for every test that didn't produce output problems (including all passing tests), and Jinja raises `TypeError: 'NoneType' object is not iterable`. Symptom in the wild: `planemo test_reports` after `planemo merge_test_reports` crashes for any successful workflow test (e.g. https://github.com/galaxyproject/iwc/actions/runs/26224703416/job/77168877129). Fix: move the `for` inside the existing `if`.

2. **`report_junit.tpl` / `report_xunit.tpl` silently hide the real failure reason for tests that errored before a job was created.**
   Both templates gated on `{% if 'job' in testcase.data %}` to choose between a per-job `<failure>` (with exit code + job dump) and a per-test fallback `<failure message=\"{{ testcase.data.execution_problem }}\">`. Post-round-trip the `job` key is always present (as `None` for execution-failed tests), so the guard is always true and the fallback branch is unreachable. The resulting JUnit/xUnit reports for such failures show `Tool exit code: ` with no exit code and no message instead of the actual `execution_problem` — silently broken in CI dashboards (Jenkins, GitHub Actions, etc.). Fix: replace `'job' in testcase.data` with `testcase.data.job`, which is truthy on a populated dict and falsy on None — correct for both pre- and post-round-trip JSON shapes.

Both fixes target the templates rather than `actions.py:70/82`'s `model_dump(mode=\"json\")` call, because changing the dump options (e.g. `exclude_none=True`) would alter the on-disk JSON shape for every consumer of planemo's report files.

## Audit of remaining templates

For completeness I also audited the other templates under `planemo/reports/`:

| Template | Verdict |
|---|---|
| `report_text.tpl` | Safe — `{% for %}` properly nested inside `{% if test.data.output_problems %}`. |
| `report_markdown_minimal.tpl` | Safe — only iterates `raw_data.tests` and a literal dict. |
| `xunit.tpl` | Out of scope — different data shape, used by `cmd_shed_diff` / `cmd_shed_update`. |
| `macros.tmpl` | Theoretical risk: `render_steps(steps)`, `render_invocation_messages(messages)`, `render_invocation_details(details)` iterate args without None-guards. Externally gated by `{% if test.data.invocation_details %}`, and the inner `.steps` / `.messages` / `.details` come from Galaxy's invocation API (typed elsewhere). No reproduction in the wild — leaving alone. |

## Test plan

- [x] `pytest tests/test_cmd_test_reports.py` — 8 pass (6 pre-existing + 2 new regression tests).
- [x] Each new regression test verified to fail in isolation without its corresponding template fix (`git stash` of the template change → test fails with the exact symptom described above).
- [x] Pre-commit (black, isort, ruff) clean on both commits.