### PR TITLE
Fix describe_outputs crash when tool_state is a dict not a JSON string

### DIFF
--- a/planemo/galaxy/workflows.py
+++ b/planemo/galaxy/workflows.py
@@ -579,7 +579,11 @@ def describe_outputs(runnable, gi=None):
         optional = False
         if not step.get("tool_id"):
             # One of the parameter types ... need eliminate this guesswork on the Galaxy side
-            tool_state = json.loads(step.get("tool_state", "{}"))
+            raw_tool_state = step.get("tool_state", {})
+            if isinstance(raw_tool_state, str):
+                tool_state = json.loads(raw_tool_state)
+            else:
+                tool_state = raw_tool_state
             optional = tool_state.get("optional", False)
         step_outputs = step.get("workflow_outputs", [])
         for step_output in step_outputs:

--- a/tests/test_galaxy_workflow_utils.py
+++ b/tests/test_galaxy_workflow_utils.py
@@ -22,6 +22,15 @@ def test_describe_outputs():
     assert output.label == "wf_output_1"
 
 
+def test_describe_outputs_dict_tool_state():
+    """A .ga with dict (not JSON-string) tool_state must not crash describe_outputs."""
+    wf_path = os.path.join(TEST_DATA_DIR, "wf14-unlinted-best-practices-dict-tool-state.ga")
+    runnable = for_path(wf_path)
+    outputs = describe_outputs(runnable)
+    assert len(outputs) == 1
+    assert outputs[0].output_name == "outfile"
+
+
 def test_required_input_steps_excludes_falsy_defaults():
     """Inputs with a default are not required, even when the default is falsy (boolean false, int 0)."""
     wf_path = os.path.join(TEST_DATA_DIR, "wf_required_defaults.gxwf.yml")


### PR DESCRIPTION
## Problem

`describe_outputs` (`planemo/galaxy/workflows.py`) read step `tool_state` with an unconditional `json.loads`:

```python
tool_state = json.loads(step.get("tool_state", "{}"))
```

Some `.ga` workflows carry `tool_state` as an already-decoded **dict** rather than a JSON-encoded string. On those, `json.loads` raises:

```
TypeError: the JSON object must be str, bytes or bytearray, not dict
```

This fires on the `planemo test` / report path (via `get_outputs` → `describe_outputs`) for a workflow that otherwise runs green.

## Fix

Guard on type before decoding — the exact pattern already merged for the lint path in #1626, which missed this second call site. This keeps `workflow_lint` and `planemo test` consistent in how they tolerate dict `tool_state`:

```python
raw_tool_state = step.get("tool_state", {})
if isinstance(raw_tool_state, str):
    tool_state = json.loads(raw_tool_state)
else:
    tool_state = raw_tool_state
```

## Test

Adds `test_describe_outputs_dict_tool_state`, reusing the existing `wf14-unlinted-best-practices-dict-tool-state.ga` fixture (its step 0 has `tool_id: null` + dict `tool_state` — exactly this path). Verified red→green: without the fix the test reproduces the `TypeError`; with it, the file's tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)