### PR TITLE
Skip bot authors in bootstrap_history acknowledgements

### DIFF
--- a/scripts/bootstrap_history.py
+++ b/scripts/bootstrap_history.py
@@ -78,10 +78,15 @@ def generate_acknowledgements():
                     req = requests.get(api_url).json()
                     title = req.get("title", "")
                     login = req["user"]["login"]
+                    is_bot = req["user"].get("type") == "Bot" or login.endswith("[bot]")
 
-                    # Format acknowledgement line
+                    # Format acknowledgement line - skip crediting bots, they have no
+                    # contributor link target and break twine's RST check.
                     title_clean = title.rstrip(".")
-                    ack_line = f"* {title_clean} (thanks to `@{login}`_). `Pull Request {pr_number}`_"
+                    if is_bot:
+                        ack_line = f"* {title_clean}. `Pull Request {pr_number}`_"
+                    else:
+                        ack_line = f"* {title_clean} (thanks to `@{login}`_). `Pull Request {pr_number}`_"
                     acknowledgements.append(ack_line)
 
                     # Add GitHub link


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of @jmchilton.

Bot authors like `dependabot[bot]` have no contributor link target in HISTORY.rst, so `bootstrap_history.py` generated a dangling RST reference (`` `@dependabot[bot]`_ ``) that failed `twine check` during the 0.75.45 release (`Unknown target name: "@dependabot[bot]"`).

This detects bot authors (GitHub API `user.type == "Bot"`, or login ending in `[bot]`) and emits the changelog line without the `(thanks to ...)` credit, so future releases with dependabot-authored PRs don't break `make release` at the dist check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
