### PR TITLE
[WIP] Add GA4GH WES execution path to planemo run

### DIFF
--- a/docs/_running_external.rst
+++ b/docs/_running_external.rst
@@ -398,3 +398,40 @@ using the ``planemo rerun`` command:
 In the first two cases, all failed, remappable jobs which are associated with
 the specified history(s) or invocation(s) will be rerun. In the third case,
 the specified jobs will simply be rerun.
+
+
+Executing workflows via GA4GH WES
+===============================================
+
+Galaxy exposes a `GA4GH Workflow Execution Service (WES)
+<https://ga4gh.github.io/workflow-execution-service-schemas/>`_ endpoint. Adding
+the ``--wes`` flag to ``planemo run`` submits the workflow to that endpoint
+instead of the native Galaxy invocation API:
+
+::
+
+    $ planemo run tutorial.ga tutorial-job.yml --wes --galaxy_url SERVER_URL --galaxy_user_key YOUR_API_KEY
+
+The ``--wes`` flag is a modifier on the Galaxy execution path rather than a
+separate engine - it reuses the usual Galaxy connection options and targets
+whichever server you are already pointing at. With ``--galaxy_url`` it runs
+against an external Galaxy; without it, it runs against a Planemo-managed Galaxy.
+A profile works too:
+
+::
+
+    $ planemo run tutorial.ga tutorial-job.yml --wes --profile tutorial_profile
+
+WES has no data-staging or output-download endpoint of its own, so this initial
+support is intentionally limited:
+
+- Only workflows are supported (not single tools).
+- Inputs must be parameters or reference data that already exists on the target
+  Galaxy (e.g. ``galaxy_id``/``{"src": "hda", "id": ...}``). Inputs that point at
+  local files (``class: File`` with ``path``/``location``) are rejected, since
+  there is nowhere for WES to upload them.
+- ``--download_outputs`` still works, but downloads happen through the native
+  Galaxy API (Planemo prints a warning noting this), as WES does not define a
+  download mechanism.
+
+Run success is reported from the terminal WES state.

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -30,6 +30,7 @@ from planemo.test.results import StructuredData
 @options.run_output_directory_option()
 @options.run_output_json_option()
 @options.run_download_outputs_option()
+@options.wes_option()
 @options.run_export_option()
 @options.invocation_export_format_arg()
 @options.engine_options()
@@ -50,6 +51,19 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
         )
     kwds["cwl"] = is_cwl
     kwds["execution_type"] = "Run"
+    if kwds.get("wes"):
+        # WES execution is Galaxy-only - validate before engine defaulting so CWL
+        # runnables don't get steered to the cwltool engine and a confusing error.
+        if runnable.type != RunnableType.galaxy_workflow:
+            raise click.UsageError(
+                "--wes execution is only supported for Galaxy workflows, "
+                "but the provided runnable is of type: %s" % runnable.type
+            )
+        if kwds.get("engine") not in (None, "galaxy", "external_galaxy"):
+            raise click.UsageError(
+                "--wes execution is only supported with the 'galaxy' or "
+                "'external_galaxy' engines, not engine [%s]." % kwds["engine"]
+            )
     if kwds.get("engine", None) is None:
         if is_cwl:
             kwds["engine"] = "cwltool"

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -17,6 +17,7 @@ from planemo.galaxy.activity import (
     execute,
     execute_rerun,
     GalaxyBaseRunResponse,
+    wes_execute,
 )
 from planemo.galaxy.config import external_galaxy_config
 from planemo.galaxy.serve import serve_daemon
@@ -62,7 +63,10 @@ class GalaxyEngine(BaseEngine, metaclass=abc.ABCMeta):
             for runnable, job_path, collect_output in zip(runnables, job_paths, output_collectors):
                 self._ctx.vlog(f"Serving artifact [{runnable}] with Galaxy.")
                 self._ctx.vlog(f"Running job path [{job_path}]")
-                run_response = execute(self._ctx, config, runnable, job_path, **self._kwds)
+                if self._kwds.get("wes"):
+                    run_response = wes_execute(self._ctx, config, runnable, job_path, **self._kwds)
+                else:
+                    run_response = execute(self._ctx, config, runnable, job_path, **self._kwds)
                 results.append(run_response)
                 if collect_output is not None:
                     collect_output(run_response)

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import sys
 import tempfile
+import time
 import traceback
 from datetime import datetime
 from typing import (
@@ -27,6 +28,7 @@ try:
 except ImportError:
     from galaxy.tool_util.client.staging import StagingInterace as StagingInterface
 
+import yaml
 from galaxy.tool_util.cwl.util import (
     invocation_to_output,
     output_to_cwl_json,
@@ -57,9 +59,21 @@ from planemo.galaxy.upload_progress import (
     _aggregate_job_states,
     UploadProgressDisplay,
 )
-from planemo.io import wait_on
+from planemo.galaxy.wes import (
+    detect_workflow_type,
+    is_failure,
+    is_success,
+    is_terminal,
+    WesClient,
+)
+from planemo.io import (
+    info,
+    wait_on,
+    warn,
+)
 from planemo.runnable import (
     ErrorRunResponse,
+    GALAXY_WORKFLOW_INSTANCE_PREFIX,
     get_outputs,
     Rerunnable,
     Runnable,
@@ -92,6 +106,177 @@ def execute(
         ctx.log("Failed to execute Galaxy activity, throwing ErrorRunResponse")
         traceback.print_exc(file=sys.stdout)
         return ErrorRunResponse(unicodify(e), start_datetime=start_datetime, end_datetime=end_datetime)
+
+
+WES_WORKFLOW_TYPE_VERSION = "1.0.0"
+DEFAULT_WES_POLL_INTERVAL = 3.0
+
+
+def wes_execute(
+    ctx: "PlanemoCliContext", config: "BaseGalaxyConfig", runnable: Runnable, job_path: str, **kwds
+) -> RunResponse:
+    """Execute a Galaxy workflow through the GA4GH WES API."""
+    start_datetime = datetime.now()
+    try:
+        return _wes_execute(ctx, config, runnable, job_path, start_datetime=start_datetime, **kwds)
+    except Exception as e:
+        end_datetime = datetime.now()
+        ctx.log("Failed to execute Galaxy activity via WES, throwing ErrorRunResponse")
+        traceback.print_exc(file=sys.stdout)
+        return ErrorRunResponse(unicodify(e), start_datetime=start_datetime, end_datetime=end_datetime)
+
+
+def _wes_execute(
+    ctx: "PlanemoCliContext",
+    config: "BaseGalaxyConfig",
+    runnable: Runnable,
+    job_path: str,
+    start_datetime: Optional[datetime] = None,
+    **kwds,
+) -> RunResponse:
+    if runnable.type != RunnableType.galaxy_workflow:
+        raise NotImplementedError("WES execution currently only supports Galaxy workflows.")
+    start_datetime = start_datetime or datetime.now()
+
+    client = WesClient(config.galaxy_url, config.user_api_key)
+    workflow_type = _wes_workflow_type(runnable)
+    params = _wes_workflow_params(job_path)
+
+    engine_parameters: Dict[str, Any] = {}
+    history_name = kwds.get("history_name")
+    if history_name:
+        engine_parameters["history_name"] = history_name
+    if kwds.get("history_id"):
+        engine_parameters["history_id"] = kwds["history_id"]
+
+    # Reference the workflow already loaded into Galaxy (via ensure_runnables_served)
+    # rather than re-uploading it as a WES attachment. workflow_id_for_runnable returns
+    # a Workflow instance id for workflow-instance URIs and a StoredWorkflow id otherwise;
+    # gxworkflow:// defaults to StoredWorkflow, so flag the instance case explicitly.
+    workflow_ref_id = config.workflow_id_for_runnable(runnable)
+    workflow_url = f"gxworkflow://{workflow_ref_id}"
+    if runnable.uri.startswith(GALAXY_WORKFLOW_INSTANCE_PREFIX):
+        workflow_url += "?instance=true"
+    ctx.vlog(f"Submitting workflow [{workflow_url}] to WES endpoint [{config.galaxy_url}] as type [{workflow_type}]")
+    submit_response = client.submit_run(
+        workflow_type=workflow_type,
+        workflow_type_version=WES_WORKFLOW_TYPE_VERSION,
+        workflow_url=workflow_url,
+        params=params,
+        engine_parameters=engine_parameters or None,
+    )
+    run_id = submit_response["run_id"]
+    ctx.vlog(f"WES run submitted with run_id [{run_id}]")
+
+    user_gi = config.user_gi
+    # WES run_id is the Galaxy workflow invocation id - use the native API to
+    # recover history/workflow ids for output collection (WES has no such endpoint).
+    invocation = user_gi.invocations.show_invocation(run_id)
+    history_id = invocation["history_id"]
+    workflow_id = invocation["workflow_id"]
+    no_wait = kwds.get("no_wait", False)
+
+    if no_wait:
+        wes_state = client.get_run_status(run_id)["state"]
+    else:
+        wes_state = _wait_for_wes_run(ctx, client, run_id, **kwds)
+        if is_failure(wes_state):
+            # Summarize before building the response - detail collection in the
+            # response constructor can itself fail on a broken invocation.
+            summarize_history(ctx, user_gi, history_id)
+
+    run_response = WesRunResponse(
+        ctx=ctx,
+        runnable=runnable,
+        user_gi=user_gi,
+        history_id=history_id,
+        workflow_id=workflow_id,
+        invocation_id=run_id,
+        wes_state=wes_state,
+        log=log_contents_str(config),
+        start_datetime=start_datetime,
+        end_datetime=datetime.now(),
+        no_wait=no_wait,
+    )
+
+    if kwds.get("download_outputs"):
+        warn(
+            "Downloading outputs via the Galaxy API - the GA4GH WES API has no "
+            "output-download endpoint, so --download_outputs does not use WES."
+        )
+        output_directory = kwds.get("output_directory", None)
+        ctx.vlog("collecting outputs from WES run...")
+        run_response.collect_outputs(output_directory)
+        ctx.vlog("collecting outputs complete")
+
+    return run_response
+
+
+def _wes_workflow_type(runnable: Runnable) -> str:
+    """Determine the WES ``workflow_type`` form value for a runnable.
+
+    Galaxy ignores this when the run references an already-stored workflow via a
+    ``gxworkflow://`` URI, but the field is required by the WES API, so detect it
+    from the workflow document when a local path is available.
+    """
+    if runnable.has_path:
+        with open(runnable.path) as f:
+            return detect_workflow_type(f.read())
+    return "gx_workflow_ga"
+
+
+def _wes_workflow_params(job_path: str) -> Dict[str, Any]:
+    """Load a planemo job file into WES ``workflow_params``.
+
+    Phase 1 supports parameter-only workflows and inputs that already exist on
+    the target Galaxy (referenced as ``{"src": "hda", "id": ...}``). Inputs that
+    would require data staging (local files via ``class: File`` / ``path`` /
+    ``location``) are rejected - WES has no data-staging endpoint.
+    """
+    with open(job_path) as f:
+        job = yaml.safe_load(f) or {}
+    if not isinstance(job, dict):
+        raise Exception(f"Job file [{job_path}] must define a mapping of input names to values.")
+
+    for input_name, value in job.items():
+        if _is_unstaged_file_input(value):
+            raise Exception(
+                f"Input [{input_name}] looks like a local file input, which WES execution does not "
+                "support yet (WES has no data-staging endpoint). Stage the data into Galaxy first and "
+                'reference it as {"src": "hda", "id": "..."}.'
+            )
+    return job
+
+
+def _is_unstaged_file_input(value: Any) -> bool:
+    if isinstance(value, dict):
+        if value.get("class") in ("File", "Directory"):
+            return True
+        if "path" in value or "location" in value:
+            return True
+    if isinstance(value, list):
+        return any(_is_unstaged_file_input(item) for item in value)
+    return False
+
+
+def _wait_for_wes_run(ctx: "PlanemoCliContext", client: WesClient, run_id: str, **kwds) -> str:
+    timeout = kwds.get("test_timeout") or 60 * 60 * 24
+    interval = DEFAULT_WES_POLL_INTERVAL
+    waited = 0.0
+    last_reported_state = None
+    while True:
+        state = client.get_run_status(run_id)["state"]
+        ctx.vlog(f"WES run [{run_id}] state [{state}]")
+        if is_terminal(state):
+            return state
+        # Surface state transitions (and a first heartbeat) without flooding output.
+        if state != last_reported_state:
+            info(f"WES run [{run_id}] state [{state}]")
+            last_reported_state = state
+        if waited > timeout:
+            raise Exception(f"Timed out waiting on WES run {run_id} (last state [{state}]).")
+        time.sleep(interval)
+        waited += interval
 
 
 def _verified_tool_id(runnable, user_gi):
@@ -907,6 +1092,55 @@ class GalaxyWorkflowRunResponse(GalaxyBaseRunResponse):
         return output_path
 
 
+class WesRunResponse(GalaxyWorkflowRunResponse):
+    """Run response for a workflow executed through the GA4GH WES API.
+
+    Submission and completion are tracked over the WES protocol and success is
+    derived from the terminal WES state (rather than per-job exit codes). The WES
+    run id is the Galaxy workflow invocation id, so output collection, downloads,
+    and invocation details reuse the Galaxy API machinery of the superclass - WES
+    itself has no data-staging or output-download endpoint.
+    """
+
+    def __init__(
+        self,
+        ctx,
+        runnable,
+        user_gi,
+        history_id,
+        workflow_id,
+        invocation_id,
+        wes_state,
+        log,
+        start_datetime=None,
+        end_datetime=None,
+        no_wait=False,
+    ):
+        self._wes_state = wes_state
+        super().__init__(
+            ctx=ctx,
+            runnable=runnable,
+            user_gi=user_gi,
+            history_id=history_id,
+            log=log,
+            workflow_id=workflow_id,
+            invocation_id=invocation_id,
+            history_state=None,
+            invocation_state=wes_state,
+            error_message=None,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+            no_wait=no_wait,
+        )
+
+    @property
+    def was_successful(self):
+        if self._no_wait:
+            # Submission succeeded; we did not wait to learn the terminal state.
+            return True
+        return is_success(self._wes_state)
+
+
 def _tool_id(tool_path):
     tool_source = get_tool_source(tool_path)
     return tool_source.parse_id()
@@ -1010,4 +1244,8 @@ def _wait_on_state(state_func, polling_backoff=0, timeout=None):
     return final_state
 
 
-__all__ = ("execute",)
+__all__ = (
+    "execute",
+    "wes_execute",
+    "WesRunResponse",
+)

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -4,7 +4,6 @@ import contextlib
 import os
 import sys
 import tempfile
-import time
 import traceback
 from datetime import datetime
 from typing import (
@@ -60,7 +59,6 @@ from planemo.galaxy.upload_progress import (
     UploadProgressDisplay,
 )
 from planemo.galaxy.wes import (
-    detect_workflow_type,
     is_failure,
     is_success,
     is_terminal,
@@ -110,12 +108,23 @@ def execute(
 
 WES_WORKFLOW_TYPE_VERSION = "1.0.0"
 DEFAULT_WES_POLL_INTERVAL = 3.0
+# Galaxy ignores ``workflow_type`` when a run references an already-stored workflow
+# via a ``gxworkflow://`` URI (the only form we submit), but the WES API requires the
+# field, so send a constant placeholder rather than parsing the workflow to detect it.
+WES_WORKFLOW_TYPE = "gx_workflow_ga"
 
 
 def wes_execute(
     ctx: "PlanemoCliContext", config: "BaseGalaxyConfig", runnable: Runnable, job_path: str, **kwds
 ) -> RunResponse:
-    """Execute a Galaxy workflow through the GA4GH WES API."""
+    """Execute a Galaxy workflow through the GA4GH WES API.
+
+    This exists to exercise Galaxy's standards-based GA4GH WES interface - a
+    compatibility checkbox, not the recommended path. Native Galaxy submission
+    and polling (``execute``) are more functional (data staging, richer progress
+    and per-job error reporting) and more performant; prefer them unless you
+    specifically need to go through WES.
+    """
     start_datetime = datetime.now()
     try:
         return _wes_execute(ctx, config, runnable, job_path, start_datetime=start_datetime, **kwds)
@@ -139,7 +148,6 @@ def _wes_execute(
     start_datetime = start_datetime or datetime.now()
 
     client = WesClient(config.galaxy_url, config.user_api_key)
-    workflow_type = _wes_workflow_type(runnable)
     params = _wes_workflow_params(job_path)
 
     engine_parameters: Dict[str, Any] = {}
@@ -157,9 +165,9 @@ def _wes_execute(
     workflow_url = f"gxworkflow://{workflow_ref_id}"
     if runnable.uri.startswith(GALAXY_WORKFLOW_INSTANCE_PREFIX):
         workflow_url += "?instance=true"
-    ctx.vlog(f"Submitting workflow [{workflow_url}] to WES endpoint [{config.galaxy_url}] as type [{workflow_type}]")
+    ctx.vlog(f"Submitting workflow [{workflow_url}] to WES endpoint [{config.galaxy_url}]")
     submit_response = client.submit_run(
-        workflow_type=workflow_type,
+        workflow_type=WES_WORKFLOW_TYPE,
         workflow_type_version=WES_WORKFLOW_TYPE_VERSION,
         workflow_url=workflow_url,
         params=params,
@@ -212,19 +220,6 @@ def _wes_execute(
     return run_response
 
 
-def _wes_workflow_type(runnable: Runnable) -> str:
-    """Determine the WES ``workflow_type`` form value for a runnable.
-
-    Galaxy ignores this when the run references an already-stored workflow via a
-    ``gxworkflow://`` URI, but the field is required by the WES API, so detect it
-    from the workflow document when a local path is available.
-    """
-    if runnable.has_path:
-        with open(runnable.path) as f:
-            return detect_workflow_type(f.read())
-    return "gx_workflow_ga"
-
-
 def _wes_workflow_params(job_path: str) -> Dict[str, Any]:
     """Load a planemo job file into WES ``workflow_params``.
 
@@ -261,10 +256,10 @@ def _is_unstaged_file_input(value: Any) -> bool:
 
 def _wait_for_wes_run(ctx: "PlanemoCliContext", client: WesClient, run_id: str, **kwds) -> str:
     timeout = kwds.get("test_timeout") or 60 * 60 * 24
-    interval = DEFAULT_WES_POLL_INTERVAL
-    waited = 0.0
     last_reported_state = None
-    while True:
+
+    def state_func() -> Optional[str]:
+        nonlocal last_reported_state
         state = client.get_run_status(run_id)["state"]
         ctx.vlog(f"WES run [{run_id}] state [{state}]")
         if is_terminal(state):
@@ -273,10 +268,9 @@ def _wait_for_wes_run(ctx: "PlanemoCliContext", client: WesClient, run_id: str, 
         if state != last_reported_state:
             info(f"WES run [{run_id}] state [{state}]")
             last_reported_state = state
-        if waited > timeout:
-            raise Exception(f"Timed out waiting on WES run {run_id} (last state [{state}]).")
-        time.sleep(interval)
-        waited += interval
+        return None
+
+    return wait_on(state_func, f"WES run {run_id}", timeout, interval=DEFAULT_WES_POLL_INTERVAL)
 
 
 def _verified_tool_id(runnable, user_gi):
@@ -1100,6 +1094,10 @@ class WesRunResponse(GalaxyWorkflowRunResponse):
     run id is the Galaxy workflow invocation id, so output collection, downloads,
     and invocation details reuse the Galaxy API machinery of the superclass - WES
     itself has no data-staging or output-download endpoint.
+
+    The Galaxy ``invocation_state``/``history_state`` are not tracked here (left
+    as None); the WES terminal state is carried separately as ``wes_state`` in the
+    invocation details so reports don't conflate WES states with Galaxy states.
     """
 
     def __init__(
@@ -1126,12 +1124,13 @@ class WesRunResponse(GalaxyWorkflowRunResponse):
             workflow_id=workflow_id,
             invocation_id=invocation_id,
             history_state=None,
-            invocation_state=wes_state,
+            invocation_state=None,
             error_message=None,
             start_datetime=start_datetime,
             end_datetime=end_datetime,
             no_wait=no_wait,
         )
+        self._invocation_details.setdefault("details", {})["wes_state"] = wes_state
 
     @property
     def was_successful(self):

--- a/planemo/galaxy/wes.py
+++ b/planemo/galaxy/wes.py
@@ -49,28 +49,6 @@ class WesError(Exception):
         self.status_code = status_code
 
 
-def detect_workflow_type(workflow_text: str) -> str:
-    """Guess the Galaxy WES ``workflow_type`` from a workflow document.
-
-    Returns ``gx_workflow_format2`` for Format2 (``class: GalaxyWorkflow``) or
-    ``gx_workflow_ga`` for native ``.ga`` workflows. Galaxy re-validates the type
-    against the referenced workflow, so this only needs to be approximately right.
-    """
-    text = workflow_text.lstrip()
-    if text.startswith("{"):
-        try:
-            parsed = json.loads(workflow_text)
-        except ValueError:
-            parsed = {}
-        if isinstance(parsed, dict) and parsed.get("class") == "GalaxyWorkflow":
-            return "gx_workflow_format2"
-        return "gx_workflow_ga"
-    # YAML-ish: Format2 documents declare ``class: GalaxyWorkflow``.
-    if "class: GalaxyWorkflow" in workflow_text or "class: 'GalaxyWorkflow'" in workflow_text:
-        return "gx_workflow_format2"
-    return "gx_workflow_ga"
-
-
 class WesClient:
     """Minimal Galaxy GA4GH WES client."""
 
@@ -130,7 +108,6 @@ class WesClient:
 
 
 __all__ = (
-    "detect_workflow_type",
     "FAILURE_STATES",
     "is_failure",
     "is_success",

--- a/planemo/galaxy/wes.py
+++ b/planemo/galaxy/wes.py
@@ -1,0 +1,142 @@
+"""A thin ``requests`` client for Galaxy's GA4GH WES endpoints.
+
+This is a dependency-light wrapper (``requests`` only) covering the subset of the
+WES wire protocol planemo needs to submit a workflow run and poll it to a
+terminal state. It is modeled on the standalone ``gxy-wes`` reference client.
+WES has no data-staging or output-download endpoint, so input staging and output
+downloads are handled separately through the native Galaxy API.
+"""
+
+import json
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+import requests
+
+WES_PREFIX = "ga4gh/wes/v1"
+
+STATE_COMPLETE = "COMPLETE"
+# Terminal states that indicate the run did not succeed.
+FAILURE_STATES = frozenset({"EXECUTOR_ERROR", "SYSTEM_ERROR", "CANCELED"})
+# WES run states that mean "stop polling".
+TERMINAL_STATES = FAILURE_STATES | {STATE_COMPLETE}
+
+
+def is_terminal(state: str) -> bool:
+    """Return True if ``state`` is a terminal WES run state (success or failure)."""
+    return state in TERMINAL_STATES
+
+
+def is_success(state: str) -> bool:
+    """Return True if ``state`` is the successful terminal WES run state."""
+    return state == STATE_COMPLETE
+
+
+def is_failure(state: str) -> bool:
+    """Return True if ``state`` is a terminal WES run state indicating failure."""
+    return state in FAILURE_STATES
+
+
+class WesError(Exception):
+    """Raised when the WES server returns a non-2xx response."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        #: HTTP status code of the failed response, when available.
+        self.status_code = status_code
+
+
+def detect_workflow_type(workflow_text: str) -> str:
+    """Guess the Galaxy WES ``workflow_type`` from a workflow document.
+
+    Returns ``gx_workflow_format2`` for Format2 (``class: GalaxyWorkflow``) or
+    ``gx_workflow_ga`` for native ``.ga`` workflows. Galaxy re-validates the type
+    against the referenced workflow, so this only needs to be approximately right.
+    """
+    text = workflow_text.lstrip()
+    if text.startswith("{"):
+        try:
+            parsed = json.loads(workflow_text)
+        except ValueError:
+            parsed = {}
+        if isinstance(parsed, dict) and parsed.get("class") == "GalaxyWorkflow":
+            return "gx_workflow_format2"
+        return "gx_workflow_ga"
+    # YAML-ish: Format2 documents declare ``class: GalaxyWorkflow``.
+    if "class: GalaxyWorkflow" in workflow_text or "class: 'GalaxyWorkflow'" in workflow_text:
+        return "gx_workflow_format2"
+    return "gx_workflow_ga"
+
+
+class WesClient:
+    """Minimal Galaxy GA4GH WES client."""
+
+    def __init__(self, galaxy_url: str, api_key: Optional[str] = None, timeout: float = 60.0) -> None:
+        self.galaxy_url = galaxy_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+        return headers
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
+        url = f"{self.galaxy_url}/{path.lstrip('/')}"
+        response = self.session.request(method, url, headers=self._headers(), timeout=self.timeout, **kwargs)
+        if not response.ok:
+            message = response.text
+            try:
+                body = response.json()
+                message = body.get("err_msg", message)
+            except ValueError:
+                pass
+            raise WesError(
+                f"{method} {url} -> HTTP {response.status_code}: {message}", status_code=response.status_code
+            )
+        return response
+
+    def submit_run(
+        self,
+        *,
+        workflow_type: str,
+        workflow_url: str,
+        workflow_type_version: str = "1.0.0",
+        params: Optional[Dict[str, Any]] = None,
+        engine_parameters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Submit a workflow run, returning ``{"run_id": ...}``."""
+        if not workflow_url:
+            raise ValueError("workflow_url is required to submit a WES run")
+
+        data: Dict[str, str] = {
+            "workflow_type": workflow_type,
+            "workflow_type_version": workflow_type_version,
+            "workflow_url": workflow_url,
+        }
+        if params is not None:
+            data["workflow_params"] = json.dumps(params)
+        if engine_parameters is not None:
+            data["workflow_engine_parameters"] = json.dumps(engine_parameters)
+        return self._request("POST", f"{WES_PREFIX}/runs", data=data).json()
+
+    def get_run_status(self, run_id: str) -> Dict[str, Any]:
+        return self._request("GET", f"{WES_PREFIX}/runs/{run_id}/status").json()
+
+
+__all__ = (
+    "detect_workflow_type",
+    "FAILURE_STATES",
+    "is_failure",
+    "is_success",
+    "is_terminal",
+    "STATE_COMPLETE",
+    "TERMINAL_STATES",
+    "WesClient",
+    "WesError",
+)

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -324,12 +324,13 @@ def tee_captured_output(output):
             sys.stderr.write(message["data"] + "\n")
 
 
-def wait_on(function, desc, timeout=5, polling_backoff=0):
+def wait_on(function, desc, timeout=5, polling_backoff=0, interval=0.25):
     """Wait on given function's readiness.
 
-    Grow the polling interval incrementally by the polling_backoff.
+    Poll every ``interval`` seconds, growing the interval incrementally by the
+    polling_backoff after each attempt.
     """
-    delta = 0.25
+    delta = interval
     timing = 0
     while True:
         if timing > timeout:

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -356,6 +356,20 @@ def run_download_outputs_option():
     )
 
 
+def wes_option():
+    return planemo_option(
+        "--wes/--no_wes",
+        is_flag=True,
+        default=False,
+        help=(
+            "Execute the workflow against the target Galaxy's GA4GH WES "
+            "(Workflow Execution Service) endpoint instead of the native "
+            "invocation API. Works with both planemo-managed and external "
+            "(--galaxy_url) Galaxy servers."
+        ),
+    )
+
+
 def run_export_option():
     return planemo_option(
         "--export_invocation",

--- a/tests/test_wes.py
+++ b/tests/test_wes.py
@@ -1,6 +1,5 @@
 """Tests for the GA4GH WES client and ``planemo run --wes`` plumbing."""
 
-import json
 from pathlib import Path
 from unittest import mock
 
@@ -15,12 +14,10 @@ from planemo.galaxy.activity import (
     _wait_for_wes_run,
     _wes_execute,
     _wes_workflow_params,
-    _wes_workflow_type,
     GalaxyWorkflowRunResponse,
     WesRunResponse,
 )
 from planemo.galaxy.wes import (
-    detect_workflow_type,
     FAILURE_STATES,
     is_failure,
     is_success,
@@ -41,20 +38,6 @@ DATA_DIR = Path(__file__).parent / "data"
 GA_WORKFLOW = str(DATA_DIR / "test_workflow_1.ga")
 CWL_WORKFLOW = str(DATA_DIR / "count-lines2-wf.cwl")
 TOOL_XML = str(DATA_DIR / "cat_list.xml")
-
-
-class TestDetectWorkflowType:
-    def test_format2_yaml(self):
-        assert detect_workflow_type("class: GalaxyWorkflow\nsteps: {}") == "gx_workflow_format2"
-
-    def test_format2_json(self):
-        assert detect_workflow_type(json.dumps({"class": "GalaxyWorkflow"})) == "gx_workflow_format2"
-
-    def test_native_ga_json(self):
-        assert detect_workflow_type(json.dumps({"a_galaxy_workflow": "true", "steps": {}})) == "gx_workflow_ga"
-
-    def test_native_ga_default(self):
-        assert detect_workflow_type("steps:\n  0: {}") == "gx_workflow_ga"
 
 
 class TestWesClient:
@@ -160,28 +143,11 @@ class TestStateHelpers:
         assert not is_terminal("RUNNING")
 
 
-class TestWesWorkflowType:
-    def test_native_ga_path(self):
-        runnable = Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow)
-        assert _wes_workflow_type(runnable) == "gx_workflow_ga"
-
-    def test_format2_path(self, tmp_path):
-        wf = tmp_path / "wf.gxwf.yml"
-        wf.write_text("class: GalaxyWorkflow\nsteps: {}\n")
-        runnable = Runnable(str(wf), RunnableType.galaxy_workflow)
-        assert _wes_workflow_type(runnable) == "gx_workflow_format2"
-
-    def test_remote_instance_uri_without_path_defaults_to_ga(self):
-        runnable = Runnable("gxid://workflow-instance/abc123", RunnableType.galaxy_workflow)
-        assert not runnable.has_path
-        assert _wes_workflow_type(runnable) == "gx_workflow_ga"
-
-
 class TestWaitForWesRun:
     def test_returns_terminal_state(self):
         client = mock.Mock()
         client.get_run_status.side_effect = [{"state": "RUNNING"}, {"state": "COMPLETE"}]
-        with mock.patch("planemo.galaxy.activity.time.sleep"):
+        with mock.patch("planemo.io.time.sleep"):
             state = _wait_for_wes_run(mock.MagicMock(), client, "run1")
         assert state == "COMPLETE"
         assert client.get_run_status.call_count == 2
@@ -189,7 +155,7 @@ class TestWaitForWesRun:
     def test_times_out(self):
         client = mock.Mock()
         client.get_run_status.return_value = {"state": "RUNNING"}
-        with mock.patch("planemo.galaxy.activity.time.sleep"):
+        with mock.patch("planemo.io.time.sleep"):
             with pytest.raises(Exception, match="Timed out"):
                 _wait_for_wes_run(mock.MagicMock(), client, "run1", test_timeout=0)
 
@@ -220,6 +186,14 @@ class TestWesRunResponseSuccess:
 
     def test_no_wait_is_successful_regardless(self):
         assert self._response("RUNNING", no_wait=True).was_successful
+
+    def test_invocation_state_not_conflated_with_wes_state(self):
+        # Galaxy invocation/history states are left untracked; the WES terminal
+        # state is surfaced separately so reports don't mix the two vocabularies.
+        response = self._response("COMPLETE")
+        assert response.invocation_state is None
+        assert response.history_state is None
+        assert response.invocation_details["details"]["wes_state"] == "COMPLETE"
 
 
 def _fake_config(workflow_ref_id="wfid", history_id="hist1"):

--- a/tests/test_wes.py
+++ b/tests/test_wes.py
@@ -1,0 +1,354 @@
+"""Tests for the GA4GH WES client and ``planemo run --wes`` plumbing."""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import responses
+from click.testing import CliRunner
+
+from planemo.cli import PlanemoCliContext
+from planemo.commands.cmd_run import cli as run_cli
+from planemo.galaxy.activity import (
+    _is_unstaged_file_input,
+    _wait_for_wes_run,
+    _wes_execute,
+    _wes_workflow_params,
+    _wes_workflow_type,
+    GalaxyWorkflowRunResponse,
+    WesRunResponse,
+)
+from planemo.galaxy.wes import (
+    detect_workflow_type,
+    FAILURE_STATES,
+    is_failure,
+    is_success,
+    is_terminal,
+    STATE_COMPLETE,
+    TERMINAL_STATES,
+    WesClient,
+    WesError,
+)
+from planemo.runnable import (
+    Runnable,
+    RunnableType,
+)
+
+GALAXY_URL = "http://localhost:8080"
+WES_RUNS = f"{GALAXY_URL}/ga4gh/wes/v1/runs"
+DATA_DIR = Path(__file__).parent / "data"
+GA_WORKFLOW = str(DATA_DIR / "test_workflow_1.ga")
+CWL_WORKFLOW = str(DATA_DIR / "count-lines2-wf.cwl")
+TOOL_XML = str(DATA_DIR / "cat_list.xml")
+
+
+class TestDetectWorkflowType:
+    def test_format2_yaml(self):
+        assert detect_workflow_type("class: GalaxyWorkflow\nsteps: {}") == "gx_workflow_format2"
+
+    def test_format2_json(self):
+        assert detect_workflow_type(json.dumps({"class": "GalaxyWorkflow"})) == "gx_workflow_format2"
+
+    def test_native_ga_json(self):
+        assert detect_workflow_type(json.dumps({"a_galaxy_workflow": "true", "steps": {}})) == "gx_workflow_ga"
+
+    def test_native_ga_default(self):
+        assert detect_workflow_type("steps:\n  0: {}") == "gx_workflow_ga"
+
+
+class TestWesClient:
+    @responses.activate
+    def test_submit_run_sends_params_and_returns_run_id(self):
+        responses.add(responses.POST, WES_RUNS, json={"run_id": "abc123"}, status=200)
+        client = WesClient(GALAXY_URL, api_key="key123")
+        result = client.submit_run(
+            workflow_type="gx_workflow_ga",
+            workflow_url="gxworkflow://abc",
+            params={"input1": 42},
+            engine_parameters={"history_name": "WES Run"},
+        )
+        assert result["run_id"] == "abc123"
+        request = responses.calls[0].request
+        assert request.headers["x-api-key"] == "key123"
+        body = request.body
+        assert "workflow_type=gx_workflow_ga" in body
+        # JSON-encoded params are url-encoded into the form body.
+        assert "input1" in body
+
+    @responses.activate
+    def test_submit_run_requires_workflow_url(self):
+        client = WesClient(GALAXY_URL)
+        with pytest.raises(ValueError):
+            client.submit_run(workflow_type="gx_workflow_ga", workflow_url="")
+
+    @responses.activate
+    def test_get_run_status(self):
+        responses.add(
+            responses.GET,
+            f"{WES_RUNS}/abc123/status",
+            json={"run_id": "abc123", "state": "RUNNING"},
+            status=200,
+        )
+        client = WesClient(GALAXY_URL, api_key="key123")
+        assert client.get_run_status("abc123")["state"] == "RUNNING"
+
+    @responses.activate
+    def test_error_raises_wes_error_with_status_code(self):
+        responses.add(responses.GET, f"{WES_RUNS}/missing/status", json={"err_msg": "nope"}, status=404)
+        client = WesClient(GALAXY_URL, api_key="key123")
+        with pytest.raises(WesError) as exc_info:
+            client.get_run_status("missing")
+        assert exc_info.value.status_code == 404
+        assert "nope" in str(exc_info.value)
+
+
+class TestStateConstants:
+    def test_complete_is_terminal_not_failure(self):
+        assert STATE_COMPLETE in TERMINAL_STATES
+        assert STATE_COMPLETE not in FAILURE_STATES
+
+    def test_failures_are_terminal(self):
+        assert FAILURE_STATES <= TERMINAL_STATES
+
+
+class TestWorkflowParams:
+    def test_scalar_params_allowed(self, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("input1: 5\ninput2: hello\n")
+        assert _wes_workflow_params(str(job)) == {"input1": 5, "input2": "hello"}
+
+    def test_prestaged_hda_reference_allowed(self, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("input1:\n  src: hda\n  id: abc123\n")
+        params = _wes_workflow_params(str(job))
+        assert params["input1"] == {"src": "hda", "id": "abc123"}
+
+    def test_local_file_input_rejected(self, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("input1:\n  class: File\n  path: ./data.txt\n")
+        with pytest.raises(Exception, match="data-staging"):
+            _wes_workflow_params(str(job))
+
+    def test_location_input_rejected(self, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("input1:\n  location: http://example.com/data.txt\n")
+        with pytest.raises(Exception, match="data-staging"):
+            _wes_workflow_params(str(job))
+
+    def test_is_unstaged_detects_nested_list(self):
+        assert _is_unstaged_file_input([{"class": "File", "path": "x"}])
+        assert not _is_unstaged_file_input([{"src": "hda", "id": "1"}])
+        assert not _is_unstaged_file_input("scalar")
+
+
+class TestStateHelpers:
+    def test_is_success(self):
+        assert is_success("COMPLETE")
+        assert not is_success("RUNNING")
+        assert not is_success("SYSTEM_ERROR")
+
+    def test_is_failure(self):
+        assert is_failure("SYSTEM_ERROR")
+        assert is_failure("EXECUTOR_ERROR")
+        assert not is_failure("COMPLETE")
+        assert not is_failure("RUNNING")
+
+    def test_is_terminal(self):
+        assert is_terminal("COMPLETE")
+        assert is_terminal("CANCELED")
+        assert not is_terminal("RUNNING")
+
+
+class TestWesWorkflowType:
+    def test_native_ga_path(self):
+        runnable = Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow)
+        assert _wes_workflow_type(runnable) == "gx_workflow_ga"
+
+    def test_format2_path(self, tmp_path):
+        wf = tmp_path / "wf.gxwf.yml"
+        wf.write_text("class: GalaxyWorkflow\nsteps: {}\n")
+        runnable = Runnable(str(wf), RunnableType.galaxy_workflow)
+        assert _wes_workflow_type(runnable) == "gx_workflow_format2"
+
+    def test_remote_instance_uri_without_path_defaults_to_ga(self):
+        runnable = Runnable("gxid://workflow-instance/abc123", RunnableType.galaxy_workflow)
+        assert not runnable.has_path
+        assert _wes_workflow_type(runnable) == "gx_workflow_ga"
+
+
+class TestWaitForWesRun:
+    def test_returns_terminal_state(self):
+        client = mock.Mock()
+        client.get_run_status.side_effect = [{"state": "RUNNING"}, {"state": "COMPLETE"}]
+        with mock.patch("planemo.galaxy.activity.time.sleep"):
+            state = _wait_for_wes_run(mock.MagicMock(), client, "run1")
+        assert state == "COMPLETE"
+        assert client.get_run_status.call_count == 2
+
+    def test_times_out(self):
+        client = mock.Mock()
+        client.get_run_status.return_value = {"state": "RUNNING"}
+        with mock.patch("planemo.galaxy.activity.time.sleep"):
+            with pytest.raises(Exception, match="Timed out"):
+                _wait_for_wes_run(mock.MagicMock(), client, "run1", test_timeout=0)
+
+
+class TestWesRunResponseSuccess:
+    def _response(self, wes_state, no_wait=False):
+        with mock.patch.object(GalaxyWorkflowRunResponse, "collect_invocation_details", return_value={}):
+            return WesRunResponse(
+                ctx=mock.MagicMock(),
+                runnable=Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow),
+                user_gi=mock.MagicMock(),
+                history_id="hist1",
+                workflow_id="wf1",
+                invocation_id="inv1",
+                wes_state=wes_state,
+                log="log",
+                no_wait=no_wait,
+            )
+
+    def test_complete_is_successful(self):
+        assert self._response("COMPLETE").was_successful
+
+    def test_failure_is_not_successful(self):
+        assert not self._response("SYSTEM_ERROR").was_successful
+
+    def test_running_is_not_successful_when_waited(self):
+        assert not self._response("RUNNING").was_successful
+
+    def test_no_wait_is_successful_regardless(self):
+        assert self._response("RUNNING", no_wait=True).was_successful
+
+
+def _fake_config(workflow_ref_id="wfid", history_id="hist1"):
+    config = mock.MagicMock()
+    config.galaxy_url = GALAXY_URL
+    config.user_api_key = "key123"
+    config.workflow_id_for_runnable.return_value = workflow_ref_id
+    config.user_gi.invocations.show_invocation.return_value = {
+        "history_id": history_id,
+        "workflow_id": "wfinstance",
+    }
+    return config
+
+
+class TestWesExecute:
+    @mock.patch("planemo.galaxy.activity.summarize_history")
+    @mock.patch("planemo.galaxy.activity.WesRunResponse")
+    @mock.patch("planemo.galaxy.activity.WesClient")
+    def test_success_submits_via_gxworkflow_uri(self, MockClient, MockResponse, mock_summarize, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("param1: 7\n")
+        client = MockClient.return_value
+        client.submit_run.return_value = {"run_id": "inv1"}
+        client.get_run_status.return_value = {"state": "COMPLETE"}
+        runnable = Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow)
+
+        result = _wes_execute(mock.MagicMock(), _fake_config(), runnable, str(job))
+
+        submit_kwargs = client.submit_run.call_args.kwargs
+        assert submit_kwargs["workflow_url"] == "gxworkflow://wfid"
+        assert submit_kwargs["workflow_type"] == "gx_workflow_ga"
+        assert submit_kwargs["params"] == {"param1": 7}
+        response_kwargs = MockResponse.call_args.kwargs
+        assert response_kwargs["wes_state"] == "COMPLETE"
+        assert response_kwargs["invocation_id"] == "inv1"
+        assert response_kwargs["history_id"] == "hist1"
+        mock_summarize.assert_not_called()
+        assert result is MockResponse.return_value
+
+    @mock.patch("planemo.galaxy.activity.summarize_history")
+    @mock.patch("planemo.galaxy.activity.WesRunResponse")
+    @mock.patch("planemo.galaxy.activity.WesClient")
+    def test_failure_summarizes_history(self, MockClient, MockResponse, mock_summarize, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("param1: 7\n")
+        client = MockClient.return_value
+        client.submit_run.return_value = {"run_id": "inv1"}
+        client.get_run_status.return_value = {"state": "SYSTEM_ERROR"}
+        runnable = Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow)
+
+        _wes_execute(mock.MagicMock(), _fake_config(), runnable, str(job))
+
+        mock_summarize.assert_called_once()
+        assert MockResponse.call_args.kwargs["wes_state"] == "SYSTEM_ERROR"
+
+    @mock.patch("planemo.galaxy.activity.summarize_history")
+    @mock.patch("planemo.galaxy.activity.WesRunResponse")
+    @mock.patch("planemo.galaxy.activity.WesClient")
+    def test_no_wait_does_not_poll_or_summarize(self, MockClient, MockResponse, mock_summarize, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("param1: 7\n")
+        client = MockClient.return_value
+        client.submit_run.return_value = {"run_id": "inv1"}
+        client.get_run_status.return_value = {"state": "QUEUED"}
+        runnable = Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow)
+
+        _wes_execute(mock.MagicMock(), _fake_config(), runnable, str(job), no_wait=True)
+
+        client.get_run_status.assert_called_once()
+        mock_summarize.assert_not_called()
+        assert MockResponse.call_args.kwargs["no_wait"] is True
+
+    @mock.patch("planemo.galaxy.activity.summarize_history")
+    @mock.patch("planemo.galaxy.activity.WesRunResponse")
+    @mock.patch("planemo.galaxy.activity.WesClient")
+    def test_instance_uri_appends_instance_flag(self, MockClient, MockResponse, mock_summarize, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("param1: 7\n")
+        client = MockClient.return_value
+        client.submit_run.return_value = {"run_id": "inv1"}
+        client.get_run_status.return_value = {"state": "COMPLETE"}
+        runnable = Runnable("gxid://workflow-instance/abc", RunnableType.galaxy_workflow)
+
+        _wes_execute(mock.MagicMock(), _fake_config(workflow_ref_id="abc"), runnable, str(job))
+
+        assert client.submit_run.call_args.kwargs["workflow_url"] == "gxworkflow://abc?instance=true"
+
+    @mock.patch("planemo.galaxy.activity.summarize_history")
+    @mock.patch("planemo.galaxy.activity.WesClient")
+    def test_download_outputs_uses_galaxy_api(self, MockClient, mock_summarize, tmp_path):
+        job = tmp_path / "job.yml"
+        job.write_text("param1: 7\n")
+        out_dir = tmp_path / "outs"
+        client = MockClient.return_value
+        client.submit_run.return_value = {"run_id": "inv1"}
+        client.get_run_status.return_value = {"state": "COMPLETE"}
+        runnable = Runnable(GA_WORKFLOW, RunnableType.galaxy_workflow)
+
+        with mock.patch("planemo.galaxy.activity.WesRunResponse") as MockResponse:
+            _wes_execute(
+                mock.MagicMock(),
+                _fake_config(),
+                runnable,
+                str(job),
+                download_outputs=True,
+                output_directory=str(out_dir),
+            )
+        MockResponse.return_value.collect_outputs.assert_called_once_with(str(out_dir))
+
+
+class TestRunCommandOption:
+    def test_wes_option_registered(self):
+        option_names = {opt.name for opt in run_cli.params}
+        assert "wes" in option_names
+
+    def _invoke(self, args):
+        return CliRunner().invoke(run_cli, args, obj=PlanemoCliContext(), standalone_mode=False)
+
+    def test_wes_rejects_cwl_workflow(self):
+        result = self._invoke([CWL_WORKFLOW, CWL_WORKFLOW, "--wes"])
+        assert result.exit_code != 0
+        assert "Galaxy workflows" in str(result.exception)
+
+    def test_wes_rejects_tool(self):
+        result = self._invoke([TOOL_XML, TOOL_XML, "--wes"])
+        assert result.exit_code != 0
+        assert "Galaxy workflows" in str(result.exception)
+
+    def test_wes_rejects_non_galaxy_engine(self):
+        result = self._invoke([GA_WORKFLOW, GA_WORKFLOW, "--wes", "--engine", "toil"])
+        assert result.exit_code != 0
+        assert "external_galaxy" in str(result.exception)


### PR DESCRIPTION
> 🤖 PR opened by Claude (AI assistant) on behalf of @jmchilton.

**[WIP]** — opening early for visibility; not ready for merge.

## What

Adds a `--wes` flag to `planemo run` that submits Galaxy workflows to the target Galaxy's [GA4GH WES](https://ga4gh.github.io/workflow-execution-service-schemas/) endpoint instead of the native invocation API.

`--wes` is a modifier on the Galaxy execution path, not a separate engine — it reuses the existing Galaxy connection options and targets whichever server you're already pointing at (planemo-managed, or external via `--galaxy_url`).

```
planemo run tutorial.ga tutorial-job.yml --wes --galaxy_url SERVER_URL --galaxy_user_key YOUR_API_KEY
```

## Phase 1 scope

WES has no data-staging or output-download endpoint, so initial support is intentionally limited:

- Workflows only (not single tools).
- Inputs must be parameters or data already on the target Galaxy (`{"src": "hda", "id": ...}`). Local file inputs (`class: File` with `path`/`location`) are rejected.
- `--download_outputs` still works but downloads via the native Galaxy API (with a warning), since WES defines no download mechanism.

Run success is derived from the terminal WES state.

## Changes

- `planemo/galaxy/wes.py` — thin `requests`-only WES client (submit run, poll to terminal state) + state helpers.
- `planemo/galaxy/activity.py` — `wes_execute` / `_wes_execute`, param validation, polling, and `WesRunResponse`.
- `planemo/engine/galaxy.py` — route to `wes_execute` when `--wes` is set.
- `planemo/commands/cmd_run.py` — `--wes` validation (Galaxy workflows + galaxy/external_galaxy engines only).
- `planemo/options.py` — `wes_option`.
- `docs/_running_external.rst` — usage docs.
- `tests/test_wes.py` — client + plumbing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)