### PR TITLE
Stop loading workflow .ga files as tools

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1271,7 +1271,7 @@ def _find_test_data(runnables, **kwds):
         return os.path.abspath(test_data)
 
     test_data_search_path = "."
-    runnables = [r for r in runnables if r.has_tools and not r.is_remote_workflow_uri]
+    runnables = [r for r in runnables if r.has_path and not r.is_remote_workflow_uri]
     if len(runnables) > 0:
         test_data_search_path = runnables[0].test_data_search_path
 
@@ -1288,7 +1288,7 @@ def _find_tool_data_table(runnables, test_data_dir, **kwds) -> Optional[List[str
         return [os.path.abspath(table_path) for table_path in tool_data_table]
 
     tool_data_search_path = "."
-    runnables = [r for r in runnables if r.has_tools and not r.is_remote_workflow_uri]
+    runnables = [r for r in runnables if r.has_path and not r.is_remote_workflow_uri]
     if len(runnables) > 0:
         tool_data_search_path = runnables[0].tool_data_search_path
 

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -144,17 +144,17 @@ class Runnable(NamedTuple):
         return None
 
     @property
-    def has_tools(self) -> property:
+    def has_tools(self) -> bool:
         """Boolean indicating if this runnable corresponds to one or more tools."""
-        return _runnable_delegate_attribute("has_tools")
+        return self.type.has_tools
 
     @property
-    def is_single_artifact(self) -> property:
+    def is_single_artifact(self) -> bool:
         """Boolean indicating if this runnable is a single artifact.
 
         Currently only directories are considered not a single artifact.
         """
-        return _runnable_delegate_attribute("is_single_artifact")
+        return self.type.is_single_artifact
 
 
 class Rerunnable(NamedTuple):
@@ -163,13 +163,6 @@ class Rerunnable(NamedTuple):
     rerunnable_id: str
     rerunnable_type: str
     server_url: str
-
-
-def _runnable_delegate_attribute(attribute: str) -> property:
-    def getter(runnable):
-        return getattr(runnable.type, attribute)
-
-    return property(getter)
 
 
 def workflows_from_dockstore_yaml(path):

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -77,6 +77,36 @@ def test_all_tool_paths_excludes_remote_galaxy_tools():
     assert f"gxid://tools/{remote_tool_id}" not in tool_paths
 
 
+def test_all_tool_paths_excludes_workflows():
+    # A workflow's own .ga path must never be handed to Galaxy as a tool - Galaxy
+    # would try to XML-parse the JSON workflow and fail. See has_tools below.
+    workflow = os.path.join(os.path.dirname(__file__), "data", "wf1.ga")
+    runnable = for_path(workflow)
+
+    assert runnable.has_tools is False
+    assert workflow not in _all_tool_paths([runnable])
+
+
+def test_runnable_delegated_properties_are_booleans():
+    # has_tools / is_single_artifact must delegate to the RunnableType and return
+    # real booleans (previously they returned an always-truthy property object).
+    from planemo.runnable import (
+        Runnable,
+        RunnableType,
+    )
+
+    for runnable_type in RunnableType:
+        runnable = Runnable("some_path", runnable_type)
+        assert isinstance(runnable.has_tools, bool)
+        assert isinstance(runnable.is_single_artifact, bool)
+        assert runnable.has_tools == runnable_type.has_tools
+        assert runnable.is_single_artifact == runnable_type.is_single_artifact
+
+    assert Runnable("t.xml", RunnableType.galaxy_tool).has_tools is True
+    assert Runnable("w.ga", RunnableType.galaxy_workflow).has_tools is False
+    assert Runnable("d", RunnableType.directory).is_single_artifact is False
+
+
 def _assert_property_is(config, prop, value):
     env_var = "GALAXY_CONFIG_OVERRIDE_%s" % prop.upper()
     assert config.env[env_var] == value

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -17,6 +17,8 @@ from planemo.galaxy.config import (
 from planemo.runnable import (
     for_path,
     for_uri,
+    Runnable,
+    RunnableType,
 )
 from .test_utils import (
     create_test_context,
@@ -90,11 +92,6 @@ def test_all_tool_paths_excludes_workflows():
 def test_runnable_delegated_properties_are_booleans():
     # has_tools / is_single_artifact must delegate to the RunnableType and return
     # real booleans (previously they returned an always-truthy property object).
-    from planemo.runnable import (
-        Runnable,
-        RunnableType,
-    )
-
     for runnable_type in RunnableType:
         runnable = Runnable("some_path", runnable_type)
         assert isinstance(runnable.has_tools, bool)


### PR DESCRIPTION
## Problem

Running `planemo test` against a Galaxy workflow makes Galaxy's toolbox log errors while trying to parse the workflow's `.ga` (JSON) file as tool XML:

```
galaxy.util ERROR Error parsing file .../cgmlst_bacterial_genome.ga
lxml.etree.XMLSyntaxError: Start tag expected, '<' not found, line 1, column 1
galaxy.tool_util.toolbox.base ERROR Error reading tool from path: .../cgmlst_bacterial_genome.ga
```

It's non-fatal (Galaxy skips the file), but it floods CI logs (e.g. iwc) and wastes toolbox startup time.

## Root cause

`Runnable.has_tools` and `Runnable.is_single_artifact` were `@property` methods that returned the result of `_runnable_delegate_attribute(...)` — which itself returns a **`property` object**, not the delegated value:

```python
@property
def has_tools(self) -> property:
    return _runnable_delegate_attribute("has_tools")   # a property object -> always truthy
```

So `runnable.has_tools` was truthy for **every** runnable type, including `galaxy_workflow`. `_all_tool_paths()` therefore added a workflow's own `.ga` path to `tool_conf.xml` as `<tool file=".../foo.ga"/>`, and Galaxy tried to XML-parse the JSON workflow at toolbox load time. This has been latent since the `Runnable` abstraction was introduced.

## Fix

- Make `has_tools` / `is_single_artifact` delegate to `self.type` so they return real booleans. `_all_tool_paths()` now correctly excludes workflow runnables — no `.ga` reaches the toolbox.
- `_find_test_data()` / `_find_tool_data_table()` also filtered on `has_tools` (effectively "not remote", given the bug) to choose the directory searched for `test-data` / `tool_data_table` next to the artifact. They must keep including local workflows, so switch them to `r.has_path and not r.is_remote_workflow_uri` (no test-data-discovery regression for workflow tests).

## Tests

- `test_all_tool_paths_excludes_workflows` — a workflow `.ga` is not added to `_all_tool_paths`, and `runnable.has_tools is False`.
- `test_runnable_delegated_properties_are_booleans` — `has_tools` / `is_single_artifact` are real `bool`s matching their `RunnableType`.
- Existing `test_all_tool_paths_excludes_remote_galaxy_tools` still passes; full `tests/test_galaxy_config.py` (17 tests) green locally.