### PR TITLE
Raise an actionable error for untranslatable collection outputs

### DIFF
--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -658,6 +658,18 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
                             attach_file_properties(element["object"], cwl_output_element)
 
                 output_metadata = self._get_metadata("dataset_collection", output_dataset_id)
+                if cwl_output is None:
+                    # galaxy-tool-util's output_to_cwl_json returns None for collection types it
+                    # cannot translate (anything whose outermost type is not list, paired or
+                    # record - e.g. sample_sheet). Without this guard attach_file_properties
+                    # fails with "object of type 'NoneType' has no len()", which names neither
+                    # the output nor the collection type responsible.
+                    raise Exception(
+                        f"Cannot collect output '{runnable_output_id}': collection type "
+                        f"'{output_metadata.get('collection_type')}' is not supported by the "
+                        "installed galaxy-tool-util's output_to_cwl_json. Upgrading "
+                        "galaxy-tool-util may resolve this."
+                    )
                 attach_file_properties(output_metadata, cwl_output)
                 output_dict_value = output_metadata
 

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -579,6 +579,32 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
         else:
             raise Exception("Unknown history content type encountered [%s]" % history_content_type)
 
+    def _collect_collection_output(self, runnable_output_id, output_dataset_id, cwl_output):
+        def attach_file_properties(collection, cwl_output):
+            elements = collection["elements"]
+            assert len(elements) == len(cwl_output)
+            for element, cwl_output_element in zip(elements, cwl_output):
+                element["_output_object"] = cwl_output_element
+                if isinstance(cwl_output_element, list):
+                    assert "elements" in element["object"]
+                    attach_file_properties(element["object"], cwl_output_element)
+
+        output_metadata = self._get_metadata("dataset_collection", output_dataset_id)
+        if cwl_output is None:
+            # galaxy-tool-util's output_to_cwl_json returns None for collection types it
+            # cannot translate (anything whose outermost type is not list, paired or
+            # record - e.g. sample_sheet). Without this guard attach_file_properties
+            # fails with "object of type 'NoneType' has no len()", which names neither
+            # the output nor the collection type responsible.
+            raise Exception(
+                f"Cannot collect output '{runnable_output_id}': collection type "
+                f"'{output_metadata.get('collection_type')}' is not supported by the "
+                "installed galaxy-tool-util's output_to_cwl_json. Upgrading "
+                "galaxy-tool-util may resolve this."
+            )
+        attach_file_properties(output_metadata, cwl_output)
+        return output_metadata
+
     def collect_outputs(
         self,
         output_directory: Optional[str] = None,
@@ -647,31 +673,7 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
             if is_cwl or output_src["src"] == "hda":
                 output_dict_value = cwl_output
             else:
-
-                def attach_file_properties(collection, cwl_output):
-                    elements = collection["elements"]
-                    assert len(elements) == len(cwl_output)
-                    for element, cwl_output_element in zip(elements, cwl_output):
-                        element["_output_object"] = cwl_output_element
-                        if isinstance(cwl_output_element, list):
-                            assert "elements" in element["object"]
-                            attach_file_properties(element["object"], cwl_output_element)
-
-                output_metadata = self._get_metadata("dataset_collection", output_dataset_id)
-                if cwl_output is None:
-                    # galaxy-tool-util's output_to_cwl_json returns None for collection types it
-                    # cannot translate (anything whose outermost type is not list, paired or
-                    # record - e.g. sample_sheet). Without this guard attach_file_properties
-                    # fails with "object of type 'NoneType' has no len()", which names neither
-                    # the output nor the collection type responsible.
-                    raise Exception(
-                        f"Cannot collect output '{runnable_output_id}': collection type "
-                        f"'{output_metadata.get('collection_type')}' is not supported by the "
-                        "installed galaxy-tool-util's output_to_cwl_json. Upgrading "
-                        "galaxy-tool-util may resolve this."
-                    )
-                attach_file_properties(output_metadata, cwl_output)
-                output_dict_value = output_metadata
+                output_dict_value = self._collect_collection_output(runnable_output_id, output_dataset_id, cwl_output)
 
             if output_id:
                 return output_dict_value

--- a/tests/test_collect_outputs.py
+++ b/tests/test_collect_outputs.py
@@ -2,15 +2,22 @@
 
 from typing import (
     Any,
+    cast,
     Dict,
     List,
     Optional,
+    TYPE_CHECKING,
 )
 
 import pytest
 
 from planemo.galaxy import activity
 from planemo.galaxy.activity import GalaxyBaseRunResponse
+
+if TYPE_CHECKING:
+    from bioblend.galaxy import GalaxyInstance
+
+    from planemo.cli import PlanemoCliContext
 
 SAMPLE_SHEET_COLLECTION_METADATA: Dict[str, Any] = {
     "id": "e9d955ca403027d5",
@@ -90,9 +97,9 @@ def unsupported_collection_response(monkeypatch) -> CollectionRunResponse:
         type = None
 
     return CollectionRunResponse(
-        ctx=MockContext(),
+        ctx=cast("PlanemoCliContext", MockContext()),
         runnable=MockRunnable(),
-        user_gi=None,
+        user_gi=cast("GalaxyInstance", None),
         history_id="a2619fc82a1e31e5",
         log="",
     )

--- a/tests/test_collect_outputs.py
+++ b/tests/test_collect_outputs.py
@@ -1,0 +1,109 @@
+"""Tests for output collection in :mod:`planemo.galaxy.activity`."""
+
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+
+import pytest
+
+from planemo.galaxy import activity
+from planemo.galaxy.activity import GalaxyBaseRunResponse
+
+SAMPLE_SHEET_COLLECTION_METADATA: Dict[str, Any] = {
+    "id": "e9d955ca403027d5",
+    "model_class": "HistoryDatasetCollectionAssociation",
+    "history_content_type": "dataset_collection",
+    "collection_type": "sample_sheet:paired",
+    "populated": True,
+    "element_count": 1,
+    "elements": [
+        {
+            "id": "dd871f1d42ebeefa",
+            "model_class": "DatasetCollectionElement",
+            "element_index": 0,
+            "element_identifier": "sample1",
+            "element_type": "dataset_collection",
+            "object": {
+                "id": "b1e4c6f0a2d3e5f7",
+                "model_class": "DatasetCollection",
+                "collection_type": "paired",
+                "populated": True,
+                "elements": [],
+            },
+        }
+    ],
+}
+
+
+class MockContext:
+    def log(self, msg, *args, **kwds):
+        pass
+
+    def vlog(self, msg, *args, **kwds):
+        pass
+
+
+class MockRunnableOutput:
+    def __init__(self, output_id: str) -> None:
+        self._id = output_id
+
+    def get_id(self) -> str:
+        return self._id
+
+    def is_optional(self) -> bool:
+        return False
+
+
+class CollectionRunResponse(GalaxyBaseRunResponse):
+    """A run response whose single output is an unsupported collection type."""
+
+    def to_galaxy_output(self, runnable_output):
+        return None
+
+    def output_src(self, output, ignore_missing_outputs: Optional[bool] = False) -> Dict[str, str]:
+        return {"src": "hdca", "id": "e9d955ca403027d5"}
+
+    def _get_metadata(self, history_content_type: str, content_id: str) -> Dict[str, Any]:
+        assert history_content_type == "dataset_collection"
+        return dict(SAMPLE_SHEET_COLLECTION_METADATA)
+
+
+@pytest.fixture
+def unsupported_collection_response(monkeypatch) -> CollectionRunResponse:
+    """A response where output_to_cwl_json returns None, as it does for sample_sheet."""
+
+    def mock_get_outputs(runnable, gi=None) -> List[MockRunnableOutput]:
+        return [MockRunnableOutput("Read quality reports")]
+
+    # Mirrors galaxy-tool-util's output_to_cwl_json, which falls through to a bare
+    # `return None` for any collection type it does not know how to translate.
+    def mock_output_to_cwl_json(*args, **kwds) -> None:
+        return None
+
+    monkeypatch.setattr(activity, "get_outputs", mock_get_outputs)
+    monkeypatch.setattr(activity, "output_to_cwl_json", mock_output_to_cwl_json)
+
+    class MockRunnable:
+        type = None
+
+    return CollectionRunResponse(
+        ctx=MockContext(),
+        runnable=MockRunnable(),
+        user_gi=None,
+        history_id="a2619fc82a1e31e5",
+        log="",
+    )
+
+
+def test_collect_outputs_unsupported_collection_type(unsupported_collection_response, tmp_path):
+    """An untranslatable collection type reports the output and type, not a TypeError."""
+    with pytest.raises(Exception) as exc_info:
+        unsupported_collection_response.collect_outputs(output_directory=str(tmp_path))
+
+    assert not isinstance(exc_info.value, TypeError)
+    message = str(exc_info.value)
+    assert "Read quality reports" in message
+    assert "sample_sheet:paired" in message


### PR DESCRIPTION
## The problem

A workflow with a promoted `sample_sheet:paired` output runs to completion — Galaxy started, 10/10 Tool Shed repos installed, 18/18 steps scheduled, 15/15 jobs terminal, 0 errors — and then `planemo test` dies while collecting outputs, before adjudicating a single assertion:

```
  File "planemo/galaxy/activity.py", line 692, in get_output
    self._outputs_dict[output_id] = self.collect_outputs(ignore_missing_output=True, output_id=output_id)
  File "planemo/galaxy/activity.py", line 661, in collect_outputs
    attach_file_properties(output_metadata, cwl_output)
  File "planemo/galaxy/activity.py", line 653, in attach_file_properties
    assert len(elements) == len(cwl_output)
TypeError: object of type 'NoneType' has no len()
```

A fully green run reported as a failure, with an error naming neither the output nor the collection type responsible.

`galaxy-tool-util`'s `output_to_cwl_json` ends its `dataset_collection` branch with a bare `return None` for any collection whose outermost type segment is not `list`, `paired` or `record`. For `sample_sheet:paired` the outer segment is `sample_sheet`, so `cwl_output` is `None` and `attach_file_properties` calls `len(None)`.

## Scope

**This PR is the defensive guard, not the fix.** The substantive fix is galaxyproject/galaxy#23152, which teaches `output_to_cwl_json` to handle `sample_sheet` and `paired_or_unpaired`.

This change is still worth making on its own: planemo pins `galaxy-tool-util`, so users hit this until a new release ships and planemo bumps to it — and the guard remains useful afterwards for whatever collection type is added to Galaxy next. It deliberately does **not** attempt to add collection-type support here.

## Why fail loudly rather than degrade gracefully

The alternative considered was skipping the `_output_object` attachment and letting assertions proceed on the metadata that is available. That option turns out not to work, and the reason is worth recording.

`planemo/test/_check_output.py:39` reads the attribute unguarded:

```python
def verify_dataset(element, element_attrib, element_outfile):
    ...
    _verify_output_file(runnable, element["_output_object"], element_attrib)
```

So skipping the attachment does not let assertions proceed — it converts the `TypeError` into a `KeyError: '_output_object'` raised one layer deeper, inside `verify_collection`, which is strictly less actionable than what we have today. The only case where degrading is not an immediate crash is when the test declares no `element_tests` for that output at all — and in that case nothing was being verified anyway, so the "usable test run" it buys is a run that silently checks less than the author asked for.

Given that, a clear error at the point of failure is the honest outcome, and it points straight at the upstream gap. The message names both the output and the collection type:

```
Cannot collect output 'Read quality reports': collection type 'sample_sheet:paired' is not
supported by the installed galaxy-tool-util's output_to_cwl_json. Upgrading galaxy-tool-util
may resolve this.
```

## Test

`tests/test_collect_outputs.py` drives `collect_outputs` with `output_to_cwl_json` stubbed to return `None`, as it does for `sample_sheet`. A unit test rather than a workflow-run test because a real reproduction needs a Galaxy server and a `sample_sheet` collection.

Before the fix — it reproduces the reported `TypeError` exactly:

```
    def test_collect_outputs_unsupported_collection_type(unsupported_collection_response, tmp_path):
        """An untranslatable collection type reports the output and type, not a TypeError."""
        with pytest.raises(Exception) as exc_info:
            unsupported_collection_response.collect_outputs(output_directory=str(tmp_path))

>       assert not isinstance(exc_info.value, TypeError)
E       assert not True
E        +  where True = isinstance(TypeError("object of type 'NoneType' has no len()"), TypeError)

tests/test_collect_outputs.py:106: AssertionError
=========================== 1 failed, 1 warning in 1.61s ===========================
```

After: passes. Related unit tests (`test_collection_elements_to_test_def.py`, `test_output_schema.py`) still pass — 15 passed.

Reproduced originally against a managed Galaxy `release_26.0`; Galaxy staged the `sample_sheet:paired` input with its `rows` payload and ran every job correctly. The defect was entirely in output translation.