### PR TITLE
Add --use_cache to planemo run

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 ---------------------
 0.75.46.dev0
 ---------------------
+* Behavior change: add ``--use_cache`` to ``planemo run``, which now reuses cached job results by default (#1665).
 
 
 ---------------------

--- a/docs/_running_external.rst
+++ b/docs/_running_external.rst
@@ -398,3 +398,30 @@ using the ``planemo rerun`` command:
 In the first two cases, all failed, remappable jobs which are associated with
 the specified history(s) or invocation(s) will be rerun. In the third case,
 the specified jobs will simply be rerun.
+
+
+Caching job results
+===============================================
+
+``planemo run`` reuses previously computed results by default. Pass
+``--no_use_cache`` to force a run to actually re-compute - note that a tool which
+exited successfully but produced bad output will have that bad output reused
+until you do.
+
+For the Galaxy engines this sets ``use_cached_job`` on the job or invocation
+request, so Galaxy looks for an equivalent job of yours to copy outputs from.
+Two things limit how often that succeeds:
+
+- The Galaxy needs a persistent database. The ephemeral local Galaxy planemo
+  starts by default gets a fresh database every run, so caching only pays off
+  against ``--galaxy_url`` or a ``--profile``.
+- Inputs given as local file paths are uploaded afresh on every run, and Galaxy
+  does not consider jobs consuming distinct uploads equivalent. Caching helps
+  most when the job file refers to datasets already on the server.
+
+For the cwltool engine this maps onto cwltool's ``--cachedir``, which caches
+individual computed steps keyed on the command line and input checksums. The
+cache lives in ``cwltool_cache`` within the planemo workspace unless
+``--cwltool_cache_directory`` says otherwise. Planemo never prunes it, and
+cwltool writes scratch directories beside it that a crashed run can leave
+behind.

--- a/docs/_running_external.rst
+++ b/docs/_running_external.rst
@@ -408,9 +408,9 @@ Caching job results
 exited successfully but produced bad output will have that bad output reused
 until you do.
 
-For the Galaxy engines this sets ``use_cached_job`` on the job or invocation
-request, so Galaxy looks for an equivalent job of yours to copy outputs from.
-Two things limit how often that succeeds:
+This sets ``use_cached_job`` on the job or invocation request, so Galaxy looks
+for an equivalent job of yours to copy outputs from. Two things limit how often
+that succeeds:
 
 - The Galaxy needs a persistent database. The ephemeral local Galaxy planemo
   starts by default gets a fresh database every run, so caching only pays off
@@ -418,10 +418,3 @@ Two things limit how often that succeeds:
 - Inputs given as local file paths are uploaded afresh on every run, and Galaxy
   does not consider jobs consuming distinct uploads equivalent. Caching helps
   most when the job file refers to datasets already on the server.
-
-For the cwltool engine this maps onto cwltool's ``--cachedir``, which caches
-individual computed steps keyed on the command line and input checksums. The
-cache lives in ``cwltool_cache`` within the planemo workspace unless
-``--cwltool_cache_directory`` says otherwise. Planemo never prunes it, and
-cwltool writes scratch directories beside it that a crashed run can leave
-behind.

--- a/docs/commands/run.rst
+++ b/docs/commands/run.rst
@@ -21,8 +21,13 @@ Planemo command for running tools and jobs.
 Job results are reused from a cache by default. A tool that exits
 successfully but produces bad output will have that bad output reused, so
 ``--no_use_cache`` is the escape hatch when a run is meant to actually
-re-compute. See "Caching job results" in the Planemo documentation for what
-each engine can and cannot reuse.
+re-compute.
+
+With the cwltool engine this maps onto cwltool's ``--cachedir``, which caches
+individual computed steps under ``--cwltool_cache_directory``. Planemo never
+prunes that directory, and cwltool leaves scratch directories beside it if a
+run crashes. With the Galaxy engines, see "Caching job results" in the
+Planemo documentation for what can actually be reused.
 
 **Options**::
 

--- a/docs/commands/run.rst
+++ b/docs/commands/run.rst
@@ -18,6 +18,12 @@ Planemo command for running tools and jobs.
 
     % planemo run cat1-tool.cwl cat-job.json
 
+Job results are reused from a cache by default. A tool that exits
+successfully but produces bad output will have that bad output reused, so
+``--no_use_cache`` is the escape hatch when a run is meant to actually
+re-compute. See "Caching job results" in the Planemo documentation for what
+each engine can and cannot reuse.
+
 **Options**::
 
 
@@ -154,12 +160,36 @@ Planemo command for running tools and jobs.
                                       local singularity postgres.
       --shed_tool_conf TEXT           Location of shed tools conf file for Galaxy.
       --shed_tool_path TEXT           Location of shed tools directory for Galaxy.
+      --shed_tool_data_table_config TEXT
+                                      Location of the shed tool data table config
+                                      file for Galaxy (records data tables
+                                      registered by shed-installed repositories).
+      --shed_data_manager_config TEXT
+                                      Location of the shed data manager config file
+                                      for Galaxy.
+      --shed_data_dir DIRECTORY       Persistent base directory for shed-install
+                                      state (local Galaxy engine). Seeds defaults
+                                      for --shed_tool_conf, --shed_tool_path,
+                                      --shed_tool_data_table_config and
+                                      --shed_data_manager_config so shed installs
+                                      (tools and their data tables) survive Galaxy
+                                      restarts. Individual options still override.
       --galaxy_single_user / --no_galaxy_single_user
                                       By default Planemo will configure Galaxy to
                                       run in single-user mode where there is just
                                       one user and this user is automatically logged
                                       it. Use --no_galaxy_single_user to prevent
                                       Galaxy from running this way.
+      --tool_evaluation_strategy [local|remote]
+                                      Determines which process will evaluate the
+                                      tool command line. If set to 'local' the tool
+                                      command line will be templated in the job
+                                      handler process. If set to 'remote' the tool
+                                      command line will be built as part of the
+                                      submitted job (beta). Setting this to 'remote'
+                                      will also implicitly set metadata_strategy to
+                                      'extended', which is required for remote tool
+                                      evaluation.
       --cwl                           Configure Galaxy for use with CWL tool. (this
                                       option is experimental and will be replaced
                                       when and if CWL support is merged into
@@ -179,6 +209,11 @@ Planemo command for running tools and jobs.
                                       After tool or workflow runs are complete,
                                       download the output files to the location
                                       specified by --output_directory.
+      --use_cache / --no_use_cache    Use cached job results if available.
+      --cwltool_cache_directory DIRECTORY
+                                      Directory the cwltool engine caches computed
+                                      steps in when --use_cache is enabled (defaults
+                                      to a directory in the planemo workspace).
       --export_invocation PATH        Export workflow invocation as archive to
                                       specified path.
       --engine [galaxy|docker_galaxy|cwltool|toil|external_galaxy]

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -30,6 +30,8 @@ from planemo.test.results import StructuredData
 @options.run_output_directory_option()
 @options.run_output_json_option()
 @options.run_download_outputs_option()
+@options.run_use_cache_option()
+@options.cwltool_cache_directory_option()
 @options.run_export_option()
 @options.invocation_export_format_arg()
 @options.engine_options()
@@ -40,6 +42,12 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
 
     \b
         % planemo run cat1-tool.cwl cat-job.json
+
+    Job results are reused from a cache by default. A tool that exits
+    successfully but produces bad output will have that bad output reused, so
+    ``--no_use_cache`` is the escape hatch when a run is meant to actually
+    re-compute. See "Caching job results" in the Planemo documentation for what
+    each engine can and cannot reuse.
     """
     runnable = for_runnable_identifier(ctx, runnable_identifier, kwds)
     is_cwl = runnable.type.is_cwl_artifact

--- a/planemo/commands/cmd_run.py
+++ b/planemo/commands/cmd_run.py
@@ -46,8 +46,13 @@ def cli(ctx, runnable_identifier, job_path, **kwds):
     Job results are reused from a cache by default. A tool that exits
     successfully but produces bad output will have that bad output reused, so
     ``--no_use_cache`` is the escape hatch when a run is meant to actually
-    re-compute. See "Caching job results" in the Planemo documentation for what
-    each engine can and cannot reuse.
+    re-compute.
+
+    With the cwltool engine this maps onto cwltool's ``--cachedir``, which caches
+    individual computed steps under ``--cwltool_cache_directory``. Planemo never
+    prunes that directory, and cwltool leaves scratch directories beside it if a
+    run crashes. With the Galaxy engines, see "Caching job results" in the
+    Planemo documentation for what can actually be reused.
     """
     runnable = for_runnable_identifier(ctx, runnable_identifier, kwds)
     is_cwl = runnable.type.is_cwl_artifact

--- a/planemo/context.py
+++ b/planemo/context.py
@@ -55,6 +55,10 @@ class PlanemoContextInterface(metaclass=abc.ABCMeta):
     def galaxy_profiles_directory(self):
         """Create a return a directory for storing Galaxy profiles."""
 
+    @abc.abstractproperty
+    def cwltool_cache_directory(self):
+        """Create and return a directory for cwltool to cache computed steps in."""
+
     @abc.abstractmethod
     def cache_download(self, url, destination):
         """Use workspace to cache download of ``url``."""
@@ -125,6 +129,12 @@ class PlanemoContext(PlanemoContextInterface):
         """Create a return a directory for storing Galaxy profiles."""
         path = os.path.join(self.workspace, "profiles")
         return self._ensure_directory(path, "Galaxy profiles")
+
+    @property
+    def cwltool_cache_directory(self) -> str:
+        """Create and return a directory for cwltool to cache computed steps in."""
+        path = os.path.join(self.workspace, "cwltool_cache")
+        return self._ensure_directory(path, "cwltool cache")
 
     def cache_download(self, url, destination):
         """Use workspace to cache download of ``url``."""

--- a/planemo/cwl/run.py
+++ b/planemo/cwl/run.py
@@ -91,6 +91,10 @@ def run_cwltool(
     if kwds.get("non_strict_cwl", False):
         args.append("--non-strict")
 
+    if kwds.get("use_cache", False):
+        cache_directory = kwds.get("cwltool_cache_directory") or ctx.cwltool_cache_directory
+        args.extend(["--cachedir", cache_directory])
+
     args.extend([runnable.path, job_path])
     ctx.vlog("Calling cwltool with arguments %s" % args)
     with tempfile.NamedTemporaryFile("w") as tmp_stdout, tempfile.NamedTemporaryFile("w") as tmp_stderr:

--- a/planemo/galaxy/activity.py
+++ b/planemo/galaxy/activity.py
@@ -280,6 +280,8 @@ def _execute(  # noqa C901
             tool_id=tool_id,
             inputs=job_dict,
             inputs_representation=inputs_representation,
+            # ``planemo test`` never sets use_cache, so tests never silently reuse results
+            use_cached_job=kwds.get("use_cache", False),
         )
         ctx.vlog("Post to Galaxy tool API with payload [%s]" % run_tool_payload)
         tool_run_response = user_gi.tools._post(run_tool_payload)
@@ -316,6 +318,7 @@ def _execute(  # noqa C901
             history_id=history_id,
             allow_tool_state_corrections=True,
             inputs_by="name",
+            use_cached_job=kwds.get("use_cache", False),
         )
         run_response = invocation_to_run_response(
             ctx,
@@ -674,12 +677,13 @@ class GalaxyBaseRunResponse(SuccessfulRunResponse):
 
     @property
     def job_info(self):
-        print(self._job_info)
         if self._job_info is not None:
             return dict(
                 stdout=self._job_info.get("stdout"),
                 stderr=self._job_info.get("stderr"),
                 command_line=self._job_info.get("command_line"),
+                # set when Galaxy reused a cached job instead of running this one
+                copied_from_job_id=self._job_info.get("copied_from_job_id"),
             )
         return None
 

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -330,6 +330,24 @@ def run_use_cache_option():
     )
 
 
+def cwltool_cache_directory_option():
+    return planemo_option(
+        "--cwltool_cache_directory",
+        type=click.Path(
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
+        default=None,
+        use_global_config=True,
+        use_env_var=True,
+        help=(
+            "Directory the cwltool engine caches computed steps in when --use_cache "
+            "is enabled (defaults to a directory in the planemo workspace)."
+        ),
+    )
+
+
 def run_output_json_option():
     return planemo_option(
         "output_json",

--- a/tests/data/job_properties_job.json
+++ b/tests/data/job_properties_job.json
@@ -1,0 +1,5 @@
+{
+    "sleepsecs": 0,
+    "thebool": true,
+    "failbool": false
+}

--- a/tests/test_galaxy_activity.py
+++ b/tests/test_galaxy_activity.py
@@ -1,0 +1,56 @@
+"""Unit tests for :mod:`planemo.galaxy.activity`."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from planemo.galaxy.activity import _execute
+from planemo.runnable import (
+    Runnable,
+    RunnableType,
+)
+from .test_utils import (
+    create_test_context,
+    PROJECT_TEMPLATES_DIR,
+    TEST_DATA_DIR,
+)
+
+TOOL_RUNNABLE = Runnable(os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml"), RunnableType.galaxy_tool)
+WORKFLOW_RUNNABLE = Runnable(os.path.join(TEST_DATA_DIR, "wf2.ga"), RunnableType.galaxy_workflow)
+
+
+class ExecutionHalted(Exception):
+    """Raised to stop ``_execute`` once the request of interest was captured."""
+
+
+def _execute_capturing_request(runnable, **kwds):
+    """Run ``_execute`` far enough to capture the request it makes of Galaxy."""
+    config = mock.MagicMock()
+    config.user_gi.tools._post.side_effect = ExecutionHalted()
+    config.user_gi.workflows.invoke_workflow.side_effect = ExecutionHalted()
+    with mock.patch("planemo.galaxy.activity.stage_in", return_value=({}, "historyid123")):
+        with pytest.raises(ExecutionHalted):
+            _execute(create_test_context(), config, runnable, job_path=None, **kwds)
+    if runnable.type == RunnableType.galaxy_tool:
+        return config.user_gi.tools._post.call_args.args[0]
+    else:
+        return config.user_gi.workflows.invoke_workflow.call_args.kwargs
+
+
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_execute_tool_forwards_use_cache(use_cache):
+    payload = _execute_capturing_request(TOOL_RUNNABLE, use_cache=use_cache)
+    assert payload["use_cached_job"] is use_cache
+
+
+@pytest.mark.parametrize("use_cache", [True, False])
+def test_execute_workflow_forwards_use_cache(use_cache):
+    invoke_kwds = _execute_capturing_request(WORKFLOW_RUNNABLE, use_cache=use_cache)
+    assert invoke_kwds["use_cached_job"] is use_cache
+
+
+def test_execute_does_not_cache_without_use_cache():
+    """Callers other than ``planemo run`` (e.g. ``planemo test``) never set use_cache."""
+    assert _execute_capturing_request(TOOL_RUNNABLE)["use_cached_job"] is False
+    assert _execute_capturing_request(WORKFLOW_RUNNABLE)["use_cached_job"] is False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from uuid import uuid4
 
 import pytest
 
@@ -66,6 +67,43 @@ class RunTestCase(CliTestCase):
             assert os.path.exists(os.path.join(f, "tool_test_output.html"))
             assert os.path.exists(os.path.join(f, "tool_test_output.json"))
 
+    @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
+    def test_run_cwltool_use_cache(self):
+        with self._isolate() as f:
+            cache_directory = os.path.join(f, "cwltool_cache")
+            test_cmd = [
+                "run",
+                "--engine",
+                "cwltool",
+                "--no_container",
+                "--cwltool_cache_directory",
+                cache_directory,
+                _cwl_file("cat1-tool.cwl"),
+                _cwl_file("cat-job.json"),
+            ]
+            self._check_exit_code(test_cmd)
+            assert os.listdir(cache_directory)
+            result = self._check_exit_code(test_cmd)
+            assert "Using cached output in" in result.output
+
+    @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")
+    def test_run_cwltool_no_use_cache(self):
+        with self._isolate() as f:
+            cache_directory = os.path.join(f, "cwltool_cache")
+            test_cmd = [
+                "run",
+                "--engine",
+                "cwltool",
+                "--no_container",
+                "--no_use_cache",
+                "--cwltool_cache_directory",
+                cache_directory,
+                _cwl_file("cat1-tool.cwl"),
+                _cwl_file("cat-job.json"),
+            ]
+            self._check_exit_code(test_cmd)
+            assert not os.path.exists(cache_directory)
+
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     @mark.tests_galaxy_branch
     def test_run_gxtool_randomlines(self):
@@ -86,6 +124,51 @@ class RunTestCase(CliTestCase):
             self._check_exit_code(test_cmd)
             assert os.path.exists(os.path.join(f, "tool_test_output.html"))
             assert os.path.exists(os.path.join(f, "tool_test_output.json"))
+
+    @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
+    @mark.tests_galaxy_branch
+    def test_run_gxtool_use_cache(self):
+        # Galaxy only reuses a job if it finds an equivalent one belonging to the same
+        # user - so this needs a profile to keep the database and files around between
+        # runs. job_properties takes no data inputs, if it did each run would upload a
+        # fresh copy of the input and Galaxy would never consider the jobs equivalent.
+        tool_path = os.path.join(TEST_DATA_DIR, "tools", "functional_test_tools", "job_properties.xml")
+        job_path = os.path.join(TEST_DATA_DIR, "job_properties_job.json")
+        # unique so an interrupted run does not leave a profile behind that blocks the next one
+        profile_name = f"planemo_test_use_cache_{uuid4().hex[:8]}"
+
+        with self._isolate() as f:
+            self._check_exit_code(["profile_create", profile_name, "--database_type", "sqlite"])
+            try:
+
+                def run(label, *extra_args):
+                    report_path = os.path.join(f, f"{label}_report.json")
+                    self._check_exit_code(
+                        [
+                            "run",
+                            "--no_dependency_resolution",
+                            "--galaxy_branch",
+                            target_galaxy_branch(),
+                            "--profile",
+                            profile_name,
+                            "--test_output_json",
+                            report_path,
+                            *extra_args,
+                            tool_path,
+                            job_path,
+                        ]
+                    )
+                    with open(report_path) as report_f:
+                        return json.load(report_f)["tests"][0]["data"]["job"]
+
+                first_job = run("first")
+                assert first_job["copied_from_job_id"] is None, first_job
+                cached_job = run("cached")
+                assert cached_job["copied_from_job_id"] is not None, cached_job
+                uncached_job = run("uncached", "--no_use_cache")
+                assert uncached_job["copied_from_job_id"] is None, uncached_job
+            finally:
+                self._check_exit_code(["profile_delete", profile_name])
 
     @skip_if_environ("PLANEMO_SKIP_GALAXY_TESTS")
     @skip_if_environ("PLANEMO_SKIP_CWLTOOL_TESTS")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,6 +57,7 @@ TEST_TOOLS_DIR = os.path.join(TEST_DATA_DIR, "tools")
 PROJECT_TEMPLATES_DIR = os.path.join(TEST_DIR, os.path.pardir, "project_templates")
 CWL_DRAFT3_DIR = os.path.join(PROJECT_TEMPLATES_DIR, "cwl_draft3_spec")
 NON_ZERO_EXIT_CODE = object()
+CWLTOOL_CACHE_ENV_PROP = "PLANEMO_CWLTOOL_CACHE_DIRECTORY"
 
 
 class MarkGenerator:
@@ -79,6 +80,11 @@ class CliTestCase(TestCase):
         self._cleanup_hooks: List[Callable] = []
         self._port = None
         os.environ[PLANEMO_CONFIG_ENV_PROP] = self.planemo_yaml_path
+        # The whole workspace cannot be isolated - it caches the Galaxy repository and
+        # virtualenv shared by the Galaxy tests. Isolate the cwltool cache though, else
+        # repeated local test runs replay cached results instead of running cwltool.
+        self._old_cwltool_cache = os.environ.get(CWLTOOL_CACHE_ENV_PROP, None)
+        os.environ[CWLTOOL_CACHE_ENV_PROP] = os.path.join(self._home, "cwltool_cache")
 
     def tearDown(self):  # noqa
         for cleanup_hook in self._cleanup_hooks:
@@ -92,6 +98,10 @@ class CliTestCase(TestCase):
             os.environ[PLANEMO_CONFIG_ENV_PROP] = self._old_config
         else:
             del os.environ[PLANEMO_CONFIG_ENV_PROP]
+        if self._old_cwltool_cache is not None:
+            os.environ[CWLTOOL_CACHE_ENV_PROP] = self._old_cwltool_cache
+        else:
+            del os.environ[CWLTOOL_CACHE_ENV_PROP]
         safe_rmtree(self._home)
 
     @property


### PR DESCRIPTION
Fixes #1665. Requested by galaxyproject/foundry#365 (item 1).

`run_use_cache_option()` was defined in `planemo/options.py` but only wired into `planemo rerun`. Neither execution path in `planemo/galaxy/activity.py::_execute` - the tool `POST` nor `invoke_workflow` - ever sent `use_cached_job`. This adds the option to `planemo run`, defaulting to on to match `rerun`, and maps it onto the cwltool engine as well.

## Changes

- **`planemo/commands/cmd_run.py`** - `--use_cache/--no_use_cache` and a new `--cwltool_cache_directory`. No plumbing needed, `cmd_run` already forwards `**kwds` through `engine_context`.
- **`planemo/galaxy/activity.py`** - `use_cached_job=kwds.get("use_cache", False)` in the tool payload and to `invoke_workflow`. The `False` fallback is deliberate, `_execute` is shared with `planemo test` which must never silently reuse results.
- **`planemo/cwl/run.py`** - maps onto cwltool's `--cachedir`, defaulting to `cwltool_cache` in the planemo workspace via a new `PlanemoContext.cwltool_cache_directory` (mirrors `galaxy_profiles_directory`).
- **`planemo/options.py`** - `--cwltool_cache_directory`, engine-specific in name so it is not confused with planemo's download cache, `use_global_config=True` and `use_env_var=True`.
- **`planemo/galaxy/activity.py`** - `job_info` now reports `copied_from_job_id`, so a cache hit is observable in the test report. Also drops a stray `print(self._job_info)` debug leftover in that property.

No dependency bump - `use_cached_job` has been on bioblend's `invoke_workflow` since well before the pinned `bioblend>=1.6.0`.

## Test isolation

`CliTestCase` invokes the CLI without `--directory`, so with cwltool caching on by default the existing `test_run_cat_cwltool*` tests would write to the developer's real `~/.planemo/cwltool_cache` and could replay a stale entry on re-runs.

The whole workspace cannot be isolated - it caches the Galaxy git mirror (`gx_repo`) and the shared virtualenv (`gx_venv_*`), so a per-test `PLANEMO_GLOBAL_WORKSPACE` would make every Galaxy test re-clone Galaxy. Instead `CliTestCase.setUp` points `PLANEMO_CWLTOOL_CACHE_DIRECTORY` at a per-test temp directory.

## Tests

- `tests/test_galaxy_activity.py` - asserts `use_cached_job` reaches the tool payload and the `invoke_workflow` kwargs for both values, and that it is `False` when the kwd is absent entirely (the `planemo test` path). Verified failing before the change.
- `tests/test_run.py::test_run_cwltool_use_cache` / `test_run_cwltool_no_use_cache` - runs `cat1-tool.cwl` twice against an explicit cache directory and asserts the second run logs `Using cached output in`; the negative case asserts no cache directory is created. Verified failing before the change.
- `tests/test_run.py::test_run_gxtool_use_cache` - creates a `--database_type sqlite` profile (needs no external services and persists both the database and `file_path`), then runs three times asserting `copied_from_job_id` is null, then set, then null again under `--no_use_cache`. Passes locally in ~3m20s.
- `--help` coverage already exists via the loop over all commands in `tests/test_planemo.py`.

## Notes on what caching can actually reuse

Two limits are documented rather than gated on, in a new "Caching job results" section of `docs/_running_external.rst`:

- Galaxy needs a persistent database. The ephemeral local Galaxy gets a fresh database each run, so caching only pays off against `--galaxy_url` or a `--profile`.
- Galaxy's job-equivalence search matches input HDAs on the underlying `Dataset` row (`JobSearch._build_stmt_for_hda`). Planemo re-uploads local file inputs on every run, so jobs consuming them are never considered equivalent. Caching helps most when the job file refers to datasets already on the server. This is why the integration test uses `job_properties.xml`, which takes no data inputs.

cwltool's `--cachedir` keys on the rendered command line and input checksums, so it does hit across runs with the same local files. Caveats: it silently flips `move_outputs` from move to copy and creates a sibling `<cachedir>_tmp`, nothing prunes it, it is mutually exclusive with `--tmp-outdir-prefix`, docker keys on the image tag rather than a digest, and cache keys are not stable across cwltool upgrades.

No warning for the `toil` engine - with `--use_cache` defaulting to on it would fire on every plain `planemo run --engine toil`.

## Out of scope

`planemo test` could take the same flag - `_execute` is shared, so it is one decorator - but caching in a test command carries an obvious regression-masking risk and deserves its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
