### PR TITLE
Use Gravity multiprocessing for modern Galaxy

### DIFF
--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -10,6 +10,8 @@ import random
 import shlex
 import shutil
 import sqlite3
+import subprocess
+import sys
 import threading
 import time
 from collections import deque
@@ -55,6 +57,7 @@ from planemo.galaxy.workflows import (
 from planemo.io import (
     communicate,
     kill_pid_file,
+    kill_process_group,
     shell,
     shell_join,
     stop_gravity,
@@ -130,6 +133,8 @@ EMPTY_JOB_METRICS_TEMPLATE = """<?xml version="1.0"?>
 <job_metrics>
 </job_metrics>
 """
+
+MINIMUM_MULTIPROCESSING_GALAXY_VERSION = parse_version("25.0.1")
 
 FILE_SOURCES_TEMPLATE = """
 - type: posix
@@ -549,8 +554,12 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
     else:
         env["GALAXY_CONFIG_FILE"] = config_join("galaxy.yml")
         env["GRAVITY_STATE_DIR"] = config_join("gravity")
-        with NamedTemporaryFile(suffix=".sock", delete=True) as nt:
-            env["SUPERVISORD_SOCKET"] = nt.name
+        use_multiprocessing = gravity_supports_multiprocessing(galaxy_root)
+        if use_multiprocessing:
+            env.pop("SUPERVISORD_SOCKET", None)
+        else:
+            with NamedTemporaryFile(suffix=".sock", delete=True) as nt:
+                env["SUPERVISORD_SOCKET"] = nt.name
         host = kwds.get("host", "localhost")
         port = template_args["port"]
         # Use "localhost" for infrastructure URL when bound to 127.0.0.1,
@@ -584,22 +593,30 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
         # and doesn't depend on GALAXY_CONFIG_OVERRIDE_* env vars being propagated
         # by Gravity to gunicorn workers.
         resolved_properties = {k: _sub(v, template_args) if isinstance(v, str) else v for k, v in properties.items()}
+        gravity = {
+            "galaxy_root": galaxy_root,
+            "gunicorn": {
+                "bind": f"{host}:{port}",
+                "preload": False,
+            },
+            "gx_it_proxy": gx_it_proxy_config,
+        }
+        if use_multiprocessing:
+            gravity["process_manager"] = "multiprocessing"
         write_file(
             env["GALAXY_CONFIG_FILE"],
             json.dumps(
                 {
                     "galaxy": resolved_properties,
-                    "gravity": {
-                        "galaxy_root": galaxy_root,
-                        "gunicorn": {
-                            "bind": f"{host}:{port}",
-                            "preload": False,
-                        },
-                        "gx_it_proxy": gx_it_proxy_config,
-                    },
+                    "gravity": gravity,
                 }
             ),
         )
+
+
+def gravity_supports_multiprocessing(galaxy_root):
+    """Return whether Galaxy includes a multiprocessing-capable Gravity."""
+    return get_galaxy_version(galaxy_root) >= MINIMUM_MULTIPROCESSING_GALAXY_VERSION
 
 
 def _expand_paths(galaxy_root: Optional[str], extra_tools: List[str]) -> List[str]:
@@ -612,21 +629,21 @@ def _expand_paths(galaxy_root: Optional[str], extra_tools: List[str]) -> List[st
     return extra_tools
 
 
+def get_galaxy_version(galaxy_root):
+    galaxy_lib = os.path.join(galaxy_root, "lib", "galaxy")
+    version_path = os.path.join(galaxy_lib, "version.py")
+    if not os.path.isfile(version_path):
+        version_path = os.path.join(galaxy_lib, "version", "__init__.py")
+    spec = importlib.util.spec_from_file_location("__galaxy_version", version_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    version = getattr(module, "VERSION", None) or module.VERSION_MAJOR
+    return parse_version(version)
+
+
 def get_galaxy_major_version(galaxy_root):
-    try:
-        spec = importlib.util.spec_from_file_location(
-            "__galaxy_version", os.path.join(galaxy_root, "lib", "galaxy", "version.py")
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return parse_version(module.VERSION_MAJOR)
-    except FileNotFoundError:
-        spec = importlib.util.spec_from_file_location(
-            "__galaxy_version", os.path.join(galaxy_root, "lib", "galaxy", "version", "__init__.py")
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return parse_version(module.VERSION_MAJOR)
+    version = get_galaxy_version(galaxy_root)
+    return parse_version(f"{version.major}.{version.minor}")
 
 
 def get_refgenie_config(galaxy_root, refgenie_dir):
@@ -1181,6 +1198,9 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
         )
         self.galaxy_root = galaxy_root
         self._virtual_env_locs = []
+        self.use_multiprocessing = gravity_supports_multiprocessing(galaxy_root)
+        self._daemon_process = None
+        self._daemon_control_fd = None
 
     @property
     def virtual_env_dir(self):
@@ -1211,13 +1231,68 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
             if exists:
                 with open(self.pid_file) as f:
                     print(f"pid_file contents are [{f.read()}]")
-        if self.env.get("GRAVITY_STATE_DIR"):
+        if self.use_multiprocessing:
+            if self._daemon_control_fd is not None:
+                os.close(self._daemon_control_fd)
+                self._daemon_control_fd = None
+            if self._daemon_process is not None:
+                kill_process_group(self._daemon_process)
+            else:
+                kill_pid_file(self.pid_file)
+        elif self.env.get("GRAVITY_STATE_DIR"):
             stop_gravity(
                 virtual_env=self.virtual_env_dir or os.path.join(self.galaxy_root, ".venv"),
                 gravity_state_dir=self.gravity_state_dir,
                 env=self.env,
             )
-        kill_pid_file(self.pid_file)
+        if not self.use_multiprocessing:
+            kill_pid_file(self.pid_file)
+        else:
+            try:
+                os.unlink(self.pid_file)
+            except FileNotFoundError:
+                pass
+
+    def start_daemon(self, command):
+        """Run foreground Galaxy in a detached session and record its PID."""
+        environ = os.environ.copy()
+        environ.update(self.env)
+        monitor_read_fd, monitor_write_fd = os.pipe()
+        try:
+            with open(self.log_file, "ab", buffering=0) as log:
+                process = subprocess.Popen(
+                    [sys.executable, "-m", "planemo.galaxy.daemon_monitor", str(monitor_read_fd), command],
+                    env=environ,
+                    pass_fds=[monitor_read_fd],
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+        except BaseException:
+            os.close(monitor_write_fd)
+            raise
+        finally:
+            os.close(monitor_read_fd)
+        self._daemon_process = process
+        self._daemon_control_fd = monitor_write_fd
+        try:
+            with open(self.pid_file, "w") as pid_file:
+                pid_file.write(str(process.pid))
+        except BaseException:
+            self.kill()
+            raise
+        return process
+
+    def detach_daemon(self):
+        """Allow a successfully launched daemon to outlive Planemo."""
+        if self._daemon_control_fd is not None:
+            try:
+                os.write(self._daemon_control_fd, b"D")
+            except BrokenPipeError:
+                pass
+            finally:
+                os.close(self._daemon_control_fd)
+                self._daemon_control_fd = None
 
     def startup_command(self, ctx, **kwds):
         """Return a shell command used to startup this instance.
@@ -1229,7 +1304,7 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
         # TODO: Allow running dockerized Galaxy here instead.
         setup_venv_command = setup_venv(ctx, kwds, self)
         run_script = f"{shlex.quote(os.path.join(self.galaxy_root, 'run.sh'))} $COMMON_STARTUP_ARGS"
-        if daemon:
+        if daemon and not self.use_multiprocessing:
             run_script += " --daemon"
         else:
             run_script += f" --server-name {shlex.quote(self.server_name)}"

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -9,6 +9,7 @@ import os
 import random
 import shlex
 import shutil
+import signal
 import sqlite3
 import subprocess
 import sys
@@ -57,7 +58,6 @@ from planemo.galaxy.workflows import (
 from planemo.io import (
     communicate,
     kill_pid_file,
-    kill_process_group,
     shell,
     shell_join,
     stop_gravity,
@@ -1236,7 +1236,11 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
                 os.close(self._daemon_control_fd)
                 self._daemon_control_fd = None
             if self._daemon_process is not None:
-                kill_process_group(self._daemon_process)
+                try:
+                    self._daemon_process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self._daemon_process.send_signal(signal.SIGTERM)
+                    self._daemon_process.wait(timeout=2)
             else:
                 kill_pid_file(self.pid_file)
         elif self.env.get("GRAVITY_STATE_DIR"):

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -9,7 +9,6 @@ import os
 import random
 import shlex
 import shutil
-import signal
 import sqlite3
 import subprocess
 import sys
@@ -61,6 +60,8 @@ from planemo.io import (
     shell,
     shell_join,
     stop_gravity,
+    terminate_process_group,
+    termination_timeout,
     untar_to,
     wait_on,
     warn,
@@ -1174,6 +1175,36 @@ class DockerGalaxyConfig(BaseManagedGalaxyConfig):
         shutil.rmtree(self.config_directory, CLEANUP_IGNORE_ERRORS)
 
 
+def _shut_down_daemon_monitor(process, asked_to_stop=True):
+    """Wait for the daemon monitor to tear Galaxy down, then insist that it exit.
+
+    Closing the control pipe is what asks the monitor to stop Galaxy, so when it
+    has just been closed give the monitor time to run its own
+    SIGTERM-then-SIGKILL escalation before signalling it. A daemon that was
+    already detached has no pipe left and has not been asked for anything, so
+    waiting there only burns a grace period it was never told to observe.
+
+    Signalling the monitor's group reaches the monitor alone - Galaxy leads a
+    separate group whose ID only the monitor holds - so escalate rather than
+    wait forever, and say so if Galaxy might be left behind.
+
+    Never raises. This runs while a config is being torn down, frequently with
+    another exception already in flight, and masking that would be worse than
+    whatever went wrong here.
+    """
+    if asked_to_stop:
+        # The monitor's own escalation is bounded by a grace period plus the
+        # settle after SIGKILL; allow both before concluding it is stuck.
+        try:
+            process.wait(timeout=2 * termination_timeout())
+            return
+        except subprocess.TimeoutExpired:
+            pass
+    terminate_process_group(process.pid, reap=process.poll)
+    if process.poll() is None:
+        warn(f"Galaxy daemon monitor [{process.pid}] would not exit; Galaxy may still be running.")
+
+
 class LocalGalaxyConfig(BaseManagedGalaxyConfig):
     """A local, non-containerized implementation of :class:`GalaxyConfig`."""
 
@@ -1243,15 +1274,12 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
                 with open(self.pid_file) as f:
                     print(f"pid_file contents are [{f.read()}]")
         if self.use_multiprocessing:
-            if self._daemon_control_fd is not None:
+            asked_to_stop = self._daemon_control_fd is not None
+            if asked_to_stop:
                 os.close(self._daemon_control_fd)
                 self._daemon_control_fd = None
             if self._daemon_process is not None:
-                try:
-                    self._daemon_process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    self._daemon_process.send_signal(signal.SIGTERM)
-                    self._daemon_process.wait(timeout=2)
+                _shut_down_daemon_monitor(self._daemon_process, asked_to_stop=asked_to_stop)
             else:
                 kill_pid_file(self.pid_file)
         elif self.env.get("GRAVITY_STATE_DIR"):

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -380,6 +380,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             galaxy_root = config_join("galaxy-dev")
         if not os.path.isdir(galaxy_root):
             _install_galaxy(ctx, galaxy_root, install_env, kwds)
+        galaxy_version = get_galaxy_version(galaxy_root)
 
         server_name = "main"
         # Once we don't have to support earlier than 18.01 - try putting these files
@@ -391,7 +392,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         kwds["all_in_one_handling"] = True
         _handle_job_config_file(config_directory, server_name, test_data_dir, all_tool_paths, kwds)
         _handle_file_sources(config_directory, test_data_dir, kwds)
-        _handle_refgenie_config(config_directory, galaxy_root, kwds)
+        _handle_refgenie_config(config_directory, galaxy_root, kwds, galaxy_version)
         _handle_vault_config(config_directory, kwds)
         file_path = kwds.get("file_path") or config_join("files")
         _ensure_directory(file_path)
@@ -508,6 +509,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             kwds=kwds,
             template_args=template_args,
             config_join=config_join,
+            galaxy_version=galaxy_version,
         )
 
         _write_tool_conf(ctx, all_tool_paths, tool_conf)
@@ -532,6 +534,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             runnables,
             galaxy_root,
             kwds,
+            galaxy_version,
         )
 
 
@@ -545,8 +548,9 @@ def _init_interactivetools_db(path):
     conn.close()
 
 
-def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, config_join):
-    if get_galaxy_major_version(galaxy_root) < parse_version("22.01"):
+def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, config_join, galaxy_version=None):
+    galaxy_version = galaxy_version or get_galaxy_version(galaxy_root)
+    if get_galaxy_major_version(galaxy_version=galaxy_version) < parse_version("22.01"):
         # Legacy .ini setup
         env["GALAXY_CONFIG_FILE"] = config_join("galaxy.ini")
         web_config = _sub(WEB_SERVER_CONFIG_TEMPLATE, template_args)
@@ -554,7 +558,7 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
     else:
         env["GALAXY_CONFIG_FILE"] = config_join("galaxy.yml")
         env["GRAVITY_STATE_DIR"] = config_join("gravity")
-        use_multiprocessing = gravity_supports_multiprocessing(galaxy_root)
+        use_multiprocessing = gravity_supports_multiprocessing(galaxy_version=galaxy_version)
         if use_multiprocessing:
             env.pop("SUPERVISORD_SOCKET", None)
         else:
@@ -614,9 +618,10 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
         )
 
 
-def gravity_supports_multiprocessing(galaxy_root):
+def gravity_supports_multiprocessing(galaxy_root=None, galaxy_version=None):
     """Return whether Galaxy includes a multiprocessing-capable Gravity."""
-    return get_galaxy_version(galaxy_root) >= MINIMUM_MULTIPROCESSING_GALAXY_VERSION
+    galaxy_version = galaxy_version or get_galaxy_version(galaxy_root)
+    return galaxy_version >= MINIMUM_MULTIPROCESSING_GALAXY_VERSION
 
 
 def _expand_paths(galaxy_root: Optional[str], extra_tools: List[str]) -> List[str]:
@@ -641,15 +646,15 @@ def get_galaxy_version(galaxy_root):
     return parse_version(version)
 
 
-def get_galaxy_major_version(galaxy_root):
-    version = get_galaxy_version(galaxy_root)
+def get_galaxy_major_version(galaxy_root=None, galaxy_version=None):
+    version = galaxy_version or get_galaxy_version(galaxy_root)
     return parse_version(f"{version.major}.{version.minor}")
 
 
-def get_refgenie_config(galaxy_root, refgenie_dir):
+def get_refgenie_config(galaxy_root, refgenie_dir, galaxy_version=None):
     config_version = 0.4
     if galaxy_root:
-        version_major = get_galaxy_major_version(galaxy_root=galaxy_root)
+        version_major = get_galaxy_major_version(galaxy_root=galaxy_root, galaxy_version=galaxy_version)
         if version_major < parse_version("21.09"):
             config_version = 0.3
     return REFGENIE_CONFIG_TEMPLATE % (config_version, refgenie_dir)
@@ -1184,6 +1189,7 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
         runnables,
         galaxy_root,
         kwds,
+        galaxy_version=None,
     ):
         super().__init__(
             ctx,
@@ -1198,7 +1204,8 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
         )
         self.galaxy_root = galaxy_root
         self._virtual_env_locs = []
-        self.use_multiprocessing = gravity_supports_multiprocessing(galaxy_root)
+        self.galaxy_version = galaxy_version or get_galaxy_version(galaxy_root)
+        self.use_multiprocessing = gravity_supports_multiprocessing(galaxy_version=self.galaxy_version)
         self._daemon_process = None
         self._daemon_control_fd = None
 
@@ -1641,11 +1648,13 @@ def _handle_file_sources(config_directory, test_data_dir, kwds):
     kwds["file_sources_config_file"] = file_sources_conf
 
 
-def _handle_refgenie_config(config_directory, galaxy_root, kwds):
+def _handle_refgenie_config(config_directory, galaxy_root, kwds, galaxy_version=None):
     refgenie_dir = os.path.join(config_directory, "refgenie")
     _ensure_directory(refgenie_dir)
     refgenie_config_file = os.path.join(refgenie_dir, "genome_config.yaml")
-    refgenie_config = get_refgenie_config(galaxy_root=galaxy_root, refgenie_dir=refgenie_dir)
+    refgenie_config = get_refgenie_config(
+        galaxy_root=galaxy_root, refgenie_dir=refgenie_dir, galaxy_version=galaxy_version
+    )
     with open(refgenie_config_file, "w") as fh:
         fh.write(refgenie_config)
     kwds["refgenie_config_file"] = refgenie_config_file

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -2,6 +2,7 @@
 
 import abc
 import contextlib
+import functools
 import hashlib
 import importlib.util
 import json
@@ -381,7 +382,6 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             galaxy_root = config_join("galaxy-dev")
         if not os.path.isdir(galaxy_root):
             _install_galaxy(ctx, galaxy_root, install_env, kwds)
-        galaxy_version = get_galaxy_version(galaxy_root)
 
         server_name = "main"
         # Once we don't have to support earlier than 18.01 - try putting these files
@@ -393,7 +393,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         kwds["all_in_one_handling"] = True
         _handle_job_config_file(config_directory, server_name, test_data_dir, all_tool_paths, kwds)
         _handle_file_sources(config_directory, test_data_dir, kwds)
-        _handle_refgenie_config(config_directory, galaxy_root, kwds, galaxy_version)
+        _handle_refgenie_config(config_directory, galaxy_root, kwds)
         _handle_vault_config(config_directory, kwds)
         file_path = kwds.get("file_path") or config_join("files")
         _ensure_directory(file_path)
@@ -510,7 +510,6 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             kwds=kwds,
             template_args=template_args,
             config_join=config_join,
-            galaxy_version=galaxy_version,
         )
 
         _write_tool_conf(ctx, all_tool_paths, tool_conf)
@@ -535,7 +534,6 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             runnables,
             galaxy_root,
             kwds,
-            galaxy_version,
         )
 
 
@@ -549,9 +547,8 @@ def _init_interactivetools_db(path):
     conn.close()
 
 
-def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, config_join, galaxy_version=None):
-    galaxy_version = galaxy_version or get_galaxy_version(galaxy_root)
-    if get_galaxy_major_version(galaxy_version=galaxy_version) < parse_version("22.01"):
+def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, config_join):
+    if get_galaxy_major_version(galaxy_root) < parse_version("22.01"):
         # Legacy .ini setup
         env["GALAXY_CONFIG_FILE"] = config_join("galaxy.ini")
         web_config = _sub(WEB_SERVER_CONFIG_TEMPLATE, template_args)
@@ -559,7 +556,7 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
     else:
         env["GALAXY_CONFIG_FILE"] = config_join("galaxy.yml")
         env["GRAVITY_STATE_DIR"] = config_join("gravity")
-        use_multiprocessing = gravity_supports_multiprocessing(galaxy_version=galaxy_version)
+        use_multiprocessing = gravity_supports_multiprocessing(galaxy_root)
         if use_multiprocessing:
             env.pop("SUPERVISORD_SOCKET", None)
         else:
@@ -619,10 +616,9 @@ def write_galaxy_config(galaxy_root, properties, env, kwds, template_args, confi
         )
 
 
-def gravity_supports_multiprocessing(galaxy_root=None, galaxy_version=None):
+def gravity_supports_multiprocessing(galaxy_root):
     """Return whether Galaxy includes a multiprocessing-capable Gravity."""
-    galaxy_version = galaxy_version or get_galaxy_version(galaxy_root)
-    return galaxy_version >= MINIMUM_MULTIPROCESSING_GALAXY_VERSION
+    return get_galaxy_version(galaxy_root) >= MINIMUM_MULTIPROCESSING_GALAXY_VERSION
 
 
 def _expand_paths(galaxy_root: Optional[str], extra_tools: List[str]) -> List[str]:
@@ -635,7 +631,14 @@ def _expand_paths(galaxy_root: Optional[str], extra_tools: List[str]) -> List[st
     return extra_tools
 
 
+@functools.lru_cache(maxsize=None)
 def get_galaxy_version(galaxy_root):
+    """Return the parsed version of the Galaxy checkout at ``galaxy_root``.
+
+    Cached because reading it means executing Galaxy's version module, and a
+    single configuration build asks several independent questions of it.
+    ``_install_galaxy`` clears the cache, since that is what changes the answer.
+    """
     galaxy_lib = os.path.join(galaxy_root, "lib", "galaxy")
     version_path = os.path.join(galaxy_lib, "version.py")
     if not os.path.isfile(version_path):
@@ -647,15 +650,15 @@ def get_galaxy_version(galaxy_root):
     return parse_version(version)
 
 
-def get_galaxy_major_version(galaxy_root=None, galaxy_version=None):
-    version = galaxy_version or get_galaxy_version(galaxy_root)
+def get_galaxy_major_version(galaxy_root):
+    version = get_galaxy_version(galaxy_root)
     return parse_version(f"{version.major}.{version.minor}")
 
 
-def get_refgenie_config(galaxy_root, refgenie_dir, galaxy_version=None):
+def get_refgenie_config(galaxy_root, refgenie_dir):
     config_version = 0.4
     if galaxy_root:
-        version_major = get_galaxy_major_version(galaxy_root=galaxy_root, galaxy_version=galaxy_version)
+        version_major = get_galaxy_major_version(galaxy_root)
         if version_major < parse_version("21.09"):
             config_version = 0.3
     return REFGENIE_CONFIG_TEMPLATE % (config_version, refgenie_dir)
@@ -1220,7 +1223,6 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
         runnables,
         galaxy_root,
         kwds,
-        galaxy_version=None,
     ):
         super().__init__(
             ctx,
@@ -1235,8 +1237,8 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
         )
         self.galaxy_root = galaxy_root
         self._virtual_env_locs = []
-        self.galaxy_version = galaxy_version or get_galaxy_version(galaxy_root)
-        self.use_multiprocessing = gravity_supports_multiprocessing(galaxy_version=self.galaxy_version)
+        self.galaxy_version = get_galaxy_version(galaxy_root)
+        self.use_multiprocessing = gravity_supports_multiprocessing(galaxy_root)
         self._daemon_process = None
         self._daemon_control_fd = None
 
@@ -1520,6 +1522,7 @@ def _tool_conf_entry_for(tool_paths):
 
 
 def _install_galaxy(ctx, galaxy_root, env, kwds):
+    get_galaxy_version.cache_clear()
     if not kwds.get("no_cache_galaxy", False):
         _install_galaxy_via_git(ctx, galaxy_root, env, kwds)
     else:
@@ -1676,13 +1679,11 @@ def _handle_file_sources(config_directory, test_data_dir, kwds):
     kwds["file_sources_config_file"] = file_sources_conf
 
 
-def _handle_refgenie_config(config_directory, galaxy_root, kwds, galaxy_version=None):
+def _handle_refgenie_config(config_directory, galaxy_root, kwds):
     refgenie_dir = os.path.join(config_directory, "refgenie")
     _ensure_directory(refgenie_dir)
     refgenie_config_file = os.path.join(refgenie_dir, "genome_config.yaml")
-    refgenie_config = get_refgenie_config(
-        galaxy_root=galaxy_root, refgenie_dir=refgenie_dir, galaxy_version=galaxy_version
-    )
+    refgenie_config = get_refgenie_config(galaxy_root=galaxy_root, refgenie_dir=refgenie_dir)
     with open(refgenie_config_file, "w") as fh:
         fh.write(refgenie_config)
     kwds["refgenie_config_file"] = refgenie_config_file

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -58,10 +58,12 @@ from planemo.galaxy.workflows import (
 from planemo.io import (
     communicate,
     kill_pid_file,
+    KILL_SETTLE_TIMEOUT,
     shell,
     shell_join,
     stop_gravity,
     terminate_process_group,
+    TERMINATION_POLL_INTERVAL,
     termination_timeout,
     untar_to,
     wait_on,
@@ -1197,9 +1199,10 @@ def _shut_down_daemon_monitor(process, asked_to_stop=True):
     """
     if asked_to_stop:
         # The monitor's own escalation is bounded by a grace period plus the
-        # settle after SIGKILL; allow both before concluding it is stuck.
+        # settle after SIGKILL. Each wait loop may overshoot by one poll, so
+        # allow both polls before concluding it is stuck.
         try:
-            process.wait(timeout=2 * termination_timeout())
+            process.wait(timeout=termination_timeout() + KILL_SETTLE_TIMEOUT + 2 * TERMINATION_POLL_INTERVAL)
             return
         except subprocess.TimeoutExpired:
             pass

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -1218,6 +1218,10 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
 
     @property
     def service_log_contents(self) -> Dict[str, str]:
+        if self.use_multiprocessing:
+            # Multiprocessing services inherit the foreground process's
+            # stdout/stderr, which start_daemon redirects to the main log.
+            return {}
         if not self.env.get("GRAVITY_STATE_DIR"):
             return {}
         return tail_log_directory(os.path.join(self.gravity_state_dir, "log"))

--- a/planemo/galaxy/daemon_monitor.py
+++ b/planemo/galaxy/daemon_monitor.py
@@ -1,0 +1,36 @@
+"""Keep a foreground Galaxy process tied to Planemo until detached."""
+
+import os
+import select
+import signal
+import subprocess
+import sys
+
+DETACH = b"D"
+POLL_INTERVAL = 0.1
+
+
+def main():
+    control_fd = int(sys.argv[1])
+    command = sys.argv[2]
+    child = subprocess.Popen(command, shell=True)
+
+    while child.poll() is None:
+        readable, _, _ = select.select([control_fd], [], [], POLL_INTERVAL)
+        if not readable:
+            continue
+        message = os.read(control_fd, 1)
+        if message == DETACH:
+            os.close(control_fd)
+            return child.wait()
+
+        # EOF means Planemo exited without explicitly detaching the daemon.
+        # The monitor and Galaxy share a dedicated process group, so signaling
+        # the group also cleans up every service launched by Gravity.
+        os.killpg(os.getpgrp(), signal.SIGTERM)
+
+    return child.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planemo/galaxy/daemon_monitor.py
+++ b/planemo/galaxy/daemon_monitor.py
@@ -5,29 +5,73 @@ import select
 import signal
 import subprocess
 import sys
+import time
 
 DETACH = b"D"
 POLL_INTERVAL = 0.1
+TERMINATION_TIMEOUT = 0.5
+
+
+def _process_group_exists(process_group):
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_for_process_group(process_group):
+    deadline = time.monotonic() + TERMINATION_TIMEOUT
+    while time.monotonic() < deadline:
+        if not _process_group_exists(process_group):
+            return True
+        time.sleep(POLL_INTERVAL)
+    return not _process_group_exists(process_group)
+
+
+def _terminate_process_group(child):
+    process_group = child.pid
+    for process_signal in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(process_group, process_signal)
+        except ProcessLookupError:
+            break
+        if _wait_for_process_group(process_group):
+            break
+    child.wait()
+    return child.returncode
 
 
 def main():
     control_fd = int(sys.argv[1])
     command = sys.argv[2]
-    child = subprocess.Popen(command, shell=True)
+    child = subprocess.Popen(command, shell=True, start_new_session=True)
+    termination_requested = False
+
+    def request_termination(signum, frame):
+        nonlocal termination_requested
+        termination_requested = True
+
+    signal.signal(signal.SIGTERM, request_termination)
+    signal.signal(signal.SIGINT, request_termination)
 
     while child.poll() is None:
+        if termination_requested:
+            return _terminate_process_group(child)
         readable, _, _ = select.select([control_fd], [], [], POLL_INTERVAL)
         if not readable:
             continue
         message = os.read(control_fd, 1)
         if message == DETACH:
             os.close(control_fd)
-            return child.wait()
+            while child.poll() is None and not termination_requested:
+                time.sleep(POLL_INTERVAL)
+            if termination_requested:
+                return _terminate_process_group(child)
+            return child.returncode
 
         # EOF means Planemo exited without explicitly detaching the daemon.
-        # The monitor and Galaxy share a dedicated process group, so signaling
-        # the group also cleans up every service launched by Gravity.
-        os.killpg(os.getpgrp(), signal.SIGTERM)
+        return _terminate_process_group(child)
 
     return child.returncode
 

--- a/planemo/galaxy/daemon_monitor.py
+++ b/planemo/galaxy/daemon_monitor.py
@@ -1,4 +1,9 @@
-"""Keep a foreground Galaxy process tied to Planemo until detached."""
+"""Keep a foreground Galaxy process tied to Planemo until detached.
+
+Planemo runs this as ``python -m planemo.galaxy.daemon_monitor``, which imports
+the ``planemo.galaxy`` package first - so all of Planemo is already loaded here
+and sharing its process-group helpers costs nothing.
+"""
 
 import os
 import select
@@ -7,39 +12,19 @@ import subprocess
 import sys
 import time
 
+from planemo.io import terminate_process_group
+
 DETACH = b"D"
 POLL_INTERVAL = 0.1
-TERMINATION_TIMEOUT = 0.5
-
-
-def _process_group_exists(process_group):
-    try:
-        os.killpg(process_group, 0)
-    except ProcessLookupError:
-        return False
-    return True
-
-
-def _wait_for_process_group(process_group):
-    deadline = time.monotonic() + TERMINATION_TIMEOUT
-    while time.monotonic() < deadline:
-        if not _process_group_exists(process_group):
-            return True
-        time.sleep(POLL_INTERVAL)
-    return not _process_group_exists(process_group)
 
 
 def _terminate_process_group(child):
-    process_group = child.pid
-    for process_signal in (signal.SIGTERM, signal.SIGKILL):
-        try:
-            os.killpg(process_group, process_signal)
-        except ProcessLookupError:
-            break
-        if _wait_for_process_group(process_group):
-            break
-    child.wait()
-    return child.returncode
+    """Stop Galaxy's process group and reap its leader."""
+    # start_new_session=True made the child a process group leader, so its PID
+    # doubles as a group ID that stays valid even after the leader is reaped.
+    if terminate_process_group(child.pid, reap=child.poll):
+        return child.wait()
+    return 1
 
 
 def main():

--- a/planemo/galaxy/ephemeris_sleep.py
+++ b/planemo/galaxy/ephemeris_sleep.py
@@ -87,7 +87,7 @@ def sleep(galaxy_url, verbose=False, timeout=0, sleep_condition=None, startup_pr
                 if verbose:
                     sys.stdout.write("[%02d] No valid json returned... %s\n" % (count, result.__str__()))
                     sys.stdout.flush()
-        except requests.exceptions.RequestException as e:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             if verbose:
                 sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, unicodify(e)[:100]))
                 sys.stdout.flush()

--- a/planemo/galaxy/ephemeris_sleep.py
+++ b/planemo/galaxy/ephemeris_sleep.py
@@ -7,6 +7,7 @@ The script functions by making repeated requests to
 ``http(s)://fqdn/api/version``, an API which requires no authentication
 to access."""
 
+import subprocess
 import sys
 import time
 from argparse import ArgumentParser
@@ -54,13 +55,26 @@ class SleepCondition:
         self.sleep = False
 
 
-def sleep(galaxy_url, verbose=False, timeout=0, sleep_condition=None):
+def _wait_for_retry(startup_process):
+    if startup_process is None:
+        time.sleep(DEFAULT_SLEEP_WAIT)
+        return False
+    try:
+        startup_process.wait(timeout=DEFAULT_SLEEP_WAIT)
+    except subprocess.TimeoutExpired:
+        return False
+    return True
+
+
+def sleep(galaxy_url, verbose=False, timeout=0, sleep_condition=None, startup_process=None):
     if sleep_condition is None:
         sleep_condition = SleepCondition()
 
     count = 0
     start_time = time.time()
     while sleep_condition.sleep:
+        if startup_process is not None and startup_process.poll() is not None:
+            return False
         try:
             result = requests.get(galaxy_url + "/api/version", timeout=CONNECT_TIMEOUT)
             try:
@@ -73,7 +87,7 @@ def sleep(galaxy_url, verbose=False, timeout=0, sleep_condition=None):
                 if verbose:
                     sys.stdout.write("[%02d] No valid json returned... %s\n" % (count, result.__str__()))
                     sys.stdout.flush()
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+        except requests.exceptions.RequestException as e:
             if verbose:
                 sys.stdout.write("[%02d] Galaxy not up yet... %s\n" % (count, unicodify(e)[:100]))
                 sys.stdout.flush()
@@ -92,7 +106,8 @@ def sleep(galaxy_url, verbose=False, timeout=0, sleep_condition=None):
             sys.stderr.write(f"Failed to contact Galaxy after {elapsed:.0f}s ({count} attempts)\n")
             return False
 
-        time.sleep(DEFAULT_SLEEP_WAIT)
+        if _wait_for_retry(startup_process):
+            return False
 
     return True
 

--- a/planemo/galaxy/run.py
+++ b/planemo/galaxy/run.py
@@ -97,8 +97,8 @@ def locate_galaxy_virtualenv(ctx, kwds: Dict[str, Any], config: Optional["LocalG
     )
 
 
-def run_galaxy_command(ctx, command, env, action):
-    """Run Galaxy command with informative verbose logging."""
+def log_galaxy_command(ctx, command, env, action):
+    """Log a Galaxy command and its environment consistently."""
     message = f"{action} with command [{command}]"
     # info not working in pytest+Github actions the way it did in nose?
     info(message)
@@ -107,12 +107,18 @@ def run_galaxy_command(ctx, command, env, action):
     for key, value in env.items():
         ctx.vlog(f'{key}="{value}"')
     ctx.vlog("============================")
+
+
+def run_galaxy_command(ctx, command, env, action):
+    """Run Galaxy command with informative verbose logging."""
+    log_galaxy_command(ctx, command, env, action)
     exit_code = shell(command, env=env)
     ctx.vlog("run command exited with return code %s" % exit_code)
     return exit_code
 
 
 __all__ = (
+    "log_galaxy_command",
     "setup_venv",
     "run_galaxy_command",
 )

--- a/planemo/galaxy/serve.py
+++ b/planemo/galaxy/serve.py
@@ -26,6 +26,31 @@ def serve(ctx, runnables=None, **kwds):
         raise
 
 
+def _start_galaxy(ctx, config, command, daemon):
+    action = "Starting Galaxy"
+    if daemon and getattr(config, "use_multiprocessing", False):
+        ctx.vlog(f"{action} with command [{command}]")
+        startup_process = config.start_daemon(command)
+        return startup_process, startup_process.poll()
+    exit_code = run_galaxy_command(ctx, command, config.env, action)
+    return None, exit_code
+
+
+def _check_startup_command(config, startup_process, exit_code):
+    if startup_process is not None and exit_code is not None:
+        message = (
+            f"Galaxy process exited with code {startup_process.returncode} during startup. "
+            f"Galaxy log: [{config.log_contents}]"
+        )
+        io.warn(message)
+        config.kill()
+        raise Exception(message)
+    if exit_code:
+        message = "Problem running Galaxy command [%s]." % config.log_contents
+        io.warn(message)
+        raise Exception(message)
+
+
 @contextlib.contextmanager
 def _serve(ctx, runnables, **kwds):
     engine = kwds.get("engine", "galaxy")
@@ -43,24 +68,29 @@ def _serve(ctx, runnables, **kwds):
 
     with galaxy_config(ctx, runnables, **kwds) as config:
         cmd = config.startup_command(ctx, **kwds)
-        action = "Starting Galaxy"
-        exit_code = run_galaxy_command(
-            ctx,
-            cmd,
-            config.env,
-            action,
-        )
-        if exit_code:
-            message = "Problem running Galaxy command [%s]." % config.log_contents
-            io.warn(message)
-            raise Exception(message)
+        startup_process, exit_code = _start_galaxy(ctx, config, cmd, daemon)
+        _check_startup_command(config, startup_process, exit_code)
         host = kwds.get("host", "127.0.0.1")
 
         startup_timeout = kwds.get("galaxy_startup_timeout", 900)
         galaxy_url = f"http://{host}:{port}"
-        galaxy_alive = sleep(galaxy_url, verbose=ctx.verbose, timeout=startup_timeout)
+        galaxy_alive = sleep(
+            galaxy_url,
+            verbose=ctx.verbose,
+            timeout=startup_timeout,
+            startup_process=startup_process,
+        )
         if not galaxy_alive:
             log_contents = config.log_contents
+            if startup_process is not None and startup_process.poll() is not None:
+                message = (
+                    f"Galaxy process exited with code {startup_process.returncode} during startup. "
+                    f"Galaxy log: [{log_contents}]"
+                )
+                config.kill()
+                raise Exception(message)
+            if startup_process is not None:
+                config.kill()
             raise Exception(
                 f"Attempted to serve Galaxy at {galaxy_url}, but it failed to start in {startup_timeout} seconds."
                 f"\nGalaxy log contents:\n{log_contents}"
@@ -72,7 +102,15 @@ def _serve(ctx, runnables, **kwds):
                 os.symlink(real_pid_file, kwds["pid_file"])
             else:
                 io.warn("Can't find Galaxy pid file [%s] to link" % real_pid_file)
-        yield config
+        try:
+            yield config
+        except BaseException:
+            if startup_process is not None:
+                config.kill()
+            raise
+        else:
+            if startup_process is not None:
+                config.detach_daemon()
 
 
 @contextlib.contextmanager

--- a/planemo/galaxy/serve.py
+++ b/planemo/galaxy/serve.py
@@ -10,7 +10,10 @@ from planemo import (
 )
 from .config import galaxy_config
 from .ephemeris_sleep import sleep
-from .run import run_galaxy_command
+from .run import (
+    log_galaxy_command,
+    run_galaxy_command,
+)
 
 
 @contextlib.contextmanager
@@ -29,7 +32,7 @@ def serve(ctx, runnables=None, **kwds):
 def _start_galaxy(ctx, config, command, daemon):
     action = "Starting Galaxy"
     if daemon and getattr(config, "use_multiprocessing", False):
-        ctx.vlog(f"{action} with command [{command}]")
+        log_galaxy_command(ctx, command, config.env, action)
         startup_process = config.start_daemon(command)
         return startup_process, startup_process.poll()
     exit_code = run_galaxy_command(ctx, command, config.env, action)

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -3,6 +3,7 @@
 import contextlib
 import errno
 import fnmatch
+import math
 import os
 import shutil
 import signal
@@ -52,10 +53,14 @@ def termination_timeout() -> float:
     if configured is None:
         return DEFAULT_TERMINATION_TIMEOUT
     try:
-        return float(configured)
+        timeout = float(configured)
     except ValueError:
-        warn(f"Ignoring non-numeric {TERMINATION_TIMEOUT_ENVIRON_KEY} [{configured}]")
+        warn(f"Ignoring invalid {TERMINATION_TIMEOUT_ENVIRON_KEY} [{configured}]")
         return DEFAULT_TERMINATION_TIMEOUT
+    if not math.isfinite(timeout) or timeout < 0:
+        warn(f"Ignoring invalid {TERMINATION_TIMEOUT_ENVIRON_KEY} [{configured}]")
+        return DEFAULT_TERMINATION_TIMEOUT
+    return timeout
 
 
 def args_to_str(args):

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -5,6 +5,7 @@ import errno
 import fnmatch
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -234,16 +235,48 @@ def kill_posix(pid: int):
             return False
 
     if _check_pid():
-        for sig in [15, 9]:
+        for process_signal in (signal.SIGTERM, signal.SIGKILL):
             try:
                 # gunicorn (unlike paste), seem to require killing process
                 # group
-                os.killpg(os.getpgid(pid), sig)
+                os.killpg(os.getpgid(pid), process_signal)
             except OSError:
                 return
             time.sleep(1)
             if not _check_pid():
                 return
+
+
+def kill_process_group(process: subprocess.Popen):
+    """Terminate a subprocess session and reap its group leader."""
+    # start_new_session=True makes the subprocess PID its process group ID.
+    # Keep using that known ID even if the leader has already exited, since
+    # one of its children may still be running in the group.
+    process_group = process.pid
+
+    for process_signal in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(process_group, process_signal)
+        except ProcessLookupError:
+            break
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
+        if process_signal == signal.SIGTERM:
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                try:
+                    os.killpg(process_group, 0)
+                except ProcessLookupError:
+                    break
+                time.sleep(0.05)
+            else:
+                continue
+            break
+
+    if process.poll() is None:
+        process.wait()
 
 
 @contextlib.contextmanager

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -32,13 +32,30 @@ IS_OS_X = _platform == "darwin"
 
 # How long a process group gets to honour SIGTERM before it is SIGKILLed, and how
 # often it is checked in the meantime.
-TERMINATION_TIMEOUT = 0.5
+DEFAULT_TERMINATION_TIMEOUT = 10.0
 TERMINATION_POLL_INTERVAL = 0.1
+TERMINATION_TIMEOUT_ENVIRON_KEY = "PLANEMO_TERMINATION_TIMEOUT"
+# SIGKILL cannot be caught, so anything still in the group afterwards is either
+# a zombie nobody has reaped or a process wedged in uninterruptible IO. Neither
+# is worth a second full grace period.
+KILL_SETTLE_TIMEOUT = 1.0
 
 
 def termination_timeout() -> float:
-    """Return the grace period a process group gets to exit on SIGTERM."""
-    return TERMINATION_TIMEOUT
+    """Return the grace period a process group gets to exit on SIGTERM.
+
+    Read from the environment on every call rather than captured at import, so
+    that the daemon monitor - which Planemo runs as a subprocess - honours the
+    same value without it being threaded through argv.
+    """
+    configured = os.environ.get(TERMINATION_TIMEOUT_ENVIRON_KEY)
+    if configured is None:
+        return DEFAULT_TERMINATION_TIMEOUT
+    try:
+        return float(configured)
+    except ValueError:
+        warn(f"Ignoring non-numeric {TERMINATION_TIMEOUT_ENVIRON_KEY} [{configured}]")
+        return DEFAULT_TERMINATION_TIMEOUT
 
 
 def args_to_str(args):
@@ -281,7 +298,7 @@ def terminate_process_group(
     """
     if timeout is None:
         timeout = termination_timeout()
-    for process_signal in (signal.SIGTERM, signal.SIGKILL):
+    for process_signal, grace in ((signal.SIGTERM, timeout), (signal.SIGKILL, KILL_SETTLE_TIMEOUT)):
         try:
             os.killpg(pgid, process_signal)
         except ProcessLookupError:
@@ -289,7 +306,7 @@ def terminate_process_group(
         except OSError:
             # Not ours to signal - there is nothing further we can do.
             return False
-        if _wait_for_process_group_exit(pgid, timeout, reap):
+        if _wait_for_process_group_exit(pgid, grace, reap):
             return True
     return not process_group_exists(pgid)
 

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -247,38 +247,6 @@ def kill_posix(pid: int):
                 return
 
 
-def kill_process_group(process: subprocess.Popen):
-    """Terminate a subprocess session and reap its group leader."""
-    # start_new_session=True makes the subprocess PID its process group ID.
-    # Keep using that known ID even if the leader has already exited, since
-    # one of its children may still be running in the group.
-    process_group = process.pid
-
-    for process_signal in (signal.SIGTERM, signal.SIGKILL):
-        try:
-            os.killpg(process_group, process_signal)
-        except ProcessLookupError:
-            break
-        try:
-            process.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            pass
-        if process_signal == signal.SIGTERM:
-            deadline = time.monotonic() + 1
-            while time.monotonic() < deadline:
-                try:
-                    os.killpg(process_group, 0)
-                except ProcessLookupError:
-                    break
-                time.sleep(0.05)
-            else:
-                continue
-            break
-
-    if process.poll() is None:
-        process.wait()
-
-
 @contextlib.contextmanager
 def conditionally_captured_io(capture, tee=False):
     """If capture is True, capture stdout and stderr for logging."""

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -12,6 +12,11 @@ import tempfile
 import time
 from io import StringIO
 from sys import platform as _platform
+from typing import (
+    Any,
+    Callable,
+    Optional,
+)
 from xml.sax.saxutils import escape
 
 import click
@@ -24,6 +29,16 @@ from .exit_codes import (
 )
 
 IS_OS_X = _platform == "darwin"
+
+# How long a process group gets to honour SIGTERM before it is SIGKILLed, and how
+# often it is checked in the meantime.
+TERMINATION_TIMEOUT = 0.5
+TERMINATION_POLL_INTERVAL = 0.1
+
+
+def termination_timeout() -> float:
+    """Return the grace period a process group gets to exit on SIGTERM."""
+    return TERMINATION_TIMEOUT
 
 
 def args_to_str(args):
@@ -224,27 +239,69 @@ def kill_pid_file(pid_file: str):
         pass
 
 
-def kill_posix(pid: int):
-    """Kill process group corresponding to specified pid."""
+def process_group_exists(pgid: int) -> bool:
+    """Return whether any process remains in the specified process group."""
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Something is still there, it just isn't ours to signal.
+        return True
+    return True
 
-    def _check_pid():
+
+def _wait_for_process_group_exit(pgid: int, timeout: float, reap: Optional[Callable[[], Any]]) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        if reap is not None:
+            reap()
+        if not process_group_exists(pgid):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(TERMINATION_POLL_INTERVAL)
+
+
+def terminate_process_group(
+    pgid: int, timeout: Optional[float] = None, reap: Optional[Callable[[], Any]] = None
+) -> bool:
+    """SIGTERM a process group, escalating to SIGKILL if it outlives ``timeout``.
+
+    ``pgid`` is a process group ID rather than a PID. A process started with
+    ``start_new_session=True`` leads a group of its own, so its PID doubles as a
+    group ID that stays valid even once the leader itself has been reaped.
+
+    Pass ``reap`` - typically ``Popen.poll`` - when the caller owns the group
+    leader. An unreaped leader lingers as a zombie that still answers signal 0,
+    so without it the group never looks empty, the grace period is always spent
+    in full, and SIGKILL is always sent to a group that already did as it was told.
+
+    Returns whether the group is gone.
+    """
+    if timeout is None:
+        timeout = termination_timeout()
+    for process_signal in (signal.SIGTERM, signal.SIGKILL):
         try:
-            os.kill(pid, 0)
+            os.killpg(pgid, process_signal)
+        except ProcessLookupError:
             return True
         except OSError:
+            # Not ours to signal - there is nothing further we can do.
             return False
+        if _wait_for_process_group_exit(pgid, timeout, reap):
+            return True
+    return not process_group_exists(pgid)
 
-    if _check_pid():
-        for process_signal in (signal.SIGTERM, signal.SIGKILL):
-            try:
-                # gunicorn (unlike paste), seem to require killing process
-                # group
-                os.killpg(os.getpgid(pid), process_signal)
-            except OSError:
-                return
-            time.sleep(1)
-            if not _check_pid():
-                return
+
+def kill_posix(pid: int):
+    """Kill process group corresponding to specified pid."""
+    try:
+        # gunicorn (unlike paste), seem to require killing process group
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return
+    terminate_process_group(pgid)
 
 
 @contextlib.contextmanager

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -1,0 +1,449 @@
+import contextlib
+import importlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+from packaging.version import InvalidVersion
+
+from planemo import network_util
+from planemo.galaxy.config import (
+    gravity_supports_multiprocessing,
+    LocalGalaxyConfig,
+    write_galaxy_config,
+)
+from .test_utils import create_test_context
+
+serve_module = importlib.import_module("planemo.galaxy.serve")
+
+
+def _make_galaxy_root(tmp_path, galaxy_version="25.0.1"):
+    galaxy_root = tmp_path / "galaxy"
+    dependencies = galaxy_root / "lib" / "galaxy" / "dependencies"
+    dependencies.mkdir(parents=True)
+    if galaxy_version is not None:
+        version_package = galaxy_root / "lib" / "galaxy" / "version"
+        version_package.mkdir()
+        version_parts = galaxy_version.split(".", 2)
+        version_major = ".".join(version_parts[:2])
+        version_minor = version_parts[2] if len(version_parts) == 3 else ""
+        (version_package / "__init__.py").write_text(
+            f'VERSION_MAJOR = "{version_major}"\n'
+            f'VERSION_MINOR = "{version_minor}"\n'
+            'VERSION = VERSION_MAJOR + (f".{VERSION_MINOR}" if VERSION_MINOR else "")\n'
+        )
+    return galaxy_root
+
+
+@pytest.mark.parametrize(
+    ("galaxy_version", "expected"),
+    [
+        ("24.2.4", False),
+        ("25.0.0", False),
+        ("25.0.1", True),
+        ("25.1.0", True),
+    ],
+)
+def test_gravity_multiprocessing_detection(tmp_path, galaxy_version, expected):
+    galaxy_root = _make_galaxy_root(tmp_path, galaxy_version)
+    assert gravity_supports_multiprocessing(str(galaxy_root)) is expected
+
+
+@pytest.mark.parametrize(
+    ("galaxy_version", "exception"),
+    [("not-a-version", InvalidVersion), (None, FileNotFoundError)],
+)
+def test_gravity_multiprocessing_detection_fails_for_invalid_galaxy_version(tmp_path, galaxy_version, exception):
+    galaxy_root = _make_galaxy_root(tmp_path, galaxy_version)
+    with pytest.raises(exception):
+        gravity_supports_multiprocessing(str(galaxy_root))
+
+
+@pytest.mark.parametrize("galaxy_version", ["25.0.0", "25.0.1"])
+def test_gravity_configuration_selects_process_manager(tmp_path, galaxy_version):
+    galaxy_root = _make_galaxy_root(tmp_path, galaxy_version)
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    env = {"SUPERVISORD_SOCKET": "old-socket"}
+
+    write_galaxy_config(
+        str(galaxy_root),
+        {},
+        env,
+        {},
+        {"port": 12345},
+        lambda name: str(config_directory / name),
+    )
+
+    with open(env["GALAXY_CONFIG_FILE"]) as config_file:
+        gravity = json.load(config_file)["gravity"]
+    if galaxy_version == "25.0.1":
+        assert gravity["process_manager"] == "multiprocessing"
+        assert "SUPERVISORD_SOCKET" not in env
+    else:
+        assert "process_manager" not in gravity
+        assert env["SUPERVISORD_SOCKET"] != "old-socket"
+
+
+def _make_local_config(galaxy_root, port):
+    config_directory = galaxy_root / "planemo-config"
+    config_directory.mkdir()
+    env = {
+        "GALAXY_LOG": str(galaxy_root / "main.log"),
+        "GALAXY_PID": str(galaxy_root / "main.pid"),
+        "GRAVITY_STATE_DIR": str(config_directory / "gravity"),
+        "TEST_RECORD": str(galaxy_root / "record.json"),
+    }
+    os.makedirs(env["GRAVITY_STATE_DIR"])
+    return LocalGalaxyConfig(
+        create_test_context(),
+        str(config_directory),
+        env,
+        None,
+        port,
+        "main",
+        "test-key",
+        [],
+        str(galaxy_root),
+        {},
+    )
+
+
+def _write_executable(path, contents):
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+MODERN_RUN_SH = r"""#!/usr/bin/env python3
+import json
+import os
+import signal
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+record_path = os.environ["TEST_RECORD"]
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"])
+with open(record_path, "w") as record:
+    json.dump({
+        "args": sys.argv[1:],
+        "child_pid": child.pid,
+        "env": {key: os.environ.get(key) for key in ["GALAXY_LOG", "GALAXY_PID", "SUPERVISORD_SOCKET"]},
+        "pid": os.getpid(),
+    }, record)
+print("modern daemon started", flush=True)
+
+def stop(signum, frame):
+    try:
+        child.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait()
+    raise SystemExit(0)
+
+signal.signal(signal.SIGTERM, stop)
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/api/version":
+            body = b'{"version_major": "25.0"}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+    def log_message(self, format, *args):
+        pass
+
+server = HTTPServer(("127.0.0.1", int(os.environ["TEST_PORT"])), Handler)
+server.serve_forever()
+"""
+
+
+LEGACY_RUN_SH = r"""#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+with open(os.environ["TEST_RECORD"], "w") as record:
+    json.dump({"args": sys.argv[1:], "env": {"SUPERVISORD_SOCKET": os.environ.get("SUPERVISORD_SOCKET")}}, record)
+process = subprocess.Popen(
+    [sys.executable, os.path.join(os.path.dirname(__file__), "server.py")],
+    env=os.environ.copy(),
+    start_new_session=True,
+)
+with open(os.environ["GALAXY_PID"], "w") as pid_file:
+    pid_file.write(str(process.pid))
+with open(os.path.join(os.environ["GRAVITY_STATE_DIR"], "legacy.pid"), "w") as pid_file:
+    pid_file.write(str(process.pid))
+"""
+
+
+SERVER_SCRIPT = r"""#!/usr/bin/env python3
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = b'{"version_major": "25.0"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, format, *args):
+        pass
+
+HTTPServer(("127.0.0.1", int(os.environ["TEST_PORT"])), Handler).serve_forever()
+"""
+
+
+GALAXYCTL = r"""#!/usr/bin/env python3
+import json
+import os
+import signal
+import sys
+
+with open(os.environ["TEST_GALAXYCTL_RECORD"], "w") as record:
+    json.dump({"args": sys.argv[1:]}, record)
+with open(os.path.join(os.environ["GRAVITY_STATE_DIR"], "legacy.pid")) as pid_file:
+    os.killpg(int(pid_file.read()), signal.SIGTERM)
+"""
+
+
+@contextlib.contextmanager
+def _configured_galaxy(config):
+    yield config
+
+
+def _pid_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_for_pid_exit(pid):
+    for _ in range(100):
+        if not _pid_exists(pid):
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"Process {pid} did not exit")
+
+
+def _wait_for_path(path):
+    for _ in range(100):
+        if path.exists():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"Path {path} was not created")
+
+
+def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_path, monkeypatch):
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
+    _write_executable(galaxy_root / "run.sh", MODERN_RUN_SH)
+    port = network_util.get_free_port()
+    config = _make_local_config(galaxy_root, port)
+    config.env["TEST_PORT"] = str(port)
+    external_pid = tmp_path / "external.pid"
+    monkeypatch.setattr(serve_module, "galaxy_config", lambda *args, **kwds: _configured_galaxy(config))
+    monkeypatch.setattr(importlib.import_module("planemo.galaxy.ephemeris_sleep"), "DEFAULT_SLEEP_WAIT", 0.05)
+
+    with serve_module.serve_daemon(
+        config._ctx,
+        daemon=True,
+        port=port,
+        pid_file=str(external_pid),
+        skip_venv=True,
+        galaxy_startup_timeout=200,
+    ):
+        with open(config.env["TEST_RECORD"]) as record_file:
+            record = json.load(record_file)
+        assert "--daemon" not in record["args"]
+        assert record["args"] == ["--server-name", "main"]
+        assert record["env"]["GALAXY_LOG"] == config.log_file
+        assert record["env"]["SUPERVISORD_SOCKET"] is None
+        assert "modern daemon started" in config.log_contents
+        assert os.path.islink(external_pid)
+        assert int(external_pid.read_text()) == config._daemon_process.pid
+        assert _pid_exists(record["pid"])
+        assert _pid_exists(record["child_pid"])
+
+    _wait_for_pid_exit(record["pid"])
+    _wait_for_pid_exit(record["child_pid"])
+    assert config._daemon_process.returncode is not None
+    assert not os.path.exists(config.pid_file)
+
+
+def test_legacy_daemon_uses_supervisor_lifecycle(tmp_path, monkeypatch):
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.0")
+    _write_executable(galaxy_root / "run.sh", LEGACY_RUN_SH)
+    _write_executable(galaxy_root / "server.py", SERVER_SCRIPT)
+    galaxyctl = galaxy_root / ".venv" / "bin" / "galaxyctl"
+    galaxyctl.parent.mkdir(parents=True)
+    _write_executable(galaxyctl, GALAXYCTL)
+    port = network_util.get_free_port()
+    config = _make_local_config(galaxy_root, port)
+    config.env.update(
+        {
+            "SUPERVISORD_SOCKET": str(tmp_path / "supervisor.sock"),
+            "TEST_GALAXYCTL_RECORD": str(galaxy_root / "galaxyctl.json"),
+            "TEST_PORT": str(port),
+        }
+    )
+    monkeypatch.setattr(serve_module, "galaxy_config", lambda *args, **kwds: _configured_galaxy(config))
+    monkeypatch.setattr(importlib.import_module("planemo.galaxy.ephemeris_sleep"), "DEFAULT_SLEEP_WAIT", 0.05)
+
+    with serve_module.serve_daemon(
+        config._ctx,
+        daemon=True,
+        port=port,
+        skip_venv=True,
+        galaxy_startup_timeout=200,
+    ):
+        with open(config.env["TEST_RECORD"]) as record_file:
+            record = json.load(record_file)
+        assert record["args"] == ["--daemon"]
+        assert record["env"]["SUPERVISORD_SOCKET"] == config.env["SUPERVISORD_SOCKET"]
+
+    with open(config.env["TEST_GALAXYCTL_RECORD"]) as record_file:
+        galaxyctl_record = json.load(record_file)
+    assert galaxyctl_record["args"] == ["--state-dir", config.gravity_state_dir, "shutdown"]
+
+
+def test_multiprocessing_startup_exit_reports_log_without_waiting_for_timeout(tmp_path, monkeypatch):
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
+    _write_executable(galaxy_root / "run.sh", "#!/bin/sh\necho controlled startup failure\nexit 7\n")
+    port = network_util.get_free_port()
+    config = _make_local_config(galaxy_root, port)
+    monkeypatch.setattr(serve_module, "galaxy_config", lambda *args, **kwds: _configured_galaxy(config))
+    monkeypatch.setattr(importlib.import_module("planemo.galaxy.ephemeris_sleep"), "DEFAULT_SLEEP_WAIT", 0.05)
+
+    started = time.monotonic()
+    with pytest.raises(Exception, match="controlled startup failure") as exc_info:
+        with serve_module.serve_daemon(
+            config._ctx,
+            daemon=True,
+            port=port,
+            skip_venv=True,
+            galaxy_startup_timeout=200,
+        ):
+            pass
+
+    assert "exited with code 7" in str(exc_info.value)
+    assert time.monotonic() - started < 5
+    assert config._daemon_process.returncode == 7
+    assert not os.path.exists(config.pid_file)
+
+
+def test_multiprocessing_daemon_survives_successful_planemo_exit(tmp_path, monkeypatch):
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
+    _write_executable(galaxy_root / "run.sh", MODERN_RUN_SH)
+    port = network_util.get_free_port()
+    config = _make_local_config(galaxy_root, port)
+    config.env["TEST_PORT"] = str(port)
+    monkeypatch.setattr(serve_module, "galaxy_config", lambda *args, **kwds: _configured_galaxy(config))
+    monkeypatch.setattr(importlib.import_module("planemo.galaxy.ephemeris_sleep"), "DEFAULT_SLEEP_WAIT", 0.05)
+
+    try:
+        with serve_module.serve(
+            config._ctx,
+            daemon=True,
+            port=port,
+            skip_venv=True,
+            galaxy_startup_timeout=200,
+        ):
+            pass
+
+        assert config._daemon_control_fd is None
+        assert config._daemon_process.poll() is None
+        assert network_util.wait_net_service("127.0.0.1", port, timeout=0.1)
+    finally:
+        config.kill()
+
+
+PARENT_PROCESS = r"""
+import json
+import os
+import shlex
+import sys
+import time
+from types import SimpleNamespace
+
+from planemo.galaxy.config import LocalGalaxyConfig
+
+galaxy_root, config_directory, port, ready_path = sys.argv[1:]
+env = {
+    "GALAXY_LOG": os.path.join(galaxy_root, "main.log"),
+    "GALAXY_PID": os.path.join(galaxy_root, "main.pid"),
+    "GRAVITY_STATE_DIR": os.path.join(config_directory, "gravity"),
+    "TEST_PORT": port,
+    "TEST_RECORD": os.path.join(galaxy_root, "record.json"),
+}
+os.makedirs(env["GRAVITY_STATE_DIR"])
+config = LocalGalaxyConfig(
+    SimpleNamespace(verbose=False),
+    config_directory,
+    env,
+    None,
+    int(port),
+    "main",
+    "test-key",
+    [],
+    galaxy_root,
+    {},
+)
+command = f"cd {shlex.quote(galaxy_root)} && ./run.sh --server-name main"
+process = config.start_daemon(command)
+with open(ready_path, "w") as ready_file:
+    ready_file.write(str(process.pid))
+while True:
+    time.sleep(60)
+"""
+
+
+def test_sigkill_of_planemo_cleans_multiprocessing_process_group(tmp_path):
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
+    _write_executable(galaxy_root / "run.sh", MODERN_RUN_SH)
+    config_directory = galaxy_root / "planemo-config"
+    config_directory.mkdir()
+    port = network_util.get_free_port()
+    ready_path = tmp_path / "parent-ready"
+    record_path = galaxy_root / "record.json"
+    repository_root = os.path.dirname(os.path.dirname(__file__))
+    environ = os.environ.copy()
+    environ["PYTHONPATH"] = repository_root
+    parent = subprocess.Popen(
+        [sys.executable, "-c", PARENT_PROCESS, str(galaxy_root), str(config_directory), str(port), str(ready_path)],
+        env=environ,
+    )
+    monitor_pid = None
+    try:
+        _wait_for_path(ready_path)
+        _wait_for_path(record_path)
+        monitor_pid = int(ready_path.read_text())
+        record = json.loads(record_path.read_text())
+        assert _pid_exists(monitor_pid)
+        assert _pid_exists(record["pid"])
+        assert _pid_exists(record["child_pid"])
+
+        os.kill(parent.pid, signal.SIGKILL)
+        parent.wait()
+
+        _wait_for_pid_exit(monitor_pid)
+        _wait_for_pid_exit(record["pid"])
+        _wait_for_pid_exit(record["child_pid"])
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait()
+        if monitor_pid is not None and _pid_exists(monitor_pid):
+            os.killpg(monitor_pid, signal.SIGKILL)

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -281,11 +281,20 @@ def _wait_for_json(path):
     raise AssertionError(f"Valid JSON was not written to {path}")
 
 
-def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_path, monkeypatch):
+def _wait_for_log(config, text):
+    for _ in range(100):
+        if text in config.log_contents:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"{text!r} was not written to {config.log_file}")
+
+
+def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_path, monkeypatch, capsys):
     galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
     _write_executable(galaxy_root / "run.sh", MODERN_RUN_SH)
     port = network_util.get_free_port()
     config = _make_local_config(galaxy_root, port)
+    config._ctx.verbose = True
     config.env["TEST_PORT"] = str(port)
     external_pid = tmp_path / "external.pid"
     monkeypatch.setattr(serve_module, "galaxy_config", lambda *args, **kwds: _configured_galaxy(config))
@@ -299,6 +308,8 @@ def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_pat
         skip_venv=True,
         galaxy_startup_timeout=200,
     ):
+        captured = capsys.readouterr()
+        config._ctx.verbose = False
         with open(config.env["TEST_RECORD"]) as record_file:
             record = json.load(record_file)
         assert "--daemon" not in record["args"]
@@ -306,8 +317,10 @@ def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_pat
         assert record["env"]["GALAXY_LOG"] == config.log_file
         assert record["env"]["SUPERVISORD_SOCKET"] is None
         assert "modern daemon started" in config.log_contents
-        assert "modern child output" in config.log_contents
+        _wait_for_log(config, "modern child output")
         assert config.service_log_contents == {}
+        assert "Starting Galaxy with command [" in captured.out
+        assert f'GALAXY_LOG="{config.log_file}"' in captured.err
         assert os.path.islink(external_pid)
         assert int(external_pid.read_text()) == config._daemon_process.pid
         assert _pid_exists(record["pid"])

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -12,12 +12,16 @@ from packaging.version import InvalidVersion
 
 from planemo import network_util
 from planemo.galaxy.config import (
+    _shut_down_daemon_monitor,
     gravity_supports_multiprocessing,
     LocalGalaxyConfig,
     write_galaxy_config,
 )
 from planemo.io import TERMINATION_TIMEOUT_ENVIRON_KEY
-from .test_utils import create_test_context
+from .test_utils import (
+    create_test_context,
+    sigterm_ignoring_group,
+)
 
 serve_module = importlib.import_module("planemo.galaxy.serve")
 
@@ -533,3 +537,39 @@ def test_monitor_escalates_for_sigterm_ignoring_process_group(tmp_path):
             parent.wait()
         if monitor_pid is not None and _pid_exists(monitor_pid):
             os.killpg(monitor_pid, signal.SIGKILL)
+
+
+def test_daemon_monitor_shutdown_escalates_without_raising(tmp_path, monkeypatch):
+    """A monitor that will not exit is killed, and teardown still returns cleanly."""
+    monkeypatch.setenv(TERMINATION_TIMEOUT_ENVIRON_KEY, "0.5")
+    with sigterm_ignoring_group(tmp_path / "ready") as process:
+        _shut_down_daemon_monitor(process)
+        assert process.returncode == -signal.SIGKILL
+
+
+def test_daemon_monitor_shutdown_waits_for_a_monitor_that_exits(tmp_path, monkeypatch):
+    """A monitor that stops on its own is never signalled."""
+    monkeypatch.setenv(TERMINATION_TIMEOUT_ENVIRON_KEY, "5")
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(0.2)"], start_new_session=True)
+    try:
+        _shut_down_daemon_monitor(process)
+        assert process.returncode == 0
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def test_daemon_monitor_shutdown_signals_a_detached_daemon_immediately(tmp_path, monkeypatch):
+    """A detached daemon was never asked to stop, so do not wait for it to."""
+    monkeypatch.setenv(TERMINATION_TIMEOUT_ENVIRON_KEY, "30")
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"], start_new_session=True)
+    try:
+        started = time.monotonic()
+        _shut_down_daemon_monitor(process, asked_to_stop=False)
+        assert time.monotonic() - started < 5
+        assert process.returncode == -signal.SIGTERM
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -16,6 +16,7 @@ from planemo.galaxy.config import (
     LocalGalaxyConfig,
     write_galaxy_config,
 )
+from planemo.io import TERMINATION_TIMEOUT_ENVIRON_KEY
 from .test_utils import create_test_context
 
 serve_module = importlib.import_module("planemo.galaxy.serve")
@@ -508,6 +509,8 @@ def test_monitor_escalates_for_sigterm_ignoring_process_group(tmp_path):
     repository_root = os.path.dirname(os.path.dirname(__file__))
     environ = os.environ.copy()
     environ["PYTHONPATH"] = repository_root
+    # Escalation is what is under test, not how long Galaxy is given first.
+    environ[TERMINATION_TIMEOUT_ENVIRON_KEY] = "0.5"
     parent = subprocess.Popen(
         [sys.executable, "-c", PARENT_PROCESS, str(galaxy_root), str(config_directory), str(port), str(ready_path)],
         env=environ,

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -18,7 +18,11 @@ from planemo.galaxy.config import (
     LocalGalaxyConfig,
     write_galaxy_config,
 )
-from planemo.io import TERMINATION_TIMEOUT_ENVIRON_KEY
+from planemo.io import (
+    KILL_SETTLE_TIMEOUT,
+    TERMINATION_POLL_INTERVAL,
+    TERMINATION_TIMEOUT_ENVIRON_KEY,
+)
 from .test_utils import (
     create_test_context,
     sigterm_ignoring_group,
@@ -559,6 +563,21 @@ def test_daemon_monitor_shutdown_waits_for_a_monitor_that_exits(tmp_path, monkey
         if process.poll() is None:
             process.kill()
             process.wait()
+
+
+def test_daemon_monitor_shutdown_allows_the_monitor_full_escalation_budget(monkeypatch):
+    """The parent waits for both monitor escalation stages and their polling overhead."""
+    monkeypatch.setenv(TERMINATION_TIMEOUT_ENVIRON_KEY, "0.5")
+
+    class ImmediateProcess:
+        timeout = None
+
+        def wait(self, timeout):
+            self.timeout = timeout
+
+    process = ImmediateProcess()
+    _shut_down_daemon_monitor(process)
+    assert process.timeout == 0.5 + KILL_SETTLE_TIMEOUT + 2 * TERMINATION_POLL_INTERVAL
 
 
 def test_daemon_monitor_shutdown_signals_a_detached_daemon_immediately(tmp_path, monkeypatch):

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -127,7 +127,9 @@ import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 record_path = os.environ["TEST_RECORD"]
-child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"])
+child = subprocess.Popen(
+    [sys.executable, "-c", 'import time; print("modern child output", flush=True); time.sleep(300)']
+)
 with open(record_path, "w") as record:
     json.dump({
         "args": sys.argv[1:],
@@ -304,6 +306,8 @@ def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_pat
         assert record["env"]["GALAXY_LOG"] == config.log_file
         assert record["env"]["SUPERVISORD_SOCKET"] is None
         assert "modern daemon started" in config.log_contents
+        assert "modern child output" in config.log_contents
+        assert config.service_log_contents == {}
         assert os.path.islink(external_pid)
         assert int(external_pid.read_text()) == config._daemon_process.pid
         assert _pid_exists(record["pid"])

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -166,6 +166,29 @@ server.serve_forever()
 """
 
 
+STUBBORN_RUN_SH = r"""#!/usr/bin/env python3
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+child = subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)",
+    ]
+)
+with open(os.environ["TEST_RECORD"], "w") as record:
+    json.dump({"child_pid": child.pid, "pid": os.getpid()}, record)
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+while True:
+    time.sleep(60)
+"""
+
+
 LEGACY_RUN_SH = r"""#!/usr/bin/env python3
 import json
 import os
@@ -245,6 +268,15 @@ def _wait_for_path(path):
             return
         time.sleep(0.05)
     raise AssertionError(f"Path {path} was not created")
+
+
+def _wait_for_json(path):
+    for _ in range(100):
+        try:
+            return json.loads(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            time.sleep(0.05)
+    raise AssertionError(f"Valid JSON was not written to {path}")
 
 
 def test_multiprocessing_daemon_uses_foreground_process_and_cleans_group(tmp_path, monkeypatch):
@@ -428,12 +460,46 @@ def test_sigkill_of_planemo_cleans_multiprocessing_process_group(tmp_path):
     monitor_pid = None
     try:
         _wait_for_path(ready_path)
-        _wait_for_path(record_path)
         monitor_pid = int(ready_path.read_text())
-        record = json.loads(record_path.read_text())
+        record = _wait_for_json(record_path)
         assert _pid_exists(monitor_pid)
         assert _pid_exists(record["pid"])
         assert _pid_exists(record["child_pid"])
+
+        os.kill(parent.pid, signal.SIGKILL)
+        parent.wait()
+
+        _wait_for_pid_exit(monitor_pid)
+        _wait_for_pid_exit(record["pid"])
+        _wait_for_pid_exit(record["child_pid"])
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait()
+        if monitor_pid is not None and _pid_exists(monitor_pid):
+            os.killpg(monitor_pid, signal.SIGKILL)
+
+
+def test_monitor_escalates_for_sigterm_ignoring_process_group(tmp_path):
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
+    _write_executable(galaxy_root / "run.sh", STUBBORN_RUN_SH)
+    config_directory = galaxy_root / "planemo-config"
+    config_directory.mkdir()
+    port = network_util.get_free_port()
+    ready_path = tmp_path / "parent-ready"
+    record_path = galaxy_root / "record.json"
+    repository_root = os.path.dirname(os.path.dirname(__file__))
+    environ = os.environ.copy()
+    environ["PYTHONPATH"] = repository_root
+    parent = subprocess.Popen(
+        [sys.executable, "-c", PARENT_PROCESS, str(galaxy_root), str(config_directory), str(port), str(ready_path)],
+        env=environ,
+    )
+    monitor_pid = None
+    try:
+        _wait_for_path(ready_path)
+        monitor_pid = int(ready_path.read_text())
+        record = _wait_for_json(record_path)
 
         os.kill(parent.pid, signal.SIGKILL)
         parent.wait()

--- a/tests/test_gravity_multiprocessing.py
+++ b/tests/test_gravity_multiprocessing.py
@@ -13,6 +13,7 @@ from packaging.version import InvalidVersion
 from planemo import network_util
 from planemo.galaxy.config import (
     _shut_down_daemon_monitor,
+    get_galaxy_version,
     gravity_supports_multiprocessing,
     LocalGalaxyConfig,
     write_galaxy_config,
@@ -573,3 +574,42 @@ def test_daemon_monitor_shutdown_signals_a_detached_daemon_immediately(tmp_path,
         if process.poll() is None:
             process.kill()
             process.wait()
+
+
+def test_galaxy_version_is_read_once_per_configuration(tmp_path):
+    """Building a configuration asks the version repeatedly; Galaxy's module runs once."""
+    galaxy_root = _make_galaxy_root(tmp_path, "25.0.1")
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    get_galaxy_version.cache_clear()
+    try:
+        write_galaxy_config(
+            str(galaxy_root),
+            {},
+            {},
+            {},
+            {"port": 12345},
+            lambda name: str(config_directory / name),
+        )
+        cache_info = get_galaxy_version.cache_info()
+        assert cache_info.misses == 1
+        assert cache_info.hits >= 1
+    finally:
+        get_galaxy_version.cache_clear()
+
+
+def test_galaxy_version_cache_is_keyed_on_the_root(tmp_path):
+    """Two checkouts do not share an answer, and reinstalling invalidates one."""
+    first = _make_galaxy_root(tmp_path / "first", "24.2.4")
+    second = _make_galaxy_root(tmp_path / "second", "25.0.1")
+    get_galaxy_version.cache_clear()
+    try:
+        assert not gravity_supports_multiprocessing(str(first))
+        assert gravity_supports_multiprocessing(str(second))
+        version_file = first / "lib" / "galaxy" / "version" / "__init__.py"
+        version_file.write_text('VERSION_MAJOR = "25.0"\nVERSION_MINOR = "1"\nVERSION = "25.0.1"\n')
+        assert not gravity_supports_multiprocessing(str(first))
+        get_galaxy_version.cache_clear()
+        assert gravity_supports_multiprocessing(str(first))
+    finally:
+        get_galaxy_version.cache_clear()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 import tempfile
 
+import pytest
+
 from planemo import io
 from .test_utils import (
     assert_equal,
@@ -87,11 +89,17 @@ def test_kill_posix_tolerates_missing_process():
     io.kill_posix(process.pid)
 
 
-def test_termination_timeout_honours_the_environment(monkeypatch):
+@pytest.mark.parametrize("configured", ["soon", "nan", "inf", "-1"])
+def test_termination_timeout_rejects_invalid_environment_values(monkeypatch, configured):
     """The grace period is tunable, and a bad value falls back rather than raising."""
+    monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, configured)
+    assert io.termination_timeout() == io.DEFAULT_TERMINATION_TIMEOUT
+
+
+def test_termination_timeout_honours_the_environment(monkeypatch):
     monkeypatch.delenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, raising=False)
     assert io.termination_timeout() == io.DEFAULT_TERMINATION_TIMEOUT
     monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "0.25")
     assert io.termination_timeout() == 0.25
-    monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "soon")
-    assert io.termination_timeout() == io.DEFAULT_TERMINATION_TIMEOUT
+    monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "0")
+    assert io.termination_timeout() == 0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,11 @@
 """Test utilities from :module:`planemo.io`."""
 
+import contextlib
+import signal
+import subprocess
+import sys
 import tempfile
+import time
 
 from planemo import io
 from .test_utils import assert_equal
@@ -44,3 +49,79 @@ def test_filter_paths():
         tmp.write("#exclude c\n\nc\n")
         tmp.flush()
         assert_filtered_is(["/a/b/c", "/a/b/d"], ["/a/b/d"], exclude_from=[tmp.name])
+
+
+SIGTERM_IGNORING_PROCESS = """
+import signal
+import sys
+import time
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with open(sys.argv[1], "w") as ready_file:
+    ready_file.write("ready")
+time.sleep(300)
+"""
+
+
+def _spawn_sigterm_ignoring_group(ready_path):
+    """Start a leader that ignores SIGTERM, in a process group of its own.
+
+    Waits for the handler to actually be installed - signalling before that
+    point would kill the process outright and prove nothing.
+    """
+    process = subprocess.Popen(
+        [sys.executable, "-c", SIGTERM_IGNORING_PROCESS, str(ready_path)],
+        start_new_session=True,
+    )
+    for _ in range(200):
+        if ready_path.exists():
+            return process
+        time.sleep(0.05)
+    process.kill()
+    process.wait()
+    raise AssertionError("Process never began ignoring SIGTERM")
+
+
+@contextlib.contextmanager
+def _sigterm_ignoring_group(ready_path):
+    process = _spawn_sigterm_ignoring_group(ready_path)
+    try:
+        yield process
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def test_terminate_process_group_escalates_to_sigkill(tmp_path):
+    """A group that ignores SIGTERM is still killed."""
+    with _sigterm_ignoring_group(tmp_path / "ready") as process:
+        assert io.terminate_process_group(process.pid, timeout=0.2, reap=process.poll)
+        assert not io.process_group_exists(process.pid)
+        assert process.returncode == -signal.SIGKILL
+
+
+def test_terminate_process_group_does_not_escalate_for_a_willing_process(tmp_path):
+    """A group that honours SIGTERM is never SIGKILLed."""
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"], start_new_session=True)
+    try:
+        assert io.terminate_process_group(process.pid, timeout=5, reap=process.poll)
+        assert process.returncode == -signal.SIGTERM
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def test_kill_posix_escalates_to_sigkill(tmp_path):
+    """:func:`planemo.io.kill_posix` escalates rather than giving up on SIGTERM."""
+    with _sigterm_ignoring_group(tmp_path / "ready") as process:
+        io.kill_posix(process.pid)
+        assert process.wait(timeout=5) == -signal.SIGKILL
+
+
+def test_kill_posix_tolerates_missing_process():
+    """Killing an already-reaped pid is a no-op rather than an error."""
+    process = subprocess.Popen([sys.executable, "-c", ""], start_new_session=True)
+    process.wait()
+    io.kill_posix(process.pid)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,14 +1,15 @@
 """Test utilities from :module:`planemo.io`."""
 
-import contextlib
 import signal
 import subprocess
 import sys
 import tempfile
-import time
 
 from planemo import io
-from .test_utils import assert_equal
+from .test_utils import (
+    assert_equal,
+    sigterm_ignoring_group,
+)
 
 
 def test_io_capture():
@@ -51,51 +52,9 @@ def test_filter_paths():
         assert_filtered_is(["/a/b/c", "/a/b/d"], ["/a/b/d"], exclude_from=[tmp.name])
 
 
-SIGTERM_IGNORING_PROCESS = """
-import signal
-import sys
-import time
-
-signal.signal(signal.SIGTERM, signal.SIG_IGN)
-with open(sys.argv[1], "w") as ready_file:
-    ready_file.write("ready")
-time.sleep(300)
-"""
-
-
-def _spawn_sigterm_ignoring_group(ready_path):
-    """Start a leader that ignores SIGTERM, in a process group of its own.
-
-    Waits for the handler to actually be installed - signalling before that
-    point would kill the process outright and prove nothing.
-    """
-    process = subprocess.Popen(
-        [sys.executable, "-c", SIGTERM_IGNORING_PROCESS, str(ready_path)],
-        start_new_session=True,
-    )
-    for _ in range(200):
-        if ready_path.exists():
-            return process
-        time.sleep(0.05)
-    process.kill()
-    process.wait()
-    raise AssertionError("Process never began ignoring SIGTERM")
-
-
-@contextlib.contextmanager
-def _sigterm_ignoring_group(ready_path):
-    process = _spawn_sigterm_ignoring_group(ready_path)
-    try:
-        yield process
-    finally:
-        if process.poll() is None:
-            process.kill()
-            process.wait()
-
-
 def test_terminate_process_group_escalates_to_sigkill(tmp_path):
     """A group that ignores SIGTERM is still killed."""
-    with _sigterm_ignoring_group(tmp_path / "ready") as process:
+    with sigterm_ignoring_group(tmp_path / "ready") as process:
         assert io.terminate_process_group(process.pid, timeout=0.2, reap=process.poll)
         assert not io.process_group_exists(process.pid)
         assert process.returncode == -signal.SIGKILL
@@ -116,7 +75,7 @@ def test_terminate_process_group_does_not_escalate_for_a_willing_process(tmp_pat
 def test_kill_posix_escalates_to_sigkill(tmp_path, monkeypatch):
     """:func:`planemo.io.kill_posix` escalates rather than giving up on SIGTERM."""
     monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "0.5")
-    with _sigterm_ignoring_group(tmp_path / "ready") as process:
+    with sigterm_ignoring_group(tmp_path / "ready") as process:
         io.kill_posix(process.pid)
         assert process.wait(timeout=5) == -signal.SIGKILL
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -113,8 +113,9 @@ def test_terminate_process_group_does_not_escalate_for_a_willing_process(tmp_pat
             process.wait()
 
 
-def test_kill_posix_escalates_to_sigkill(tmp_path):
+def test_kill_posix_escalates_to_sigkill(tmp_path, monkeypatch):
     """:func:`planemo.io.kill_posix` escalates rather than giving up on SIGTERM."""
+    monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "0.5")
     with _sigterm_ignoring_group(tmp_path / "ready") as process:
         io.kill_posix(process.pid)
         assert process.wait(timeout=5) == -signal.SIGKILL
@@ -125,3 +126,13 @@ def test_kill_posix_tolerates_missing_process():
     process = subprocess.Popen([sys.executable, "-c", ""], start_new_session=True)
     process.wait()
     io.kill_posix(process.pid)
+
+
+def test_termination_timeout_honours_the_environment(monkeypatch):
+    """The grace period is tunable, and a bad value falls back rather than raising."""
+    monkeypatch.delenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, raising=False)
+    assert io.termination_timeout() == io.DEFAULT_TERMINATION_TIMEOUT
+    monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "0.25")
+    assert io.termination_timeout() == 0.25
+    monkeypatch.setenv(io.TERMINATION_TIMEOUT_ENVIRON_KEY, "soon")
+    assert io.termination_timeout() == io.DEFAULT_TERMINATION_TIMEOUT

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,8 @@ import functools
 import os
 import shutil
 import signal
+import subprocess
+import sys
 import time
 import traceback
 from concurrent.futures import (
@@ -63,6 +65,49 @@ CWLTOOL_CACHE_ENV_PROP = "PLANEMO_CWLTOOL_CACHE_DIRECTORY"
 def test_sleep_fails_immediately_for_invalid_url():
     with pytest.raises(requests_lib.exceptions.InvalidURL):
         sleep("http://::1:9090")
+
+
+SIGTERM_IGNORING_PROCESS = """
+import signal
+import sys
+import time
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with open(sys.argv[1], "w") as ready_file:
+    ready_file.write("ready")
+time.sleep(300)
+"""
+
+
+def _spawn_sigterm_ignoring_group(ready_path):
+    """Start a leader that ignores SIGTERM, in a process group of its own.
+
+    Waits for the handler to actually be installed - signalling before that
+    point would kill the process outright and prove nothing.
+    """
+    process = subprocess.Popen(
+        [sys.executable, "-c", SIGTERM_IGNORING_PROCESS, str(ready_path)],
+        start_new_session=True,
+    )
+    for _ in range(200):
+        if ready_path.exists():
+            return process
+        time.sleep(0.05)
+    process.kill()
+    process.wait()
+    raise AssertionError("Process never began ignoring SIGTERM")
+
+
+@contextlib.contextmanager
+def sigterm_ignoring_group(ready_path):
+    """Yield a running process group that refuses to die on SIGTERM."""
+    process = _spawn_sigterm_ignoring_group(ready_path)
+    try:
+        yield process
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
 
 
 class MarkGenerator:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,6 +60,11 @@ NON_ZERO_EXIT_CODE = object()
 CWLTOOL_CACHE_ENV_PROP = "PLANEMO_CWLTOOL_CACHE_DIRECTORY"
 
 
+def test_sleep_fails_immediately_for_invalid_url():
+    with pytest.raises(requests_lib.exceptions.InvalidURL):
+        sleep("http://::1:9090")
+
+
 class MarkGenerator:
     def __getattr__(self, name):
         return getattr(pytest.mark, name)


### PR DESCRIPTION
## Summary

- Automatically select Gravity multiprocessing for Galaxy 25.0.1 and newer using Galaxy version detection, while retaining the Supervisor lifecycle for older Galaxy checkouts.
- Launch daemonized multiprocessing instances through foreground run.sh in a dedicated process group, preserving Planemo PID-file and log behavior.
- Stop readiness polling when startup exits, terminate and reap the entire process group on shutdown, and clean up Galaxy if Planemo dies unexpectedly, including from SIGKILL. A successfully launched daemon still detaches normally.

## Advantages

- Avoids Supervisor Unix-socket path-length limitations.
- Does not need to locate the correct galaxyctl in Galaxy virtual environments to stop an instance.
- Makes cleanup of Gravity, Gunicorn, Celery, and their child processes more reliable because Planemo owns the foreground process group directly.

## Compatibility

Galaxy 25.0.1 is the first Galaxy release with Gravity 1.1.0, which supports the multiprocessing manager. Galaxy 25.0.0 and older continue to use run.sh --daemon and galaxyctl shutdown. Galaxy version detection failures are surfaced instead of silently selecting a potentially incorrect manager.

## Verification

- make lint
- tox -e mypy
- Real-process tests covering version selection, configuration, PID/log handling, early startup failure, SIGKILL parent-death cleanup, successful detach, full parent/child cleanup, and legacy galaxyctl shutdown
- Fork CI: all Python 3.10/3.13 lint, mypy, quick, Galaxy 23.1, Galaxy 25.0, Galaxy dev, diagnostic serve, and full unit jobs green
