### PR TITLE
Surface Galaxy service logs when a tool test fails

### DIFF
--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -3,7 +3,9 @@
 import abc
 import contextlib
 from typing import (
+    Any,
     Callable,
+    Dict,
     List,
     Optional,
     TYPE_CHECKING,
@@ -33,6 +35,19 @@ if TYPE_CHECKING:
     from planemo.cli import PlanemoCliContext
 
 INSTALLING_MESSAGE = "Installing repositories - this may take some time..."
+
+
+def log_service_logs_on_failure(ctx: "PlanemoCliContext", config, results: List[Dict[str, Any]]) -> None:
+    """Dump logs of services running alongside Galaxy if a test didn't succeed.
+
+    Galaxy's own log covers only the web process, but uploads run in Celery - so
+    a test that dies staging its inputs otherwise leaves no trace at all in the
+    log Planemo streams.
+    """
+    if results and all(result["data"].get("status") == "success" for result in results):
+        return
+    for name, contents in config.service_log_contents.items():
+        ctx.log(f"Tail of Galaxy service log [{name}]:\n{contents}")
 
 
 class GalaxyEngine(BaseEngine, metaclass=abc.ABCMeta):
@@ -111,6 +126,7 @@ class GalaxyEngine(BaseEngine, metaclass=abc.ABCMeta):
                         )
 
                     verbose = self._ctx.verbose
+                    result_index = len(test_results)
                     try:
                         if verbose:
                             # TODO: this is pretty hacky, it'd be better to send a stream
@@ -128,6 +144,8 @@ class GalaxyEngine(BaseEngine, metaclass=abc.ABCMeta):
                         )
                     except Exception:
                         pass
+
+                    log_service_logs_on_failure(self._ctx, config, test_results[result_index:])
 
         return test_results
 

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -12,6 +12,7 @@ import shutil
 import sqlite3
 import threading
 import time
+from collections import deque
 from string import Template
 from tempfile import (
     mkdtemp,
@@ -170,6 +171,7 @@ COMMAND_STARTUP_COMMAND = "./scripts/common_startup.sh ${COMMON_STARTUP_ARGS}"
 CLEANUP_IGNORE_ERRORS = True
 DEFAULT_GALAXY_BRAND = "Configured by Planemo"
 DEFAULT_TOOL_INSTALL_TIMEOUT = 60 * 60 * 1
+SERVICE_LOG_TAIL_LINES = 100
 UNINITIALIZED = object()
 
 
@@ -214,6 +216,24 @@ def read_log(ctx, log_path, e: threading.Event):
             if log_lines:
                 ctx.log(log_lines.rstrip())
             log_fh.close()
+
+
+def tail_log_directory(log_directory: str, lines: int = SERVICE_LOG_TAIL_LINES) -> Dict[str, str]:
+    """Map each ``.log`` file in ``log_directory`` to the tail of its contents."""
+    if not os.path.isdir(log_directory):
+        return {}
+    tails = {}
+    for name in sorted(os.listdir(log_directory)):
+        if not name.endswith(".log"):
+            continue
+        path = os.path.join(log_directory, name)
+        if not os.path.isfile(path):
+            continue
+        with open(path, errors="replace") as log_fh:
+            contents = "".join(deque(log_fh, lines)).rstrip()
+        if contents:
+            tails[name] = contents
+    return tails
 
 
 @contextlib.contextmanager
@@ -1002,6 +1022,15 @@ class BaseGalaxyConfig(GalaxyInterface):
             self._target_user_config = self.user_gi.config.get_config()
         return self._target_user_config
 
+    @property
+    def service_log_contents(self) -> Dict[str, str]:
+        """Tails of logs for services running alongside the Galaxy web process.
+
+        Galaxy's own log covers only the web process - uploads for instance run
+        entirely in Celery, so a failure there is invisible without these.
+        """
+        return {}
+
 
 class BaseManagedGalaxyConfig(BaseGalaxyConfig):
     def __init__(
@@ -1166,6 +1195,12 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
     @property
     def gravity_state_dir(self):
         return self.env["GRAVITY_STATE_DIR"]
+
+    @property
+    def service_log_contents(self) -> Dict[str, str]:
+        if not self.env.get("GRAVITY_STATE_DIR"):
+            return {}
+        return tail_log_directory(os.path.join(self.gravity_state_dir, "log"))
 
     def kill(self):
         if self._ctx.verbose:

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -3,6 +3,7 @@
 import os
 
 from planemo.engine import engine_context
+from planemo.engine.galaxy import log_service_logs_on_failure
 from planemo.runnable import (
     for_path,
     get_outputs,
@@ -58,3 +59,36 @@ def test_runnable_types():
     assert RunnableType.galaxy_workflow.is_galaxy_artifact
     assert not RunnableType.cwl_tool.is_galaxy_artifact
     assert not RunnableType.cwl_workflow.is_galaxy_artifact
+
+
+class _RecordingContext:
+    def __init__(self):
+        self.messages = []
+
+    def log(self, msg, *args):
+        self.messages.append(msg)
+
+
+class _ConfigWithServiceLogs:
+    service_log_contents = {"celery.log": "Task galaxy.fetch_data raised unexpected"}
+
+
+def test_service_logs_not_logged_when_tests_pass():
+    ctx = _RecordingContext()
+    log_service_logs_on_failure(ctx, _ConfigWithServiceLogs(), [{"data": {"status": "success"}}])
+    assert ctx.messages == []
+
+
+def test_service_logs_logged_when_test_fails():
+    ctx = _RecordingContext()
+    log_service_logs_on_failure(ctx, _ConfigWithServiceLogs(), [{"data": {"status": "error"}}])
+    assert len(ctx.messages) == 1
+    assert "celery.log" in ctx.messages[0]
+    assert "raised unexpected" in ctx.messages[0]
+
+
+def test_service_logs_logged_when_no_result_registered():
+    """verify_tool blew up before registering anything - still want the logs."""
+    ctx = _RecordingContext()
+    log_service_logs_on_failure(ctx, _ConfigWithServiceLogs(), [])
+    assert len(ctx.messages) == 1

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -12,6 +12,7 @@ from planemo.galaxy.config import (
     _shed_config_paths,
     galaxy_config,
     get_refgenie_config,
+    tail_log_directory,
     write_galaxy_config,
 )
 from planemo.runnable import (
@@ -268,3 +269,36 @@ def test_shed_config_paths_individual_override_wins():
     # untouched ones still derive from --shed_data_dir
     assert paths["shed_tool_path"] == "/persist/shed_tools"
     assert paths["shed_tool_data_table_config"] == "/persist/shed_tool_data_table_conf.xml"
+
+
+def test_tail_log_directory_missing_directory():
+    """A Galaxy that never started leaves no log directory at all."""
+    with TempDirectoryContext() as tdc:
+        assert tail_log_directory(os.path.join(tdc.temp_directory, "nope")) == {}
+
+
+def test_tail_log_directory_reads_only_logs():
+    with TempDirectoryContext() as tdc:
+        log_directory = tdc.temp_directory
+        with open(os.path.join(log_directory, "celery.log"), "w") as f:
+            f.write("task failed\n")
+        with open(os.path.join(log_directory, "celery_broker.sqlite"), "w") as f:
+            f.write("not a log\n")
+        os.mkdir(os.path.join(log_directory, "subdir.log"))
+        assert tail_log_directory(log_directory) == {"celery.log": "task failed"}
+
+
+def test_tail_log_directory_truncates_to_tail():
+    with TempDirectoryContext() as tdc:
+        log_directory = tdc.temp_directory
+        with open(os.path.join(log_directory, "celery.log"), "w") as f:
+            f.writelines(f"line {i}\n" for i in range(10))
+        tails = tail_log_directory(log_directory, lines=3)
+        assert tails["celery.log"] == "line 7\nline 8\nline 9"
+
+
+def test_tail_log_directory_skips_empty_logs():
+    with TempDirectoryContext() as tdc:
+        log_directory = tdc.temp_directory
+        open(os.path.join(log_directory, "gunicorn.log"), "w").close()
+        assert tail_log_directory(log_directory) == {}


### PR DESCRIPTION
Planemo streams exactly one log while a managed Galaxy runs — `read_log()` on `<galaxy_root>/main.log`. But the entire upload lifecycle runs in **Celery**: the `__DATA_FETCH__` job, `finish_job`, `compute_dataset_hash`. Celery logs to `<config_dir>/gravity/log/celery.log`, which planemo never reads or prints.

The result is that a tool test which dies staging its inputs produces output ending at

```
galaxy.tools.execute DEBUG Created 1 job(s) for tool __DATA_FETCH__ request
```

…and then nothing. `verify_tool` records "Input staging problem", planemo prints `<tool> (Test #1): failed`, and the actual reason is in a file that has already been `rmtree`'d.

I ran into this chasing a CI flake in `test_tool_in_directory` (https://github.com/galaxyproject/planemo/actions/runs/29866047660/job/88754412598, unrelated to the PR it appeared on — the identical tree passed 13 minutes earlier). The `copy` tool job was never submitted, so the failure was celery-side, and nothing beyond that was recoverable from CI. Verified against a healthy local run: a *successful* upload also emits zero lines to main.log, so the streamed log genuinely cannot distinguish the two.

## Changes

- **`planemo/galaxy/config.py`** — `tail_log_directory()` returning `{filename: tail}` for the `.log` files in a directory, and a `service_log_contents` property: `{}` on `BaseGalaxyConfig` (external/docker Galaxy), the gravity log directory on `LocalGalaxyConfig`.
- **`planemo/engine/galaxy.py`** — `log_service_logs_on_failure()`, called after each `verify_tool` when the registered result isn't `success` (or when nothing got registered at all, which means `verify_tool` blew up early). Nothing is printed on the happy path.

Tail is capped at 100 lines per file, so the added output only appears on failure and is bounded.

## Testing

- `tests/test_galaxy_config.py` — `tail_log_directory` over a missing directory, non-`.log` files and `.log`-suffixed *directories*, tail truncation, and empty logs.
- `tests/test_engines.py` — `log_service_logs_on_failure` stays quiet on success, fires on a failed result, and fires when no result was registered.
- End to end: ran `planemo test` on a tool with a deliberately unsatisfiable `assert_command`. All four service logs (`celery.log`, `celery-beat.log`, `gunicorn.log`, `gx-it-proxy.log`) now appear, and the celery tail reaches the full `__DATA_FETCH__` → `finish_job` → `compute_dataset_hash` chain — exactly what was missing from the CI log above. Confirmed nothing is printed when the same tool test passes.

## Not addressed

This does not fix the flake — it makes the next occurrence diagnosable. Worth noting there's precedent for celery-side flakiness here: e24fefc1 moved the Celery broker to its own sqlite file to dodge write-lock contention between gunicorn and the workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)