### PR TITLE
GitHub workflow improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ env:
   GIT_AUTHOR_EMAIL: planemo@galaxyproject.org
   GIT_COMMITTER_NAME: planemo
   GIT_COMMITTER_EMAIL: planemo@galaxyproject.org
+permissions: {}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,6 @@
 name: Deploy
 on: [push, pull_request]
+permissions: {}
 jobs:
   build_packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    paths:
+      - '.github/workflows/*'
+      - zizmor.yml
+  pull_request:
+    paths:
+      - '.github/workflows/*'
+      - zizmor.yml
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': ref-pin


### PR DESCRIPTION
recommended by [zizmor](https://docs.zizmor.sh/).

Also:
- Run zizmor-action on changes to GitHub workflows.
- Impose a 7-day cooldown for GitHub action updates.
- Update all GitHub actions into a single pull request.