### PR TITLE
command used to list available workflows (rebase + fixes)

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -37,6 +37,7 @@ documentation describes these commands.
 .. include:: commands/list_alias.rst
 .. include:: commands/list_invocations.rst
 .. include:: commands/list_repos.rst
+.. include:: commands/list_workflows.rst
 .. include:: commands/merge_test_reports.rst
 .. include:: commands/mull.rst
 .. include:: commands/mulled_init.rst

--- a/docs/commands/list_workflows.rst
+++ b/docs/commands/list_workflows.rst
@@ -1,0 +1,28 @@
+
+``list_workflows`` command
+========================================
+
+This section is auto-generated from the help text for the planemo command
+``list_workflows``. This help message can be generated with ``planemo list_workflows
+--help``.
+
+**Usage**::
+
+    planemo list_workflows [OPTIONS]
+
+**Help**
+
+
+Display available workflows.
+
+**Options**::
+
+
+      --raw                    output will be a json structure.
+      --galaxy_url TEXT        Remote Galaxy URL to use with external Galaxy engine.
+      --galaxy_admin_key TEXT  Admin key to use with external Galaxy engine.
+      --galaxy_user_key TEXT   User key to use with external Galaxy engine.
+      --profile TEXT           Name of profile (created with the profile_create
+                               command) to use with this command.
+      --help                   Show this message and exit.
+    

--- a/docs/planemo.commands.rst
+++ b/docs/planemo.commands.rst
@@ -252,6 +252,14 @@ planemo.commands.cmd\_list\_repos module
    :show-inheritance:
    :undoc-members:
 
+planemo.commands.cmd\_list\_workflows module
+---------------------------------------------
+
+.. automodule:: planemo.commands.cmd_list_workflows
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 planemo.commands.cmd\_merge\_test\_reports module
 -------------------------------------------------
 

--- a/planemo/commands/cmd_delete_alias.py
+++ b/planemo/commands/cmd_delete_alias.py
@@ -10,11 +10,6 @@ from planemo.io import (
     info,
 )
 
-try:
-    from tabulate import tabulate
-except ImportError:
-    tabulate = None  # type: ignore
-
 
 @click.command("delete_alias")
 @options.alias_option(required=True)

--- a/planemo/commands/cmd_list_alias.py
+++ b/planemo/commands/cmd_list_alias.py
@@ -1,18 +1,14 @@
 """Module describing the planemo ``list_alias`` command."""
 
-import json
-
 import click
 
 from planemo import options
 from planemo.cli import command_function
 from planemo.galaxy import profiles
-from planemo.io import info
-
-try:
-    from tabulate import tabulate
-except ImportError:
-    tabulate = None  # type: ignore
+from planemo.io import (
+    info,
+    print_table,
+)
 
 
 @click.command("list_alias")
@@ -24,10 +20,7 @@ def cli(ctx, profile, **kwds):
     """
     info("Looking for profiles...")
     aliases = profiles.list_alias(ctx, profile)
-    if tabulate is not None:
-        print(tabulate({"Alias": aliases.keys(), "Object": aliases.values()}, headers="keys"))
-    else:
-        print(json.dumps(aliases, indent=4, sort_keys=True))
+    print_table({"Alias": list(aliases.keys()), "Object": list(aliases.values())})
 
     info(f"{len(aliases)} aliases were found for profile {profile}.")
 

--- a/planemo/commands/cmd_list_invocations.py
+++ b/planemo/commands/cmd_list_invocations.py
@@ -1,7 +1,5 @@
 """Module describing the planemo ``list_invocations`` command."""
 
-import json
-
 import click
 
 from planemo import options
@@ -10,15 +8,10 @@ from planemo.galaxy import profiles
 from planemo.galaxy.api import get_invocations
 from planemo.galaxy.workflows import remote_runnable_to_workflow_id
 from planemo.io import (
-    error,
     info,
+    print_table,
 )
 from planemo.runnable_resolve import for_runnable_identifier
-
-try:
-    from tabulate import tabulate
-except ImportError:
-    tabulate = None  # type: ignore
 
 
 @click.command("list_invocations")
@@ -43,41 +36,29 @@ def cli(ctx, workflow_identifier, **kwds):
         key=profile["galaxy_admin_key"] or profile["galaxy_user_key"],
         workflow_id=workflow_id,
     )
-    if tabulate is not None:
-        state_colors = {
-            "ok": "\033[92m",  # green
-            "running": "\033[93m",  # yellow
-            "error": "\033[91m",  # red
-            "paused": "\033[96m",  # cyan
-            "deleted": "\033[95m",  # magenta
-            "deleted_new": "\033[95m",  # magenta
-            "new": "\033[96m",  # cyan
-            "queued": "\033[93m",  # yellow
+    state_colors = {
+        "ok": "\033[92m",  # green
+        "running": "\033[93m",  # yellow
+        "error": "\033[91m",  # red
+        "paused": "\033[96m",  # cyan
+        "deleted": "\033[95m",  # magenta
+        "deleted_new": "\033[95m",  # magenta
+        "new": "\033[96m",  # cyan
+        "queued": "\033[93m",  # yellow
+    }
+    galaxy_url = profile["galaxy_url"].rstrip("/")
+    print_table(
+        {
+            "Invocation ID": list(invocations.keys()),
+            "Jobs status": [
+                ", ".join([f"{state_colors[k]}{v} jobs {k}\033[0m" for k, v in inv["states"].items()])
+                for inv in invocations.values()
+            ],
+            "Invocation report URL": [
+                f"{galaxy_url}/workflows/invocations/report?id={inv_id}" for inv_id in invocations
+            ],
+            "History URL": [f"{galaxy_url}/histories/view?id={inv['history_id']}" for inv in invocations.values()],
         }
-        print(
-            tabulate(
-                {
-                    "Invocation ID": invocations.keys(),
-                    "Jobs status": [
-                        ", ".join([f"{state_colors[k]}{v} jobs {k}\033[0m" for k, v in inv["states"].items()])
-                        for inv in invocations.values()
-                    ],
-                    "Invocation report URL": [
-                        "{}/workflows/invocations/report?id={}".format(profile["galaxy_url"].strip("/"), inv_id)
-                        for inv_id in invocations
-                    ],
-                    "History URL": [
-                        "{}/histories/view?id={}".format(
-                            profile["galaxy_url"].strip("/"), invocations[inv_id]["history_id"]
-                        )
-                        for inv_id in invocations
-                    ],
-                },
-                headers="keys",
-            )
-        )
-    else:
-        error("The tabulate package is not installed, invocations could not be listed correctly.")
-        print(json.dumps(invocations, indent=4, sort_keys=True))
+    )
     info(f"{len(invocations)} invocations found.")
     return

--- a/planemo/commands/cmd_list_workflows.py
+++ b/planemo/commands/cmd_list_workflows.py
@@ -1,0 +1,79 @@
+"""Module describing the planemo ``list_workflows`` command."""
+
+import json
+
+import click
+
+from planemo import options
+from planemo.cli import command_function
+from planemo.galaxy import profiles
+from planemo.galaxy.api import get_workflows
+from planemo.io import (
+    error,
+    info,
+)
+
+try:
+    from tabulate import tabulate
+except ImportError:
+    tabulate = None  # type: ignore
+
+
+def format_url(url):
+    if url == "N/A":
+        return ""
+    return url
+
+
+@click.command("list_workflows")
+@click.option(
+    "--raw",
+    is_flag=True,
+    help="output will be a json structure.",
+    default=False,
+)
+@options.galaxy_url_option()
+@options.galaxy_user_key_option()
+@options.profile_option()
+@command_function
+def cli(ctx, raw, **kwds):
+    """
+    Display available workflows.
+    """
+    if not raw:
+        info("Looking for workflows...")
+    profile = kwds.get("profile")
+    if profile is not None:
+        profile = profiles.ensure_profile(ctx, profile)
+        url = profile["galaxy_url"]
+        key = profile["galaxy_admin_key"] or profile["galaxy_user_key"]
+    else:
+        url = kwds.get("galaxy_url")
+        key = kwds.get("galaxy_admin_key") or kwds.get("galaxy_user_key")
+
+    workflows = get_workflows(
+        url=url,
+        key=key,
+    )
+    if tabulate is not None:
+        if raw:
+            print(json.dumps(workflows, indent=4, sort_keys=True))
+            return
+        else:
+            print(
+                tabulate(
+                    {
+                        "Workflow ID": workflows.keys(),
+                        "Name": [workflow["name"] for _, workflow in workflows.items()],
+                        "Url": [format_url(f"{url}/{workflow['url'].strip('/')}") for _, workflow in workflows.items()],
+                        "Repo Url": [format_url(workflow["repo_url"]) for _, workflow in workflows.items()],
+                    },
+                    headers="keys",
+                )
+            )
+    else:
+        error("The tabulate package is not installed, invocations could not be listed correctly.")
+        print(json.dumps(workflows, indent=4, sort_keys=True))
+    if not raw:
+        info(f"{len(workflows)} workflows found.")
+    return

--- a/planemo/commands/cmd_list_workflows.py
+++ b/planemo/commands/cmd_list_workflows.py
@@ -9,20 +9,22 @@ from planemo.cli import command_function
 from planemo.galaxy import profiles
 from planemo.galaxy.api import get_workflows
 from planemo.io import (
-    error,
     info,
+    print_table,
 )
 
-try:
-    from tabulate import tabulate
-except ImportError:
-    tabulate = None  # type: ignore
 
+def workflow_display_url(galaxy_url, workflow_id, published):
+    """Build a browsable URL for a workflow.
 
-def format_url(url):
-    if url == "N/A":
-        return ""
-    return url
+    The API URL returned by Galaxy renders JSON rather than something a user can
+    usefully open, so point at the editor - or the published view when the
+    workflow has been shared.
+    """
+    base = galaxy_url.rstrip("/")
+    if published:
+        return f"{base}/published/workflow?id={workflow_id}"
+    return f"{base}/workflows/edit?id={workflow_id}"
 
 
 @click.command("list_workflows")
@@ -33,6 +35,7 @@ def format_url(url):
     default=False,
 )
 @options.galaxy_url_option()
+@options.galaxy_admin_key_option()
 @options.galaxy_user_key_option()
 @options.profile_option()
 @command_function
@@ -40,8 +43,6 @@ def cli(ctx, raw, **kwds):
     """
     Display available workflows.
     """
-    if not raw:
-        info("Looking for workflows...")
     profile = kwds.get("profile")
     if profile is not None:
         profile = profiles.ensure_profile(ctx, profile)
@@ -50,30 +51,30 @@ def cli(ctx, raw, **kwds):
     else:
         url = kwds.get("galaxy_url")
         key = kwds.get("galaxy_admin_key") or kwds.get("galaxy_user_key")
+    if not url:
+        raise click.UsageError(
+            "Please specify --galaxy_url or --profile to indicate which Galaxy to list workflows from."
+        )
 
+    if not raw:
+        info("Looking for workflows...")
     workflows = get_workflows(
         url=url,
         key=key,
     )
-    if tabulate is not None:
-        if raw:
-            print(json.dumps(workflows, indent=4, sort_keys=True))
-            return
-        else:
-            print(
-                tabulate(
-                    {
-                        "Workflow ID": workflows.keys(),
-                        "Name": [workflow["name"] for _, workflow in workflows.items()],
-                        "Url": [format_url(f"{url}/{workflow['url'].strip('/')}") for _, workflow in workflows.items()],
-                        "Repo Url": [format_url(workflow["repo_url"]) for _, workflow in workflows.items()],
-                    },
-                    headers="keys",
-                )
-            )
-    else:
-        error("The tabulate package is not installed, invocations could not be listed correctly.")
+    if raw:
         print(json.dumps(workflows, indent=4, sort_keys=True))
-    if not raw:
-        info(f"{len(workflows)} workflows found.")
-    return
+        return
+    print_table(
+        {
+            "Workflow ID": list(workflows.keys()),
+            "Name": [workflow["name"] for workflow in workflows.values()],
+            "Published": ["yes" if workflow["published"] else "no" for workflow in workflows.values()],
+            "Url": [
+                workflow_display_url(url, workflow_id, workflow["published"])
+                for workflow_id, workflow in workflows.items()
+            ],
+            "Repo Url": [workflow["repo_url"] or "" for workflow in workflows.values()],
+        }
+    )
+    info(f"{len(workflows)} workflows found.")

--- a/planemo/galaxy/api.py
+++ b/planemo/galaxy/api.py
@@ -140,6 +140,26 @@ def export_invocation_as_archive(url=None, key=None, user_gi=None, invocation_id
     return response
 
 
+def get_workflows(url, key):
+    inv_gi = gi(None, url, key)
+    workflows = inv_gi.workflows.get_workflows()
+
+    def get_report_url(workflow):
+        if "source_metadata" in workflow and workflow["source_metadata"] and "url" in workflow["source_metadata"]:
+            return workflow["source_metadata"]["url"]
+        return "N/A"
+
+    return {
+        workflow["id"]: {
+            "name": workflow["name"],
+            "repo_url": get_report_url(workflow),
+            "url": workflow["url"],
+            "published": workflow.get("published", False),
+        }
+        for workflow in workflows
+    }
+
+
 def _format_for_summary(blob, empty_message, prefix="|  "):
     contents = "\n".join([f"{prefix}{line.strip()}" for line in StringIO(blob).readlines() if line.rstrip("\n\r")])
     return contents or f"{prefix}*{empty_message}*"

--- a/planemo/galaxy/api.py
+++ b/planemo/galaxy/api.py
@@ -141,18 +141,17 @@ def export_invocation_as_archive(url=None, key=None, user_gi=None, invocation_id
 
 
 def get_workflows(url, key):
-    inv_gi = gi(None, url, key)
-    workflows = inv_gi.workflows.get_workflows()
+    wf_gi = gi(None, url, key)
+    workflows = wf_gi.workflows.get_workflows()
 
-    def get_report_url(workflow):
-        if "source_metadata" in workflow and workflow["source_metadata"] and "url" in workflow["source_metadata"]:
-            return workflow["source_metadata"]["url"]
-        return "N/A"
+    def get_repo_url(workflow):
+        source_metadata = workflow.get("source_metadata") or {}
+        return source_metadata.get("url")
 
     return {
         workflow["id"]: {
             "name": workflow["name"],
-            "repo_url": get_report_url(workflow),
+            "repo_url": get_repo_url(workflow),
             "url": workflow["url"],
             "published": workflow.get("published", False),
         }

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -16,6 +16,7 @@ from xml.sax.saxutils import escape
 import click
 from galaxy.util import commands
 from galaxy.util.commands import download_command
+from tabulate import tabulate
 
 from .exit_codes import (
     EXIT_CODE_NO_SUCH_TARGET,
@@ -72,6 +73,15 @@ def error(message, *args):
     if args:
         message = message % args
     click.echo(click.style(message, bold=True, fg="red"), err=True)
+
+
+def print_table(columns):
+    """Print a mapping of column header to column values as a text table.
+
+    Centralized so the table rendering used by the various ``list_*`` commands
+    can be restyled in one place.
+    """
+    print(tabulate(columns, headers="keys"))
 
 
 def warn(message, *args):

--- a/tests/test_cmd_list_workflows.py
+++ b/tests/test_cmd_list_workflows.py
@@ -1,0 +1,99 @@
+"""Tests for the planemo ``list_workflows`` command."""
+
+import json
+from unittest.mock import patch
+
+import planemo.galaxy.api
+from .test_utils import CliTestCase
+
+WORKFLOWS = [
+    {
+        "id": "abc123",
+        "name": "Published WF",
+        "url": "/api/workflows/abc123",
+        "source_metadata": {"url": "https://github.com/org/repo/wf.ga"},
+        "published": True,
+    },
+    {
+        "id": "def456",
+        "name": "Unpublished WF",
+        "url": "/api/workflows/def456",
+        "source_metadata": None,
+        "published": False,
+    },
+]
+
+
+class FakeWorkflowClient:
+    def get_workflows(self):
+        return WORKFLOWS
+
+
+class FakeGalaxyInstance:
+    workflows = FakeWorkflowClient()
+
+
+class CmdListWorkflowsTestCase(CliTestCase):
+    def _list_workflows(self, galaxy_url, *extra_args):
+        command = [
+            "list_workflows",
+            "--galaxy_url",
+            galaxy_url,
+            "--galaxy_user_key",
+            "test_key",
+            *extra_args,
+        ]
+        with patch.object(planemo.galaxy.api, "gi", lambda *args, **kwds: FakeGalaxyInstance()):
+            return self._check_exit_code(command)
+
+    def test_table_lists_each_workflow(self):
+        result = self._list_workflows("http://localhost:8080")
+        assert "Published WF" in result.output
+        assert "Unpublished WF" in result.output
+        assert "2 workflows found." in result.output
+
+    def test_urls_are_browsable_not_api_endpoints(self):
+        result = self._list_workflows("http://localhost:8080")
+        # The API URL renders JSON - users need something they can open.
+        assert "/api/workflows/abc123" not in result.output
+        assert "http://localhost:8080/published/workflow?id=abc123" in result.output
+        assert "http://localhost:8080/workflows/edit?id=def456" in result.output
+
+    def test_trailing_slash_in_galaxy_url_does_not_double_up(self):
+        result = self._list_workflows("http://localhost:8080/")
+        assert "//published" not in result.output
+        assert "//workflows" not in result.output
+        assert "http://localhost:8080/published/workflow?id=abc123" in result.output
+
+    def test_published_state_is_reported(self):
+        result = self._list_workflows("http://localhost:8080")
+        header = next(line for line in result.output.splitlines() if "Workflow ID" in line)
+        assert "Published" in header
+        published_row = next(line for line in result.output.splitlines() if line.startswith("abc123"))
+        unpublished_row = next(line for line in result.output.splitlines() if line.startswith("def456"))
+        assert published_row.split()[-3] == "yes"
+        assert unpublished_row.split()[-2] == "no"
+
+    def test_repo_url_shown_when_present_and_blank_otherwise(self):
+        result = self._list_workflows("http://localhost:8080")
+        assert "https://github.com/org/repo/wf.ga" in result.output
+        assert "N/A" not in result.output
+
+    def test_raw_emits_json_without_display_placeholders(self):
+        result = self._list_workflows("http://localhost:8080", "--raw")
+        parsed = json.loads(result.output)
+        assert parsed["abc123"]["repo_url"] == "https://github.com/org/repo/wf.ga"
+        # A missing repo URL must be null rather than a human-readable placeholder.
+        assert parsed["def456"]["repo_url"] is None
+        assert parsed["abc123"]["published"] is True
+
+    def test_raw_suppresses_informational_output(self):
+        result = self._list_workflows("http://localhost:8080", "--raw")
+        assert "Looking for workflows" not in result.output
+        assert "workflows found" not in result.output
+
+    def test_missing_galaxy_url_reports_usage_error(self):
+        result = self._runner.invoke(self._cli.planemo, ["list_workflows"])
+        assert result.exit_code == 2
+        assert "--galaxy_url" in result.output
+        assert not isinstance(result.exception, AttributeError)

--- a/tests/test_external_galaxy_commands.py
+++ b/tests/test_external_galaxy_commands.py
@@ -96,9 +96,7 @@ class ExternalGalaxyCommandsTestCase(CliTestCase):
                 assert "Run successfully executed" in result.output
                 result = self._check_exit_code(list_invocs_cmd)
                 assert "2 invocations found." in result.output
-                assert (
-                    "1 jobs ok" in result.output or '"ok": 1' in result.output
-                )  # so it passes regardless if tabulate is installed or not
+                assert "1 jobs ok" in result.output
 
                 # test rerun
                 invocation_id = config.user_gi.workflows.get_invocations(wfid)[0]["id"]


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of the PR author — they did not write this text personally.

Rebase of #1533 by Smeds (original commit and authorship preserved), plus the fixes that came out of reviewing it. Opened here because #1533 has been waiting on a rebase since 2025-06-19.

Adds `planemo list_workflows` — a sibling to `list_invocations` that lists a Galaxy's workflows as a table, or JSON under `--raw`.

### Rebase

Single add/add conflict in `planemo/galaxy/api.py`: master added `export_invocation_as_archive`, the PR added `get_workflows`, in the same place. Both kept.

### Fixes on top

**The `Url` column pointed at an API endpoint.** `workflow["url"]` from bioblend is `/api/workflows/<id>`, so the column rendered a JSON endpoint rather than something clickable. It now links to `/published/workflow?id=` for published workflows and `/workflows/edit?id=` otherwise — which also gives the `published` field, previously fetched but never displayed, something to do (it's now a column too).

**The `//` in the constructed URL.** Flagged in review on the original PR and still live: the base URL wasn't stripped, so a trailing slash produced `host//api/...`. Now `rstrip("/")`. Applied the same fix to `list_invocations`, which used `.strip("/")` — stripping the *leading* character of a URL was never the intent.

**`"N/A"` leaked into `--raw`.** A display placeholder was returned from the API layer and translated back to `""` by the command for rendering, so `--raw` — whose entire purpose is machine consumption — emitted `"repo_url": "N/A"` instead of `null`. The API layer now returns `None`.

**No target produced a traceback.** `planemo list_workflows` with neither `--profile` nor `--galaxy_url` raised `AttributeError` from inside bioblend. Now a `UsageError`. Relatedly, the command read `kwds.get("galaxy_admin_key")` without ever declaring the option, so it was always `None` — the option is now wired up.

**Naming.** `get_report_url` returned the repo URL and was assigned into `"repo_url"`; renamed.

### Shared table rendering

Four commands carried a copy of this:

```python
try:
    from tabulate import tabulate
except ImportError:
    tabulate = None  # type: ignore
```

...followed by an `if tabulate is not None:` / JSON-fallback branch. The guards have been dead since 976843e9 made `tabulate` an unconditional requirement — *"It doesn't have any requirements itself and is MIT licensed, so why not."* `cmd_delete_alias.py` imported it and never called it.

All of it now goes through `planemo.io.print_table`. It is deliberately a thin wrapper: the point is that the `rich` restyle suggested in review on #1533 becomes a one-function change instead of a four-file sweep. That restyle is **not** in this PR, per the note there that it's a good follow-up.

One knock-on: `tests/test_external_galaxy_commands.py` asserted `"1 jobs ok" in result.output or '"ok": 1' in result.output`, commented *"so it passes regardless if tabulate is installed or not"*. The `or` branch is unreachable now, so the assertion was tightened to the first clause.

### Tests

`tests/test_external_galaxy_commands.py` is where this would naturally be covered, but the whole class is `@skip`ped, so a case there would verify nothing. Added `tests/test_cmd_list_workflows.py` — 8 cases against a mocked bioblend client, running under `unit-quick`. Written red-to-green: with the source fixes reverted, 4 of the 8 fail, one per bug above.

### Docs

Added the generated `docs/commands/list_workflows.rst`, its `docs/commands.rst` include, and the `docs/planemo.commands.rst` automodule entry.

Worth noting separately: running `scripts/commands_to_rst.py` also rewrote 18 *unrelated* command docs. Two causes — genuinely stale help text (e.g. `--shed_tool_data_table_config` is a real option in `options.py` but missing from the checked-in `run.rst`), and trailing whitespace the generator emits but the committed files don't have, which will flip-flop on every regeneration. That churn is reverted here, but `docs/` could use a regeneration pass of its own, and `lint_docs` only builds the docs — it doesn't check them for drift.

### Also noticed, not addressed here

`rich` is imported by `planemo/galaxy/upload_progress.py`, `planemo/galaxy/invocations/progress.py`, and `tests/test_workflow_progress.py`, but isn't in `requirements.txt`. It currently arrives only because `ephemeris` happens to declare a bare `rich` — nothing in planemo's own dependency set asks for it. Filed separately.

Closes #1533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
