### PR TITLE
Add --lf/--failed to re-run only previously-failed tests

### DIFF
--- a/planemo/commands/cmd_test.py
+++ b/planemo/commands/cmd_test.py
@@ -13,12 +13,19 @@ from planemo.runnable_resolve import for_runnable_identifiers
 @options.optional_tools_arg(multiple=True, allow_uris=True)
 @click.option(
     "--failed",
+    "--lf",
     is_flag=True,
-    help="Re-run only failed tests. This command will read "
-    "tool_test_output.json to determine which tests failed so this "
-    "file must have been produced with the same set of tool ids "
-    "previously.",
+    help="Re-run only failed tests from the previous run. Reads from "
+    "--failed_json (or --test_output_json if not set) to determine "
+    "which tests failed.",
     default=False,
+)
+@click.option(
+    "--failed_json",
+    type=click.Path(),
+    help="JSON file from a previous planemo test run to read failed test IDs "
+    "from when using --failed/--lf. Defaults to --test_output_json.",
+    default=None,
 )
 @click.option(
     "--test_index",

--- a/planemo/engine/interface.py
+++ b/planemo/engine/interface.py
@@ -10,6 +10,8 @@ from typing import (
     Optional,
 )
 
+import click
+
 from planemo.exit_codes import EXIT_CODE_UNSUPPORTED_FILE_TYPE
 from planemo.io import error
 from planemo.runnable import (
@@ -89,6 +91,25 @@ class BaseEngine(Engine):
             else:
                 # If no tests match the specified indices, log a warning and use original
                 self._ctx.log(f"Warning: No tests found with indices {test_indices}. Running all tests instead.")
+
+        # Filter test cases to only previously-failed ones when --failed/--lf is set
+        if self._kwds.get("failed"):
+            failed_json = self._kwds.get("failed_json") or self._kwds.get("test_output_json")
+            if not failed_json or not os.path.exists(failed_json):
+                raise click.ClickException(
+                    "--failed/--lf requires a previous test output JSON. "
+                    "Set --failed_json or ensure --test_output_json exists from a prior run."
+                )
+            previous = StructuredData(json_path=failed_json)
+            failed_ids = previous.failed_ids
+            if not failed_ids:
+                self._ctx.log("No failed tests in previous run — nothing to re-run.")
+                empty = StructuredData(data={"version": "0.1", "tests": []})
+                empty.calculate_summary_data()
+                return empty
+            test_cases = [
+                tc for tc in test_cases if hasattr(tc, "_test_id") and f"{tc._test_id}_{tc.index}" in failed_ids
+            ]
 
         test_results = self._collect_test_results(test_cases, test_timeout)
         tests = []

--- a/tests/test_last_failed.py
+++ b/tests/test_last_failed.py
@@ -1,0 +1,222 @@
+"""Unit tests for --failed/--lf (last-failed) test filtering."""
+
+import json
+import os
+from tempfile import NamedTemporaryFile
+from typing import (
+    Any,
+    Dict,
+    List,
+)
+from unittest.mock import MagicMock
+
+import pytest
+
+import planemo.engine.interface as _engine_iface
+from planemo.engine.interface import BaseEngine
+from planemo.test.results import StructuredData
+
+# Importing test_utils first causes planemo.cli → planemo.runnable to be fully
+# initialized before planemo.engine.interface is imported below, preventing the
+# circular import that otherwise occurs when planemo.engine is loaded in isolation.
+from .test_utils import create_test_context
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_json(tests: List[Dict[str, Any]]) -> str:
+    tmp = NamedTemporaryFile(suffix=".json", delete=False, mode="w")
+    json.dump({"version": "0.1", "tests": tests}, tmp)
+    tmp.close()
+    return tmp.name
+
+
+def _test_entry(test_id: str, status: str) -> Dict[str, Any]:
+    return {"id": test_id, "has_data": True, "data": {"status": status}}
+
+
+def _make_test_case(test_id: str, index: int) -> MagicMock:
+    tc = MagicMock()
+    tc._test_id = test_id
+    tc.index = index
+    return tc
+
+
+class _MinimalEngine(BaseEngine):
+    """Stub engine that records which test cases reach _collect_test_results."""
+
+    handled_runnable_types = []
+
+    def __init__(self, ctx, submitted, **kwds):
+        super().__init__(ctx, **kwds)
+        self._submitted = submitted
+
+    def _check_can_run_all(self, runnables):
+        """No-op: allow any runnable type in tests."""
+
+    def _run(self, runnables, job_paths, output_collectors=None):
+        return []
+
+    def _collect_test_results(self, cases, test_timeout):
+        self._submitted.extend(cases)
+        return []
+
+
+def _run_engine_filter(test_cases, kwds):
+    """Call BaseEngine.test() with a stub cases() and return submitted cases."""
+    submitted = []
+    engine = _MinimalEngine(create_test_context(), submitted, **kwds)
+
+    fake_runnable = MagicMock()
+    original_cases = _engine_iface.cases
+    _engine_iface.cases = lambda _: test_cases
+    try:
+        engine.test([fake_runnable], test_timeout=0)
+    finally:
+        _engine_iface.cases = original_cases
+
+    return submitted
+
+
+# ---------------------------------------------------------------------------
+# StructuredData.failed_ids
+# ---------------------------------------------------------------------------
+
+
+class TestFailedIds:
+    def test_returns_only_non_success(self):
+        json_path = _make_json(
+            [
+                _test_entry("tool_a_0", "success"),
+                _test_entry("tool_a_1", "failure"),
+                _test_entry("tool_b_0", "error"),
+                _test_entry("tool_c_0", "skip"),
+            ]
+        )
+        try:
+            assert StructuredData(json_path=json_path).failed_ids == {"tool_a_1", "tool_b_0", "tool_c_0"}
+        finally:
+            os.unlink(json_path)
+
+    def test_empty_when_all_pass(self):
+        json_path = _make_json(
+            [
+                _test_entry("tool_a_0", "success"),
+                _test_entry("tool_a_1", "success"),
+            ]
+        )
+        try:
+            assert StructuredData(json_path=json_path).failed_ids == set()
+        finally:
+            os.unlink(json_path)
+
+    def test_all_when_all_fail(self):
+        json_path = _make_json(
+            [
+                _test_entry("tool_a_0", "failure"),
+                _test_entry("tool_b_0", "failure"),
+            ]
+        )
+        try:
+            assert StructuredData(json_path=json_path).failed_ids == {"tool_a_0", "tool_b_0"}
+        finally:
+            os.unlink(json_path)
+
+
+# ---------------------------------------------------------------------------
+# BaseEngine.test() filtering via --failed
+# ---------------------------------------------------------------------------
+
+
+class TestBaseEngineFailedFilter:
+    def test_no_filter_without_flag(self, tmp_path):
+        """Without --failed, all test cases are submitted."""
+        cases = [_make_test_case("tool_a", 0), _make_test_case("tool_a", 1)]
+        submitted = _run_engine_filter(cases, {"failed": False})
+        assert len(submitted) == 2
+
+    def test_filters_to_failed_only(self, tmp_path):
+        """With --failed, only test cases matching failed IDs are submitted."""
+        json_path = str(tmp_path / "prev.json")
+        with open(json_path, "w") as f:
+            json.dump(
+                {
+                    "version": "0.1",
+                    "tests": [
+                        _test_entry("tool_a_0", "failure"),
+                        _test_entry("tool_a_1", "success"),
+                    ],
+                },
+                f,
+            )
+
+        cases = [_make_test_case("tool_a", 0), _make_test_case("tool_a", 1)]
+        submitted = _run_engine_filter(cases, {"failed": True, "test_output_json": json_path})
+        assert len(submitted) == 1
+        assert submitted[0]._test_id == "tool_a"
+        assert submitted[0].index == 0
+
+    def test_failed_json_takes_precedence_over_test_output_json(self, tmp_path):
+        """--failed_json is used instead of --test_output_json when both are set."""
+        output_json = str(tmp_path / "output.json")
+        with open(output_json, "w") as f:
+            json.dump(
+                {
+                    "version": "0.1",
+                    "tests": [
+                        _test_entry("tool_a_0", "success"),
+                        _test_entry("tool_a_1", "failure"),
+                    ],
+                },
+                f,
+            )
+
+        failed_json = str(tmp_path / "failed.json")
+        with open(failed_json, "w") as f:
+            json.dump(
+                {
+                    "version": "0.1",
+                    "tests": [
+                        _test_entry("tool_a_0", "failure"),
+                        _test_entry("tool_a_1", "success"),
+                    ],
+                },
+                f,
+            )
+
+        cases = [_make_test_case("tool_a", 0), _make_test_case("tool_a", 1)]
+        submitted = _run_engine_filter(
+            cases,
+            {"failed": True, "failed_json": failed_json, "test_output_json": output_json},
+        )
+        # failed_json says index 0 failed; output.json says index 1 failed
+        assert len(submitted) == 1
+        assert submitted[0].index == 0
+
+    def test_raises_when_no_json_exists(self, tmp_path):
+        """--failed without a readable JSON raises ClickException."""
+        from click import ClickException
+
+        cases = [_make_test_case("tool_a", 0)]
+        with pytest.raises(ClickException, match="--failed/--lf requires"):
+            _run_engine_filter(cases, {"failed": True, "test_output_json": str(tmp_path / "missing.json")})
+
+    def test_returns_empty_when_all_passed(self, tmp_path):
+        """--failed when no tests previously failed returns zero submitted cases."""
+        json_path = str(tmp_path / "prev.json")
+        with open(json_path, "w") as f:
+            json.dump(
+                {
+                    "version": "0.1",
+                    "tests": [
+                        _test_entry("tool_a_0", "success"),
+                    ],
+                },
+                f,
+            )
+
+        cases = [_make_test_case("tool_a", 0)]
+        submitted = _run_engine_filter(cases, {"failed": True, "test_output_json": json_path})
+        assert submitted == []


### PR DESCRIPTION
## Summary

The `--failed` flag has been defined in `planemo test` since 2015 but was never
wired into the modern execution pipeline — the only code that referenced it
(`GalaxyTestCommand.build()`) is dead code left over from the old `run_tests.sh`
approach.

This PR implements the flag properly:

- **`--failed` / `--lf`**: filters test cases *before* execution to only those
  whose IDs appear as non-success in a previous `tool_test_output.json`.
  `--lf` is added as a pytest-compatible alias.
- **`--failed_json`**: optional separate path to read the previous results from,
  distinct from `--test_output_json`. This is needed when the planemo-ci-action
  test loop runs multiple tool groups, each writing their own output JSON, while
  all reading from the same previous chunk-level JSON for filtering.

### How the filter works

Test case IDs follow the pattern `{tool_id}_{index}` (e.g. `bwa_mem_0`).
`StructuredData.failed_ids` already returns these from the JSON; the new code
in `BaseEngine.test()` filters the gathered test cases against that set before
handing them to the engine.

### planemo-ci-action changes

A companion PR to [planemo-ci-action](https://github.com/galaxyproject/planemo-ci-action)
adds a `retest` mode and a `previous-run-id` input. In `retest` mode the action:

1. Downloads the `Tool test output {chunk}` artifact from the specified previous
   run via `gh run download`
2. Finds the same tool groups for this chunk
3. Runs `planemo test --failed --failed_json previous_run_results/tool_test_output.json`
   for each group

This lets IUC weekly test maintainers re-run only the failing tests from a
previous scheduled run by triggering a `workflow_dispatch` with the failed run's
ID, without re-testing everything that already passed.

## Usage

```bash
# normal run
planemo test tool.xml --test_output_json results.json

# re-run only failures (reads results.json, overwrites it)
planemo test tool.xml --lf --test_output_json results.json

# separate input and output (useful in CI loops)
planemo test tool.xml --lf --failed_json prev.json --test_output_json rerun.json
```

## Test plan

- [x] Unit tests in `tests/test_last_failed.py` covering:
  - `StructuredData.failed_ids` includes failure/error/skip, excludes success
  - Without `--failed`, all test cases pass through unchanged
  - With `--failed`, only previously-failed cases are submitted to the engine
  - `--failed_json` takes precedence over `--test_output_json` as input source
  - Missing JSON raises a clear `ClickException`
  - All-passed previous run returns empty result immediately (no engine calls)