### PR TITLE
Persist shed-installed data table config across Galaxy restarts

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -120,6 +120,11 @@ SHED_DATA_MANAGER_CONF_TEMPLATE = """<?xml version="1.0"?>
 </data_managers>
 """
 
+SHED_TOOL_DATA_TABLE_CONF_TEMPLATE = """<?xml version="1.0"?>
+<tables>
+</tables>
+"""
+
 EMPTY_JOB_METRICS_TEMPLATE = """<?xml version="1.0"?>
 <job_metrics>
 </job_metrics>
@@ -369,14 +374,16 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         tool_dependency_dir = kwds.get("tool_dependency_dir") or config_join("deps")
         _ensure_directory(tool_dependency_dir)
 
-        shed_tool_conf = kwds.get("shed_tool_conf") or config_join("shed_tools_conf.xml")
+        shed_config_paths = _shed_config_paths(kwds, config_join)
+        shed_tool_conf = shed_config_paths["shed_tool_conf"]
+        shed_tool_path = shed_config_paths["shed_tool_path"]
+        shed_tool_data_table_config = shed_config_paths["shed_tool_data_table_config"]
+        shed_data_manager_config_file = shed_config_paths["shed_data_manager_config_file"]
+
         empty_tool_conf = config_join("empty_tool_conf.xml")
 
         tool_conf = config_join("tool_conf.xml")
 
-        shed_data_manager_config_file = config_join("shed_data_manager_conf.xml")
-
-        shed_tool_path = kwds.get("shed_tool_path") or config_join("shed_tools")
         _ensure_directory(shed_tool_path)
 
         sheds_config_path = _configure_sheds_config_file(ctx, config_directory, runnables, **kwds)
@@ -435,6 +442,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
                 integrated_tool_panel_config=("${temp_directory}/integrated_tool_panel_conf.xml"),
                 migrated_tools_config=empty_tool_conf,
                 test_data_dir=test_data_dir,  # TODO: make gx respect this
+                shed_tool_data_table_config=shed_tool_data_table_config,
                 shed_data_manager_config_file=shed_data_manager_config_file,
                 outputs_to_working_directory="true",  # this makes Galaxy's files dir RO for dockerized testing
                 object_store_store_by="uuid",
@@ -481,10 +489,12 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         write_file(empty_tool_conf, EMPTY_TOOL_CONF_TEMPLATE)
 
         shed_tool_conf_contents = _sub(SHED_TOOL_CONF_TEMPLATE, template_args)
-        # Write a new shed_tool_conf.xml if needed.
-        write_file(shed_tool_conf, shed_tool_conf_contents, force=False)
-
-        write_file(shed_data_manager_config_file, SHED_DATA_MANAGER_CONF_TEMPLATE)
+        _write_shed_config_files(
+            shed_tool_conf,
+            shed_tool_conf_contents,
+            shed_tool_data_table_config,
+            shed_data_manager_config_file,
+        )
 
         yield LocalGalaxyConfig(
             ctx,
@@ -1558,6 +1568,56 @@ def _sub(template, args):
 def _ensure_directory(path):
     if path is not None and not os.path.exists(path):
         os.makedirs(path)
+
+
+def _shed_config_paths(kwds, config_join):
+    """Resolve persistent locations for the shed-install config files.
+
+    Precedence per file: an explicit per-option value, else a location under
+    ``--shed_data_dir``, else the ephemeral per-run config directory (the
+    historical behavior). Pinning these under a shared ``--shed_data_dir`` lets
+    shed installs -- tools, their data tables and data managers -- survive
+    Galaxy restarts, e.g. across a chunk of workflow tests that reuse a tool.
+
+    Pure path resolution; the caller is responsible for creating directories.
+    """
+    shed_data_dir = kwds.get("shed_data_dir")
+
+    def _resolve(kwd, basename):
+        explicit = kwds.get(kwd)
+        if explicit:
+            return explicit
+        if shed_data_dir:
+            return os.path.join(shed_data_dir, basename)
+        return config_join(basename)
+
+    return dict(
+        shed_tool_conf=_resolve("shed_tool_conf", "shed_tools_conf.xml"),
+        shed_tool_path=_resolve("shed_tool_path", "shed_tools"),
+        shed_tool_data_table_config=_resolve("shed_tool_data_table_config", "shed_tool_data_table_conf.xml"),
+        shed_data_manager_config_file=_resolve("shed_data_manager_config", "shed_data_manager_conf.xml"),
+    )
+
+
+def _write_shed_config_files(
+    shed_tool_conf,
+    shed_tool_conf_contents,
+    shed_tool_data_table_config,
+    shed_data_manager_config_file,
+):
+    """Write the shed-install config files only if absent (force=False).
+
+    Pinning these under ``--shed_data_dir`` or a persistent profile lets
+    shed-install state survive Galaxy restarts. ``write_file`` does not create
+    parent directories, so ensure them first.
+    """
+    for shed_path, contents in (
+        (shed_tool_conf, shed_tool_conf_contents),
+        (shed_tool_data_table_config, SHED_TOOL_DATA_TABLE_CONF_TEMPLATE),
+        (shed_data_manager_config_file, SHED_DATA_MANAGER_CONF_TEMPLATE),
+    ):
+        _ensure_directory(os.path.dirname(shed_path))
+        write_file(shed_path, contents, force=False)
 
 
 __all__ = (

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -215,6 +215,8 @@ def _profile_options(ctx, profile_name, **kwds):
         file_path = os.path.join(profile_directory, "files")
         shed_tool_path = os.path.join(profile_directory, "shed_tools")
         shed_tool_conf = os.path.join(profile_directory, "shed_tool_conf.xml")
+        shed_tool_data_table_config = os.path.join(profile_directory, "shed_tool_data_table_conf.xml")
+        shed_data_manager_config = os.path.join(profile_directory, "shed_data_manager_conf.xml")
         tool_dependency_dir = os.path.join(profile_directory, "deps")
 
         mulled_resolution_cache_data_dir = os.path.join(profile_directory, "mulled_resolution_cache")
@@ -224,6 +226,8 @@ def _profile_options(ctx, profile_name, **kwds):
             tool_dependency_dir=tool_dependency_dir,
             shed_tool_conf=shed_tool_conf,
             shed_tool_path=shed_tool_path,
+            shed_tool_data_table_config=shed_tool_data_table_config,
+            shed_data_manager_config=shed_data_manager_config,
             galaxy_brand=profile_name,
             mulled_resolution_cache_data_dir=mulled_resolution_cache_data_dir,
         )

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -447,6 +447,41 @@ def shed_tools_directory_option():
     )
 
 
+def shed_tool_data_table_config_option():
+    return planemo_option(
+        "--shed_tool_data_table_config",
+        type=str,
+        help="Location of the shed tool data table config file for Galaxy "
+        "(records data tables registered by shed-installed repositories).",
+        default=None,
+        use_global_config=True,
+    )
+
+
+def shed_data_manager_config_option():
+    return planemo_option(
+        "--shed_data_manager_config",
+        type=str,
+        help="Location of the shed data manager config file for Galaxy.",
+        default=None,
+        use_global_config=True,
+    )
+
+
+def shed_data_dir_option():
+    return planemo_option(
+        "--shed_data_dir",
+        type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
+        help="Persistent base directory for shed-install state (local Galaxy "
+        "engine). Seeds defaults for --shed_tool_conf, --shed_tool_path, "
+        "--shed_tool_data_table_config and --shed_data_manager_config so shed "
+        "installs (tools and their data tables) survive Galaxy restarts. "
+        "Individual options still override.",
+        default=None,
+        use_global_config=True,
+    )
+
+
 def tool_dependency_dir_option():
     return planemo_option(
         "--tool_dependency_dir",
@@ -1386,6 +1421,9 @@ def galaxy_config_options():
         postgres_database_storage_location_option(),
         shed_tools_conf_option(),
         shed_tools_directory_option(),
+        shed_tool_data_table_config_option(),
+        shed_data_manager_config_option(),
+        shed_data_dir_option(),
         single_user_mode_option(),
         tool_evaluation_strategy_option(),
     )

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -9,6 +9,7 @@ import yaml
 from planemo.galaxy.config import (
     _all_tool_paths,
     _shared_galaxy_properties,
+    _shed_config_paths,
     galaxy_config,
     get_refgenie_config,
     write_galaxy_config,
@@ -203,3 +204,40 @@ def _test_write_galaxy_config(**kwds):
             config_data = json.load(f)
 
         yield config_data, properties, env
+
+
+def _config_join(*args):
+    return os.path.join("/ephemeral", *args)
+
+
+def test_shed_config_paths_default_ephemeral():
+    """Without --shed_data_dir the paths fall back to the config directory."""
+    paths = _shed_config_paths({}, _config_join)
+    assert paths["shed_tool_conf"] == "/ephemeral/shed_tools_conf.xml"
+    assert paths["shed_tool_path"] == "/ephemeral/shed_tools"
+    assert paths["shed_tool_data_table_config"] == "/ephemeral/shed_tool_data_table_conf.xml"
+    assert paths["shed_data_manager_config_file"] == "/ephemeral/shed_data_manager_conf.xml"
+
+
+def test_shed_config_paths_seeded_by_shed_data_dir():
+    """--shed_data_dir seeds all four shed-install config paths."""
+    paths = _shed_config_paths({"shed_data_dir": "/persist"}, _config_join)
+    assert paths["shed_tool_conf"] == "/persist/shed_tools_conf.xml"
+    assert paths["shed_tool_path"] == "/persist/shed_tools"
+    assert paths["shed_tool_data_table_config"] == "/persist/shed_tool_data_table_conf.xml"
+    assert paths["shed_data_manager_config_file"] == "/persist/shed_data_manager_conf.xml"
+
+
+def test_shed_config_paths_individual_override_wins():
+    """An explicit per-file option overrides the --shed_data_dir default."""
+    kwds = {
+        "shed_data_dir": "/persist",
+        "shed_tool_conf": "/custom/conf.xml",
+        "shed_data_manager_config": "/custom/dm.xml",
+    }
+    paths = _shed_config_paths(kwds, _config_join)
+    assert paths["shed_tool_conf"] == "/custom/conf.xml"
+    assert paths["shed_data_manager_config_file"] == "/custom/dm.xml"
+    # untouched ones still derive from --shed_data_dir
+    assert paths["shed_tool_path"] == "/persist/shed_tools"
+    assert paths["shed_tool_data_table_config"] == "/persist/shed_tool_data_table_conf.xml"


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.**

## Problem

Fixes the CI failure reported in [galaxyproject/iwc#1294](https://github.com/galaxyproject/iwc/issues/1294).

When workflow tests run in a chunk, planemo reuses shed-installed tools across separate `planemo test` invocations via the fixed `--shed_tool_conf` / `--shed_tool_path` paths. But the shed-installed **data-table** config (`shed_tool_data_table_config`) and the shed **data-manager** config were only ever written into the ephemeral per-run `mkdtemp()` config directory.

So the 2nd+ workflow in a chunk to use a data-table tool (e.g. `featurecounts` in `rnaseq-sr`, after `rnaseq-pe`) sees the tool **already installed**, skips reinstall — and reinstall was the only thing that registered the data-table columns. The tool then can't resolve its columns and fails with:

```
ValueError: invalid literal for int() with base 10: 'dbkey'
```

even though the tool works fine on production Galaxy instances.

## Change

- New `--shed_data_dir <path>` base option that seeds persistent defaults for all four shed-install config paths — `shed_tool_conf`, `shed_tool_path`, `shed_tool_data_table_config`, `shed_data_manager_config` — each still individually overridable. Precedence: explicit per-option value > `--shed_data_dir`-derived > ephemeral per-run dir (unchanged historical default). Mirrors the existing profile-directory cascading pattern.
- Expose `--shed_tool_data_table_config` and `--shed_data_manager_config` (previously had no override at all), and set `shed_tool_data_table_config` in Galaxy properties (it was never set).
- Write the shed configs with `force=False` so pinned state survives Galaxy restarts.
- Persist the two previously-ephemeral configs for named profiles too (`_profile_options`), which shared the same failure mode.

## Notes

- Opt-in: with no caller passing `--shed_data_dir`, behavior is unchanged. A companion change in [planemo-ci-action](https://github.com/galaxyproject/planemo-ci-action) to pass `--shed_data_dir` at a fixed path is what actually closes iwc#1294.
- Scoped to the local Galaxy engine (`local_galaxy_config`); the fully-dockerized engine is unchanged.

## Tests

Added unit tests for the new `_shed_config_paths` precedence resolution (default / seeded / per-option override). `tests/test_galaxy_config.py` passes; flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)