### PR TITLE
Lint that a workflow's pinned changeset_revision provides the referenced tool version

### DIFF
--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -497,18 +497,73 @@ def find_repos_from_tool_id(tool_id: str, ts: ToolShedInstance) -> Tuple[str, Di
         return ("", repos)
 
 
-def assert_valid_tool_id_in_tool_shed(tool_id: str, ts: ToolShedInstance) -> Optional[str]:
+def assert_valid_tool_id_in_tool_shed(
+    tool_id: str, ts: ToolShedInstance, changeset_revision: Optional[str] = None
+) -> Optional[str]:
     if "/repos" not in tool_id:
         return None
     warning_msg, repos = find_repos_from_tool_id(tool_id, ts)
     if warning_msg:
         return warning_msg
+
+    tool_found = any(
+        tool_id == tool.get("guid")
+        for repo in repos.values()
+        if isinstance(repo, dict)
+        for tool in repo.get("tools", [])
+    )
+    if not tool_found:
+        return f"The tool {tool_id} is not in the toolshed (may have been tagged as invalid)."
+
+    if changeset_revision is not None:
+        # The tool version exists in the toolshed; make sure the pinned revision provides it.
+        return _assert_tool_id_in_changeset(tool_id, changeset_revision, repos)
+
+    return None
+
+
+def _assert_tool_id_in_changeset(tool_id: str, changeset_revision: str, repos: Dict[str, Any]) -> Optional[str]:
+    """Check that the pinned ``changeset_revision`` actually provides ``tool_id``.
+
+    When a native ``.ga`` workflow references a tool it also pins a
+    ``tool_shed_repository`` changeset revision, and that is the exact revision
+    Galaxy installs when bootstrapping the workflow's tests. If the pinned
+    revision does not provide the referenced tool version the tool is never
+    installed and the workflow fails to run, so verify the two agree.
+    """
+    matching_revision = None
     for repo in repos.values():
-        tools = repo.get("tools", [])
-        for tool in tools:
-            if tool_id == tool.get("guid"):
-                return None
-    return f"The tool {tool_id} is not in the toolshed (may have been tagged as invalid)."
+        if not isinstance(repo, dict):
+            continue
+        if repo.get("changeset_revision") == changeset_revision:
+            matching_revision = repo
+            break
+
+    if matching_revision is None:
+        return (
+            f"The tool {tool_id} references changeset_revision {changeset_revision}, "
+            "which is not an installable revision of the repository."
+        )
+
+    for tool in matching_revision.get("tools", []):
+        if tool_id == tool.get("guid"):
+            return None
+
+    # The referenced version is not provided by the pinned changeset. Point at
+    # the revision(s) that do provide it so the mismatch is actionable.
+    providing_revisions = [
+        repo.get("changeset_revision")
+        for repo in repos.values()
+        if isinstance(repo, dict) and any(tool_id == tool.get("guid") for tool in repo.get("tools", []))
+    ]
+    message = (
+        f"The tool {tool_id} is not provided by the pinned changeset_revision "
+        f"{changeset_revision} of the repository (the tool_shed_repository revision "
+        "and the tool version in the workflow do not match)."
+    )
+    if providing_revisions:
+        message += f" This version is provided by changeset_revision {', '.join(providing_revisions)}."
+    return message
 
 
 def _lint_tool_ids(path: str, lint_context: WorkflowLintContext) -> None:
@@ -518,7 +573,13 @@ def _lint_tool_ids(path: str, lint_context: WorkflowLintContext) -> None:
         steps = wf_dict.get("steps", {})
         for step in steps.values():
             if step.get("type", "tool") == "tool" and not step.get("run", {}).get("class") == "GalaxyWorkflow":
-                warning_msg = assert_valid_tool_id_in_tool_shed(step["tool_id"], ts)
+                tool_shed_repository = step.get("tool_shed_repository")
+                if not tool_shed_repository:
+                    # Nothing to validate the tool_id/version against (e.g. built-in tools
+                    # or gxformat2 steps without a pinned repository), so skip the check.
+                    continue
+                changeset_revision = tool_shed_repository.get("changeset_revision")
+                warning_msg = assert_valid_tool_id_in_tool_shed(step["tool_id"], ts, changeset_revision)
                 if warning_msg:
                     lint_context.error(warning_msg)
                     failed = True

--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -553,9 +553,11 @@ def _assert_tool_id_in_changeset(tool_id: str, changeset_revision: str, repos: D
     # The referenced version is not provided by the pinned changeset. Point at
     # the revision(s) that do provide it so the mismatch is actionable.
     providing_revisions = [
-        repo.get("changeset_revision")
+        repo["changeset_revision"]
         for repo in repos.values()
-        if isinstance(repo, dict) and any(tool_id == tool.get("guid") for tool in repo.get("tools", []))
+        if isinstance(repo, dict)
+        and repo.get("changeset_revision")
+        and any(tool_id == tool.get("guid") for tool in repo.get("tools", []))
     ]
     message = (
         f"The tool {tool_id} is not provided by the pinned changeset_revision "

--- a/planemo/workflow_lint.py
+++ b/planemo/workflow_lint.py
@@ -176,6 +176,7 @@ def _lint_workflow_artifacts_on_path(lint_context: WorkflowLintContext, path: st
             lint_context.lint("lint_best_practices", _lint_best_practices, potential_workflow_artifact_path)
             lint_context.lint("lint_tests", _lint_tsts, potential_workflow_artifact_path)
             lint_context.lint("lint_tool_ids", _lint_tool_ids, potential_workflow_artifact_path)
+            lint_context.lint("lint_tool_versions", _lint_tool_versions, potential_workflow_artifact_path)
         else:
             # Allow linting ro crates and such also
             pass
@@ -566,41 +567,61 @@ def _assert_tool_id_in_changeset(tool_id: str, changeset_revision: str, repos: D
     return message
 
 
-def _lint_tool_ids(path: str, lint_context: WorkflowLintContext) -> None:
-    def _lint_tool_ids_steps(lint_context: WorkflowLintContext, wf_dict: Dict, ts: ToolShedInstance) -> bool:
-        """Returns whether a single tool_id was invalid"""
-        failed = False
-        steps = wf_dict.get("steps", {})
-        for step in steps.values():
-            if step.get("type", "tool") == "tool" and not step.get("run", {}).get("class") == "GalaxyWorkflow":
-                tool_shed_repository = step.get("tool_shed_repository")
-                if not tool_shed_repository:
-                    # Nothing to validate the tool_id/version against (e.g. built-in tools
-                    # or gxformat2 steps without a pinned repository), so skip the check.
-                    continue
-                changeset_revision = tool_shed_repository.get("changeset_revision")
-                warning_msg = assert_valid_tool_id_in_tool_shed(step["tool_id"], ts, changeset_revision)
-                if warning_msg:
-                    lint_context.error(warning_msg)
-                    failed = True
-            elif step.get("type") == "subworkflow":  # GA SWF
-                sub_failed = _lint_tool_ids_steps(lint_context, step["subworkflow"], ts)
-                if sub_failed:
-                    failed = True
-            elif step.get("run", {}).get("class") == "GalaxyWorkflow":  # gxformat2 SWF
-                sub_failed = _lint_tool_ids_steps(lint_context, step["run"], ts)
-                if sub_failed:
-                    failed = True
-            else:
-                continue
-        return failed
+def _iter_tool_steps(wf_dict: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    """Yield every tool step in a workflow, recursing into subworkflows."""
+    steps = wf_dict.get("steps", {})
+    if isinstance(steps, dict):
+        steps = steps.values()
+    for step in steps:
+        if step.get("type", "tool") == "tool" and not step.get("run", {}).get("class") == "GalaxyWorkflow":
+            yield step
+        elif step.get("type") == "subworkflow":  # GA SWF
+            yield from _iter_tool_steps(step["subworkflow"])
+        elif step.get("run", {}).get("class") == "GalaxyWorkflow":  # gxformat2 SWF
+            yield from _iter_tool_steps(step["run"])
 
+
+def _lint_tool_ids(path: str, lint_context: WorkflowLintContext) -> None:
     with open(path) as f:
         workflow_dict = ordered_load(f)
     ts = toolshed.ToolShedInstance(url=MAIN_TOOLSHED_URL)
-    failed = _lint_tool_ids_steps(lint_context, workflow_dict, ts)
+    failed = False
+    for step in _iter_tool_steps(workflow_dict):
+        tool_shed_repository = step.get("tool_shed_repository")
+        if not tool_shed_repository:
+            # Nothing to validate the tool_id/version against (e.g. built-in tools
+            # or gxformat2 steps without a pinned repository), so skip the check.
+            continue
+        changeset_revision = tool_shed_repository.get("changeset_revision")
+        warning_msg = assert_valid_tool_id_in_tool_shed(step["tool_id"], ts, changeset_revision)
+        if warning_msg:
+            lint_context.error(warning_msg)
+            failed = True
     if not failed:
         lint_context.valid("All tool ids appear to be valid.")
+    return None
+
+
+def _lint_tool_versions(path: str, lint_context: WorkflowLintContext) -> None:
+    """Check that each step's tool_version matches the version encoded in its tool_id."""
+    with open(path) as f:
+        workflow_dict = ordered_load(f)
+    failed = False
+    for step in _iter_tool_steps(workflow_dict):
+        tool_id = step.get("tool_id")
+        tool_version = step.get("tool_version")
+        if not tool_id or "/repos/" not in tool_id:
+            # Only tool shed tool ids encode the version, so nothing to compare against.
+            continue
+        version_in_tool_id = tool_id.rsplit("/", 1)[1]
+        if tool_version is not None and tool_version != version_in_tool_id:
+            lint_context.error(
+                f"The tool_version '{tool_version}' does not match the version '{version_in_tool_id}' "
+                f"encoded in tool_id {tool_id}."
+            )
+            failed = True
+    if not failed:
+        lint_context.valid("Tool versions appear to match tool ids.")
     return None
 
 

--- a/tests/data/wf_repos/autoupdate_tests/workflow_with_matching_changeset.ga
+++ b/tests/data/wf_repos/autoupdate_tests/workflow_with_matching_changeset.ga
@@ -1,0 +1,92 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Workflow with matching changeset revision",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "input"
+                }
+            ],
+            "label": "input",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "62da4422-2462-40d8-a4f6-35b0fd1156f4",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "070bf2da-a153-4b1e-a38c-55fc164ca4f9"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "infile": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Join two files",
+                    "name": "infile"
+                }
+            ],
+            "label": "join",
+            "name": "Join two files",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 281,
+                "top": 47
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "20344ce0c811",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "c15c0342-6bde-4c83-9399-3b8597de6a83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "outfile",
+                    "uuid": "61762374-8db1-46bc-8446-0eaca9ab8e92"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "e75d0ddc-b376-456f-b5e3-a8afbb7b85ef",
+    "version": 1
+}

--- a/tests/data/wf_repos/autoupdate_tests/workflow_with_mismatched_changeset.ga
+++ b/tests/data/wf_repos/autoupdate_tests/workflow_with_mismatched_changeset.ga
@@ -1,0 +1,92 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Workflow with mismatched changeset revision",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "input"
+                }
+            ],
+            "label": "input",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "62da4422-2462-40d8-a4f6-35b0fd1156f4",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "070bf2da-a153-4b1e-a38c-55fc164ca4f9"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "infile": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Join two files",
+                    "name": "infile"
+                }
+            ],
+            "label": "join",
+            "name": "Join two files",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 281,
+                "top": 47
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "288462ec2630",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "c15c0342-6bde-4c83-9399-3b8597de6a83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "outfile",
+                    "uuid": "61762374-8db1-46bc-8446-0eaca9ab8e92"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "e75d0ddc-b376-456f-b5e3-a8afbb7b85ee",
+    "version": 1
+}

--- a/tests/data/wf_repos/autoupdate_tests/workflow_with_mismatched_tool_version.ga
+++ b/tests/data/wf_repos/autoupdate_tests/workflow_with_mismatched_tool_version.ga
@@ -1,0 +1,92 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Workflow with mismatched tool_version",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "input"
+                }
+            ],
+            "label": "input",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "62da4422-2462-40d8-a4f6-35b0fd1156f4",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "070bf2da-a153-4b1e-a38c-55fc164ca4f9"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "infile": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Join two files",
+                    "name": "infile"
+                }
+            ],
+            "label": "join",
+            "name": "Join two files",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 281,
+                "top": 47
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "20344ce0c811",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "c15c0342-6bde-4c83-9399-3b8597de6a83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "outfile",
+                    "uuid": "61762374-8db1-46bc-8446-0eaca9ab8e92"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "e75d0ddc-b376-456f-b5e3-a8afbb7b85f1",
+    "version": 1
+}

--- a/tests/data/wf_repos/autoupdate_tests/workflow_without_tool_shed_repository.ga
+++ b/tests/data/wf_repos/autoupdate_tests/workflow_without_tool_shed_repository.ga
@@ -1,0 +1,86 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Workflow without tool_shed_repository",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "input"
+                }
+            ],
+            "label": "input",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "62da4422-2462-40d8-a4f6-35b0fd1156f4",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "070bf2da-a153-4b1e-a38c-55fc164ca4f9"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unexisting/unexisting/0.1.0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "infile": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool",
+                    "name": "infile"
+                }
+            ],
+            "label": "no shed repo",
+            "name": "Some tool",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 281,
+                "top": 47
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unexisting/unexisting/0.1.0",
+            "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.0",
+            "type": "tool",
+            "uuid": "c15c0342-6bde-4c83-9399-3b8597de6a83",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "outfile",
+                    "uuid": "61762374-8db1-46bc-8446-0eaca9ab8e92"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "e75d0ddc-b376-456f-b5e3-a8afbb7b85f0",
+    "version": 1
+}

--- a/tests/test_cmd_workflow_lint.py
+++ b/tests/test_cmd_workflow_lint.py
@@ -232,6 +232,38 @@ class CmdWorkflowLintTestCase(CliTestCase):
         result = self._runner.invoke(self._cli.planemo, lint_cmd)
         assert "ERROR: The ToolShed returned an error when searching" in result.output
 
+    def test_tool_id_linting_mismatched_changeset(self):
+        # tp_easyjoin_tool/1.1.0 is a valid tool version, but the pinned
+        # changeset_revision (288462ec2630) only provides version 1.0.0.
+        workflow_path = "/".join(
+            (TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_with_mismatched_changeset.ga")
+        )
+        lint_cmd = ["workflow_lint", workflow_path]
+        result = self._runner.invoke(self._cli.planemo, lint_cmd)
+        assert (
+            "ERROR: The tool toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0 "
+            "is not provided by the pinned changeset_revision 288462ec2630" in result.output
+        )
+
+    def test_tool_id_linting_matching_changeset(self):
+        # tp_easyjoin_tool/1.1.0 is provided by changeset_revision 20344ce0c811.
+        workflow_path = "/".join((TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_with_matching_changeset.ga"))
+        lint_cmd = ["workflow_lint", "--skip", "best_practices", workflow_path]
+        result = self._runner.invoke(self._cli.planemo, lint_cmd)
+        assert "All tool ids appear to be valid." in result.output
+
+    def test_tool_id_linting_without_tool_shed_repository(self):
+        # A tool step without a tool_shed_repository has nothing to validate the
+        # tool_id/version against, so the check is skipped even for an otherwise
+        # invalid toolshed tool_id.
+        workflow_path = "/".join(
+            (TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_without_tool_shed_repository.ga")
+        )
+        lint_cmd = ["workflow_lint", "--skip", "best_practices", workflow_path]
+        result = self._runner.invoke(self._cli.planemo, lint_cmd)
+        assert "not in the toolshed" not in result.output
+        assert "All tool ids appear to be valid." in result.output
+
     def test_workflow_linting_asserts(self):
         repo = _wf_repo("basic_format2_ok_collection")
         lint_cmd = ["workflow_lint", "--skip", "best_practices", repo]

--- a/tests/test_cmd_workflow_lint.py
+++ b/tests/test_cmd_workflow_lint.py
@@ -264,6 +264,25 @@ class CmdWorkflowLintTestCase(CliTestCase):
         assert "not in the toolshed" not in result.output
         assert "All tool ids appear to be valid." in result.output
 
+    def test_tool_version_linting_mismatch(self):
+        # tool_id encodes version 1.1.0 but the step's tool_version is 1.0.0.
+        workflow_path = "/".join(
+            (TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_with_mismatched_tool_version.ga")
+        )
+        lint_cmd = ["workflow_lint", "--skip", "best_practices", workflow_path]
+        result = self._runner.invoke(self._cli.planemo, lint_cmd)
+        assert (
+            "ERROR: The tool_version '1.0.0' does not match the version '1.1.0' encoded in tool_id "
+            "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.0" in result.output
+        )
+
+    def test_tool_version_linting_match(self):
+        # tool_id and tool_version agree in this fixture.
+        workflow_path = "/".join((TEST_DATA_DIR, "wf_repos", "autoupdate_tests", "workflow_with_matching_changeset.ga"))
+        lint_cmd = ["workflow_lint", "--skip", "best_practices", workflow_path]
+        result = self._runner.invoke(self._cli.planemo, lint_cmd)
+        assert "Tool versions appear to match tool ids." in result.output
+
     def test_workflow_linting_asserts(self):
         repo = _wf_repo("basic_format2_ok_collection")
         lint_cmd = ["workflow_lint", "--skip", "best_practices", repo]


### PR DESCRIPTION
Fixes #1658

## Problem

A native `.ga` workflow tool step pins several related things that can silently drift apart:
- `tool_id` — a tool shed GUID that **embeds** the tool version as its last path component
- `tool_version` — the version stored separately on the step
- `tool_shed_repository.changeset_revision` — the exact revision planemo installs when bootstrapping the workflow's tests

The tool-id linter previously only checked that the tool version existed in *some* revision of the repository. So a workflow could lint clean yet fail at run/test time with:

> `Workflow was not invoked; the following required tools are not installed: … (version …)`

exactly the error reported in the issue.

## Changes

Two checks, kept separate because they have different needs:

**1. `lint_tool_ids` — pinned changeset must provide the referenced version (needs ToolShed).**
`assert_valid_tool_id_in_tool_shed` now accepts an optional `changeset_revision`. It first confirms the tool version exists anywhere (preserving the existing "not in the toolshed" diagnosis for bogus versions), then cross-checks that the pinned changeset provides it. On a mismatch the error names the changeset(s) that **do** provide the version, so the fix is actionable:
> `The tool …/tp_easyjoin_tool/1.1.0 is not provided by the pinned changeset_revision 288462ec2630 … This version is provided by changeset_revision 20344ce0c811, 60edf2f8c28f.`

Reuses the single ToolShed metadata fetch already done by `find_repos_from_tool_id` — no extra API calls. Steps without a `tool_shed_repository` have nothing to validate against and are skipped.

**2. `lint_tool_versions` — `tool_version` must match the version encoded in `tool_id` (local, no network).**
A new linter flags any disagreement between the step's `tool_version` and the version embedded in its tool shed `tool_id`.

The recursive tool-step walk is factored into a shared `_iter_tool_steps` helper so both linters (and subworkflow recursion) stay in sync.

## Tests

New cases in `tests/test_cmd_workflow_lint.py` (fixtures under `tests/data/wf_repos/autoupdate_tests/`):
- version pinned to a changeset that ships a different version → error
- version pinned to the correct changeset → clean
- tool step without a `tool_shed_repository` → skipped
- `tool_version` disagreeing with the `tool_id` version → error
- `tool_version` matching → clean

Existing "wrong version" / "wrong tool" tests continue to pass.