### PR TITLE
Fix job_config_init profile wiring and legacy version default

### DIFF
--- a/docs/commands/job_config_init.rst
+++ b/docs/commands/job_config_init.rst
@@ -50,6 +50,7 @@ Initialize an small Galaxy job config file for hosted workflow runs.
       --runner [local|slurm|drmaa|k8s|condor]
                                       Galaxy runner (e.g. DRM) to target.
       --galaxy_version TEXT           Version of Galaxy to target for configuration
-                                      (default 24.2).
+                                      (defaults to the newest Galaxy the generator
+                                      knows).
       --help                          Show this message and exit.
     

--- a/docs/commands/profile_job_config_init.rst
+++ b/docs/commands/profile_job_config_init.rst
@@ -50,6 +50,7 @@ Initialize a Galaxy job configuration for specified profile.
       --runner [local|slurm|drmaa|k8s|condor]
                                       Galaxy runner (e.g. DRM) to target.
       --galaxy_version TEXT           Version of Galaxy to target for configuration
-                                      (default 24.2).
+                                      (defaults to the newest Galaxy the generator
+                                      knows).
       --help                          Show this message and exit.
     

--- a/planemo/galaxy/profiles.py
+++ b/planemo/galaxy/profiles.py
@@ -269,7 +269,7 @@ def initialize_job_config(ctx, profile_name, **kwds):
         f.write(job_config)
 
     config, profile_config_path = _load_profile_to_json(ctx, profile_name)
-    config["job_config_file"] = os.path.abspath(profile_config_path)
+    config["job_config_file"] = os.path.abspath(job_config_path)
     with open(profile_config_path, "w") as f:
         json.dump(config, f)
     return job_config_path

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -209,8 +209,8 @@ def galaxy_version_option():
     return planemo_option(
         "--galaxy_version",
         type=str,
-        default="24.2",
-        help="Version of Galaxy to target for configuration (default 24.2).",
+        default=None,
+        help="Version of Galaxy to target for configuration (defaults to the newest Galaxy the generator knows).",
     )
 
 

--- a/tests/test_cmd_job_config_init.py
+++ b/tests/test_cmd_job_config_init.py
@@ -36,6 +36,16 @@ class CmdJobConfigInitTestCase(CliTestCase):
                 config = yaml.safe_load(fh)
             assert config["execution"]["default"] == "slurm"
 
+    def test_job_config_init_defaults_to_modern_galaxy(self):
+        with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
+            init_cmd = ["job_config_init", "--tpv", "--runner", "drmaa"]
+            self._check_exit_code(init_cmd)
+            assert os.path.exists("job_conf.yml")
+            with open("job_conf.yml") as fh:
+                config = yaml.safe_load(fh)
+            assert config["execution"]["default"] == "tpv"
+            assert config["execution"]["environments"]["tpv"]["runner"] == "dynamic_tpv"
+
     def test_job_config_init_25_0(self):
         with self._isolate_with_test_data("wf_repos/from_format2/0_basic_native"):
             init_cmd = ["job_config_init", "--tpv", "--runner", "drmaa", "--galaxy_version", "25.0"]

--- a/tests/test_cmd_profile_job_config_init.py
+++ b/tests/test_cmd_profile_job_config_init.py
@@ -1,4 +1,10 @@
-"""Tests for the ``job_config_init`` command."""
+"""Tests for the ``profile_job_config_init`` command."""
+
+import json
+import os
+from tempfile import mkdtemp
+
+import yaml
 
 from .test_utils import CliTestCase
 
@@ -12,3 +18,20 @@ class CmdJobConfigInitTestCase(CliTestCase):
             init_cmd = ["profile_job_config_init", TEST_PROFILE_NAME]
             self._check_exit_code(init_cmd)
             self._check_exit_code(["profile_delete", TEST_PROFILE_NAME])
+
+    def test_job_config_recorded_in_profile(self):
+        with self._isolate():
+            workspace = mkdtemp()
+            self._check_exit_code(["--directory", workspace, "profile_create", TEST_PROFILE_NAME])
+            self._check_exit_code(
+                ["--directory", workspace, "profile_job_config_init", TEST_PROFILE_NAME, "--runner", "slurm"]
+            )
+            profile_directory = os.path.join(workspace, "profiles", TEST_PROFILE_NAME)
+            with open(os.path.join(profile_directory, "planemo_profile_options.json")) as fh:
+                profile_options = json.load(fh)
+
+            job_config_file = profile_options["job_config_file"]
+            assert job_config_file == os.path.join(profile_directory, "job_conf.yml")
+            with open(job_config_file) as fh:
+                job_config = yaml.safe_load(fh)
+            assert job_config["execution"]["default"] == "slurm"


### PR DESCRIPTION
Two independent bugs in `job_config_init` / `profile_job_config_init`, both found while addressing review comments on #1683.

## `profile_job_config_init` records the wrong file

`initialize_job_config` writes `job_conf.yml` into the profile directory and then stores the profile's own `planemo_profile_options.json` path as `job_config_file`:

```python
config["job_config_file"] = os.path.abspath(profile_config_path)
```

A profile set up this way hands Galaxy its options JSON as a job configuration, so the generated runner configuration never takes effect. Before:

```console
$ planemo profile_create slurm_cluster
$ planemo profile_job_config_init slurm_cluster --runner slurm
$ jq -r .job_config_file ~/.planemo/profiles/slurm_cluster/planemo_profile_options.json
.../profiles/slurm_cluster/planemo_profile_options.json
```

`tests/test_cmd_profile_job_config_init.py` only asserted exit codes, which is why this survived. It now asserts the recorded path and parses the config it points at.

## `--galaxy_version` defaults to the legacy layout

`galaxy_version_option()` pins the click default to `"24.2"`, while `gxjobconfinit` defaults to `"25.0"` when the value is `None` and branches on `galaxy_version < "25.0"`. Omitting the flag therefore selects the *legacy* configuration rather than a modern one.

For `--runner slurm --singularity` the output is byte-identical either way. For `--tpv` it is not:

| | with `--galaxy_version 25.0` | default (`24.2`) |
|---|---|---|
| runner | `dynamic_tpv` | `dynamic` + `type: python` + `rules_module: tpv.rules` |
| TPV config | inline `tpv_configs` | external `tpv.yml` the user must create |
| `tpvdb_slurm` destination | generated | commented-out template only |

Passing `None` through lets the library's default apply and move with it. Callers that want the old layout still pass `--galaxy_version 24.2` explicitly, which the existing `test_job_config_init_24_2` covers.

## Validation

- `pytest tests/test_cmd_job_config_init.py tests/test_cmd_profile_job_config_init.py` — 8 passed; both new tests confirmed red before the fixes
- `flake8`, `black --check`, `isort --check-only` clean on all changed files
- `docs/commands/{job_config_init,profile_job_config_init}.rst` regenerated with `scripts/commands_to_rst.py`. The generator also rewrites eleven unrelated command docs that have drifted from merged PRs; those are left alone here.
- End-to-end: `profile_create` + `profile_job_config_init --runner slurm --tpv --singularity` now yields `dynamic_tpv`, an uncommented `tpvdb_slurm` destination, `https://gxy.io/tpv/db.yml`, `singularity_cmd: singularity`, a commented `drmaa_library_path`, `native_specification`, `tmp_dir: true`, and a profile recording the real `job_conf.yml`.

## Relationship to #1683

#1683 drops `--galaxy_version 25.0` from its examples and recommends `profile_job_config_init`, per review there. Both of those are only correct once this lands, so this should merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5F4LLXH1Rpt2MCLQCgwgU
