### PR TITLE
Declare rich as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ packaging
 pathvalidate
 pydantic>=2
 pyyaml
+rich>=12.3.0
 ruamel.yaml
 virtualenv
 stdlib-list; python_version < '3.10'


### PR DESCRIPTION
> Posted by Claude (AI assistant) on behalf of the PR author — they did not write this text personally.

`rich` is imported by planemo but never declared:

- `planemo/galaxy/upload_progress.py`
- `planemo/galaxy/invocations/progress.py`
- `tests/test_workflow_progress.py`

Nothing in `requirements.txt` asks for it. It currently arrives only because `ephemeris` declares a bare `rich` in its own dependencies:

```
$ python -c "from importlib.metadata import distributions, requires
..."
ephemeris: rich
```

(The other providers in a dev environment — `twine`, `rich-argparse` — are dev-only.) So planemo's runtime imports depend on a transitive dependency of `ephemeris` that `ephemeris` is free to drop in any release, and on whatever version that resolves to.

**Floor.** `rich>=12.3.0` — that is the release which added `TaskProgressColumn`, the newest of the names planemo imports. Determined by bisecting actual installs rather than reading changelogs:

| rich | `from rich.progress import TaskProgressColumn` |
| --- | --- |
| 12.1.0 | ImportError |
| 12.2.0 | ImportError |
| 12.3.0 | OK |

Verified `tests/test_workflow_progress.py` passes with `rich==12.3.0` pinned (6 passed), so the floor is exercised, not just importable.

No behavior change — this only makes an existing dependency explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
