### PR TITLE
[WIP] Add an embedded Galaxy engine for package-installed Galaxy

### DIFF
--- a/planemo/commands/cmd_serve.py
+++ b/planemo/commands/cmd_serve.py
@@ -40,5 +40,5 @@ def cli(ctx, uris, **kwds):
     """
     paths = uris_to_paths(ctx, uris)
     runnables = for_paths(paths)
-    with galaxy_serve(ctx, runnables, **kwds):
-        pass
+    with galaxy_serve(ctx, runnables, **kwds) as config:
+        config.wait_for_serve()

--- a/planemo/context.py
+++ b/planemo/context.py
@@ -32,8 +32,8 @@ class PlanemoContextInterface(metaclass=abc.ABCMeta):
         """Specify how an option was set."""
 
     @abc.abstractmethod
-    def get_option_source(self, param_name):
-        """Return OptionSource value indicating how the option was set."""
+    def get_option_source(self, param_name, default=None):
+        """Return how an option was set, or ``default`` when it is unknown."""
 
     @abc.abstractproperty
     def global_config(self):
@@ -85,10 +85,9 @@ class PlanemoContext(PlanemoContextInterface):
             assert param_name not in self.option_source, f"Option source for [{param_name}] already set"
         self.option_source[param_name] = option_source
 
-    def get_option_source(self, param_name: str) -> "OptionSource":
-        """Return OptionSource value indicating how the option was set."""
-        assert param_name in self.option_source, f"No option source for [{param_name}]"
-        return self.option_source[param_name]
+    def get_option_source(self, param_name: str, default=None) -> Optional["OptionSource"]:
+        """Return how an option was set, or ``default`` when it is unknown."""
+        return self.option_source.get(param_name, default)
 
     @property
     def global_config(self) -> Dict[str, Any]:

--- a/planemo/engine/factory.py
+++ b/planemo/engine/factory.py
@@ -7,6 +7,8 @@ from planemo.engine.interface import BaseEngine
 from .cwltool import CwlToolEngine
 from .galaxy import (
     DockerizedManagedGalaxyEngine,
+    EmbeddedGalaxyEngine,
+    EmbeddedGalaxyEngineWithSingularityDB,
     ExternalGalaxyEngine,
     LocalManagedGalaxyEngine,
     LocalManagedGalaxyEngineWithSingularityDB,
@@ -19,7 +21,7 @@ UNKNOWN_ENGINE_TYPE_MESSAGE = "Unknown engine type specified [%s]."
 def is_galaxy_engine(**kwds):
     """Return True iff the engine configured is :class:`GalaxyEngine`."""
     engine_type_str = kwds.get("engine", "galaxy")
-    return engine_type_str in ["galaxy", "docker_galaxy", "external_galaxy"]
+    return engine_type_str in ["galaxy", "embedded_galaxy", "docker_galaxy", "external_galaxy"]
 
 
 def build_engine(ctx, **kwds):
@@ -30,6 +32,11 @@ def build_engine(ctx, **kwds):
             engine_type = LocalManagedGalaxyEngineWithSingularityDB
         else:
             engine_type = LocalManagedGalaxyEngine
+    elif engine_type_str == "embedded_galaxy":
+        if "database_type" in kwds and kwds["database_type"] == "postgres_singularity":
+            engine_type = EmbeddedGalaxyEngineWithSingularityDB
+        else:
+            engine_type = EmbeddedGalaxyEngine
     elif engine_type_str == "docker_galaxy":
         engine_type = DockerizedManagedGalaxyEngine
     elif engine_type_str == "external_galaxy":

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -21,6 +21,7 @@ from planemo.galaxy.activity import (
     GalaxyBaseRunResponse,
 )
 from planemo.galaxy.config import external_galaxy_config
+from planemo.galaxy.embedded import serve_embedded
 from planemo.galaxy.serve import serve_daemon
 from planemo.runnable import (
     DelayedGalaxyToolTestCase,
@@ -191,8 +192,9 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
             if self._ctx.verbose:
                 print("Failed to install tool repositories, Galaxy log:")
                 print(config.log_contents)
-                print("Galaxy root:")
-                io.shell(["ls", config.galaxy_root])
+                if config.galaxy_root:
+                    print("Galaxy root:")
+                    io.shell(["ls", config.galaxy_root])
             raise
 
     def _serve_kwds(self):
@@ -200,6 +202,57 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
 
 
 class LocalManagedGalaxyEngineWithSingularityDB(LocalManagedGalaxyEngine):
+    def run(self, runnables, job_paths, output_collectors: Optional[List[Callable]] = None):
+        with SingularityPostgresDatabaseSource(**self._kwds.copy()):
+            run_responses = super().run(runnables, job_paths, output_collectors)
+        return run_responses
+
+
+class EmbeddedGalaxyEngine(LocalManagedGalaxyEngine):
+    """A managed Galaxy loaded from packages into the Planemo process."""
+
+    def __init__(self, ctx, **kwds):
+        super().__init__(ctx, **kwds)
+        self._active_embedded_config = None
+        self._active_embedded_runnable_uris = set()
+
+    @contextlib.contextmanager
+    def _serve_runnables(self, runnables, *, for_tests=False):
+        serve_kwds = self._serve_kwds()
+        serve_kwds["for_tests"] = for_tests
+        with serve_embedded(self._ctx, runnables, **serve_kwds) as config:
+            if "install_args_list" in serve_kwds:
+                self.shed_install(config)
+            yield config
+
+    @contextlib.contextmanager
+    def ensure_runnables_served(self, runnables):
+        active_config = getattr(self, "_active_embedded_config", None)
+        if active_config is not None:
+            requested_uris = {runnable.uri for runnable in runnables}
+            if not requested_uris.issubset(self._active_embedded_runnable_uris):
+                raise RuntimeError("The active embedded Galaxy was not configured for all requested runnables.")
+            yield active_config
+        else:
+            with self._serve_runnables(runnables) as config:
+                yield config
+
+    def test(self, runnables, test_timeout):
+        # GalaxyEngine divides native tool tests from workflow/job-file tests.
+        # Keep those inner execution paths on one embedded application because
+        # Galaxy does not promise independent reconstruction in one process.
+        self._check_can_run_all(runnables)
+        with self._serve_runnables(runnables, for_tests=True) as config:
+            self._active_embedded_config = config
+            self._active_embedded_runnable_uris = {runnable.uri for runnable in runnables}
+            try:
+                return super().test(runnables, test_timeout)
+            finally:
+                self._active_embedded_config = None
+                self._active_embedded_runnable_uris = set()
+
+
+class EmbeddedGalaxyEngineWithSingularityDB(EmbeddedGalaxyEngine):
     def run(self, runnables, job_paths, output_collectors: Optional[List[Callable]] = None):
         with SingularityPostgresDatabaseSource(**self._kwds.copy()):
             run_responses = super().run(runnables, job_paths, output_collectors)
@@ -260,6 +313,8 @@ def expand_test_cases(config, test_cases):
 
 __all__ = (
     "DockerizedManagedGalaxyEngine",
+    "EmbeddedGalaxyEngine",
+    "EmbeddedGalaxyEngineWithSingularityDB",
     "ExternalGalaxyEngine",
     "LocalManagedGalaxyEngine",
     "LocalManagedGalaxyEngineWithSingularityDB",

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -98,66 +98,81 @@ class GalaxyEngine(BaseEngine, metaclass=abc.ABCMeta):
     def ensure_runnables_served(self, runnables):
         """Use a context manager and describe Galaxy instance with runnables being served."""
 
-    def _run_test_cases(self, test_cases, test_timeout):
-        test_results = []
-        file_based_test_cases = []
-        embedded_test_cases = []
+    def _collect_test_results(self, test_cases, test_timeout):
+        indexed_file_based_test_cases = []
+        indexed_embedded_test_cases = []
         # TODO: unify interface so we don't need to split test cases
-        for test_case in test_cases:
+        for index, test_case in enumerate(test_cases):
             if isinstance(test_case, ExternalGalaxyToolTestCase):
-                embedded_test_cases.append(test_case)
+                indexed_embedded_test_cases.append((index, test_case))
             else:
-                file_based_test_cases.append(test_case)
-        if file_based_test_cases:
-            test_results.extend(super()._run_test_cases(file_based_test_cases, test_timeout))
-        if embedded_test_cases:
-            runnables = [test_case.runnable for test_case in embedded_test_cases]
+                indexed_file_based_test_cases.append((index, test_case))
+
+        # Galaxy tool tests and workflow/job-file tests use different runners.
+        # Keep the association with the original case explicit: batching the two
+        # groups otherwise reorders their results before BaseEngine pairs them.
+        indexed_results = [[] for _ in test_cases]
+        if indexed_file_based_test_cases:
+            file_based_test_cases = [test_case for _, test_case in indexed_file_based_test_cases]
+            file_based_results = super()._run_test_cases(file_based_test_cases, test_timeout)
+            for (index, test_case), result in zip(indexed_file_based_test_cases, file_based_results):
+                indexed_results[index].append((test_case, result))
+
+        if indexed_embedded_test_cases:
+            runnables = [test_case.runnable for _, test_case in indexed_embedded_test_cases]
             with self.ensure_runnables_served(runnables) as config:
-                expanded_test_cases = expand_test_cases(config, embedded_test_cases)
-                for test_case in expanded_test_cases:
-                    galaxy_interactor_kwds = {
-                        "galaxy_url": config.galaxy_url,
-                        "master_api_key": config.master_api_key,
-                        "api_key": config.user_api_key,
-                        "keep_outputs_dir": self._kwds.get("test_data_target_dir"),
-                    }
-                    tool_id = test_case.tool_id
-                    test_index = test_case.test_index
-                    tool_version = test_case.tool_version
-                    galaxy_interactor = interactor.GalaxyInteractorApi(**galaxy_interactor_kwds)
+                for index, original_test_case in indexed_embedded_test_cases:
+                    expanded_test_cases = expand_test_cases(config, [original_test_case])
+                    for test_case in expanded_test_cases:
+                        case_results = []
+                        self._run_galaxy_tool_test_case(config, test_case, test_timeout, case_results.append)
+                        indexed_results[index].extend((test_case, result) for result in case_results)
 
-                    def _register_job_data(job_data):
-                        test_results.append(
-                            {
-                                "id": tool_id + "-" + str(test_index),
-                                "has_data": True,
-                                "data": job_data,
-                            }
-                        )
+        return [case_and_result for results in indexed_results for case_and_result in results]
 
-                    verbose = self._ctx.verbose
-                    result_index = len(test_results)
-                    try:
-                        if verbose:
-                            # TODO: this is pretty hacky, it'd be better to send a stream
-                            # and capture the output information somehow.
-                            interactor.VERBOSE_GALAXY_ERRORS = True
+    def _run_galaxy_tool_test_case(self, config, test_case, test_timeout, register_job_data):
+        galaxy_interactor_kwds = {
+            "galaxy_url": config.galaxy_url,
+            "master_api_key": config.master_api_key,
+            "api_key": config.user_api_key,
+            "keep_outputs_dir": self._kwds.get("test_data_target_dir"),
+        }
+        tool_id = test_case.tool_id
+        test_index = test_case.test_index
+        tool_version = test_case.tool_version
+        galaxy_interactor = interactor.GalaxyInteractorApi(**galaxy_interactor_kwds)
 
-                        interactor.verify_tool(
-                            tool_id,
-                            galaxy_interactor,
-                            test_index=test_index,
-                            tool_version=tool_version,
-                            register_job_data=_register_job_data,
-                            maxseconds=test_timeout,
-                            quiet=not verbose,
-                        )
-                    except Exception:
-                        pass
+        case_results = []
 
-                    log_service_logs_on_failure(self._ctx, config, test_results[result_index:])
+        def register_result(job_data):
+            result = {
+                "id": tool_id + "-" + str(test_index),
+                "has_data": True,
+                "data": job_data,
+            }
+            case_results.append(result)
+            register_job_data(result)
 
-        return test_results
+        verbose = self._ctx.verbose
+        try:
+            if verbose:
+                # TODO: this is pretty hacky, it'd be better to send a stream
+                # and capture the output information somehow.
+                interactor.VERBOSE_GALAXY_ERRORS = True
+
+            interactor.verify_tool(
+                tool_id,
+                galaxy_interactor,
+                test_index=test_index,
+                tool_version=tool_version,
+                register_job_data=register_result,
+                maxseconds=test_timeout,
+                quiet=not verbose,
+            )
+        except Exception:
+            pass
+
+        log_service_logs_on_failure(self._ctx, config, case_results)
 
 
 class LocalManagedGalaxyEngine(GalaxyEngine):

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -229,9 +229,11 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
 
 
 class SingularityDBMixin:
+    _kwds: Dict[str, Any]
+
     def run(self, runnables, job_paths, output_collectors: Optional[List[Callable]] = None):
         with SingularityPostgresDatabaseSource(**self._kwds.copy()):
-            run_responses = super().run(runnables, job_paths, output_collectors)
+            run_responses = getattr(super(), "run")(runnables, job_paths, output_collectors)
         return run_responses
 
 

--- a/planemo/engine/galaxy.py
+++ b/planemo/engine/galaxy.py
@@ -167,12 +167,24 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
     """
 
     @contextlib.contextmanager
+    def _serve_context(self, runnables, **serve_kwds):
+        with serve_daemon(self._ctx, runnables, **serve_kwds) as config:
+            yield config
+
+    @contextlib.contextmanager
+    def _serve_runnables(self, runnables, *, for_tests=False):
+        serve_kwds = self._serve_kwds()
+        serve_kwds["for_tests"] = for_tests
+        with self._serve_context(runnables, **serve_kwds) as config:
+            if "install_args_list" in serve_kwds:
+                self.shed_install(config)
+            yield config
+
+    @contextlib.contextmanager
     def ensure_runnables_served(self, runnables):
         # TODO: define an interface for this - not everything in config would make sense for a
         # pre-existing Galaxy interface.
-        with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
-            if "install_args_list" in self._serve_kwds():
-                self.shed_install(config)
+        with self._serve_runnables(runnables) as config:
             yield config
 
     def shed_install(self, config):
@@ -201,11 +213,15 @@ class LocalManagedGalaxyEngine(GalaxyEngine):
         return self._kwds.copy()
 
 
-class LocalManagedGalaxyEngineWithSingularityDB(LocalManagedGalaxyEngine):
+class SingularityDBMixin:
     def run(self, runnables, job_paths, output_collectors: Optional[List[Callable]] = None):
         with SingularityPostgresDatabaseSource(**self._kwds.copy()):
             run_responses = super().run(runnables, job_paths, output_collectors)
         return run_responses
+
+
+class LocalManagedGalaxyEngineWithSingularityDB(SingularityDBMixin, LocalManagedGalaxyEngine):
+    pass
 
 
 class EmbeddedGalaxyEngine(LocalManagedGalaxyEngine):
@@ -217,17 +233,13 @@ class EmbeddedGalaxyEngine(LocalManagedGalaxyEngine):
         self._active_embedded_runnable_uris = set()
 
     @contextlib.contextmanager
-    def _serve_runnables(self, runnables, *, for_tests=False):
-        serve_kwds = self._serve_kwds()
-        serve_kwds["for_tests"] = for_tests
+    def _serve_context(self, runnables, **serve_kwds):
         with serve_embedded(self._ctx, runnables, **serve_kwds) as config:
-            if "install_args_list" in serve_kwds:
-                self.shed_install(config)
             yield config
 
     @contextlib.contextmanager
     def ensure_runnables_served(self, runnables):
-        active_config = getattr(self, "_active_embedded_config", None)
+        active_config = self._active_embedded_config
         if active_config is not None:
             requested_uris = {runnable.uri for runnable in runnables}
             if not requested_uris.issubset(self._active_embedded_runnable_uris):
@@ -252,11 +264,8 @@ class EmbeddedGalaxyEngine(LocalManagedGalaxyEngine):
                 self._active_embedded_runnable_uris = set()
 
 
-class EmbeddedGalaxyEngineWithSingularityDB(EmbeddedGalaxyEngine):
-    def run(self, runnables, job_paths, output_collectors: Optional[List[Callable]] = None):
-        with SingularityPostgresDatabaseSource(**self._kwds.copy()):
-            run_responses = super().run(runnables, job_paths, output_collectors)
-        return run_responses
+class EmbeddedGalaxyEngineWithSingularityDB(SingularityDBMixin, EmbeddedGalaxyEngine):
+    pass
 
 
 class DockerizedManagedGalaxyEngine(LocalManagedGalaxyEngine):

--- a/planemo/galaxy/config.py
+++ b/planemo/galaxy/config.py
@@ -16,6 +16,7 @@ import sys
 import threading
 import time
 from collections import deque
+from dataclasses import dataclass
 from string import Template
 from tempfile import (
     mkdtemp,
@@ -184,6 +185,21 @@ SERVICE_LOG_TAIL_LINES = 100
 UNINITIALIZED = object()
 
 
+@dataclass(frozen=True)
+class _ManagedGalaxyConfigArtifacts:
+    """Files and settings shared by checkout and embedded Galaxy runtimes."""
+
+    config_directory: str
+    env: Dict[str, Any]
+    test_data_dir: Optional[str]
+    port: int
+    server_name: str
+    master_api_key: str
+    galaxy_config_file: str
+    galaxy_properties: Dict[str, Any]
+    kwds: Dict[str, Any]
+
+
 @contextlib.contextmanager
 def galaxy_config(ctx, runnables, **kwds):
     """Set up a ``GalaxyConfig`` in an auto-cleaned context."""
@@ -340,9 +356,229 @@ def docker_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         )
 
 
+def _configure_mulled_containers(ctx, kwds):
+    """Normalize dependency options shared by local Galaxy runtimes."""
+    if kwds.get("mulled_containers", False):
+        if not kwds.get("docker", False):
+            if ctx.get_option_source("docker", None) != OptionSource.cli:
+                kwds["docker"] = True
+            else:
+                raise Exception("Specified no docker and mulled containers together.")
+        conda_default_options = ("conda_auto_init", "conda_auto_install")
+        use_conda_options = ("dependency_resolution", "conda_use_local", "conda_prefix", "conda_exec")
+        if not any(kwds.get(_) for _ in use_conda_options) and all(
+            ctx.get_option_source(_, OptionSource.default) == OptionSource.default for _ in conda_default_options
+        ):
+            kwds["no_dependency_resolution"] = kwds["no_conda_auto_init"] = True
+
+
+def _configure_embedded_properties(properties, config_join):
+    # Embedded mode targets the new package-only Galaxy release, so use the
+    # canonical name while checkout-backed engines retain compatibility with
+    # Galaxy versions that still require ``master_api_key``.
+    properties["bootstrap_admin_api_key"] = properties.pop("master_api_key")
+    properties.update(
+        auto_configure_logging=False,
+        # ``build_galaxy_web_app`` forwards this constructor-only keyword to
+        # GalaxyManagerApplication; it is deliberately omitted from galaxy.yml
+        # below because it is not a Galaxy configuration-schema property.
+        configure_logging=False,
+        enable_celery_tasks=True,
+        interactivetools_enable=False,
+        monitor_thread_join_timeout=5,
+        watch_tools=False,
+        amqp_internal_connection=f"sqlalchemy+sqlite:///{config_join('control.sqlite')}",
+        celery_conf={
+            "broker_url": "memory://",
+            "result_backend": "rpc://localhost",
+            "worker_hijack_root_logger": False,
+        },
+    )
+
+
+def _write_embedded_config(properties, template_args, config_join):
+    galaxy_properties = {
+        key: _sub(value, template_args) if isinstance(value, str) else value
+        for key, value in properties.items()
+        if value is not None
+    }
+    galaxy_config_file = config_join("galaxy.yml")
+    env = {"GALAXY_CONFIG_FILE": galaxy_config_file}
+    file_properties = {key: value for key, value in galaxy_properties.items() if key != "configure_logging"}
+    write_file(galaxy_config_file, json.dumps({"galaxy": file_properties}))
+    return env, galaxy_config_file, galaxy_properties
+
+
+def _write_checkout_config(properties, template_args, config_join, galaxy_root, server_name, kwds):
+    env = _build_env_for_galaxy(properties, template_args)
+    env["GALAXY_DEVELOPMENT_ENVIRONMENT"] = "1"
+    env["GALAXY_LOG"] = f"{server_name}.log"
+    env["GALAXY_PID"] = f"{server_name}.pid"
+    write_galaxy_config(
+        galaxy_root=galaxy_root,
+        properties=properties,
+        env=env,
+        kwds=kwds,
+        template_args=template_args,
+        config_join=config_join,
+    )
+    return env, env["GALAXY_CONFIG_FILE"], properties
+
+
+def _prepare_managed_galaxy_config(
+    *,
+    ctx,
+    config_directory,
+    runnables,
+    test_data_dir,
+    tool_data_tables,
+    data_manager_config_paths,
+    galaxy_root,
+    for_tests,
+    embedded,
+    kwds,
+):
+    """Generate the checkout-independent files used by local Galaxy engines."""
+
+    def config_join(*args):
+        return os.path.join(config_directory, *args)
+
+    ensure_dependency_resolvers_conf_configured(ctx, kwds, config_join("resolvers_conf.xml"))
+    all_tool_paths = _all_tool_paths(runnables, galaxy_root=galaxy_root, extra_tools=kwds.get("extra_tools"))
+    kwds["all_in_one_handling"] = True
+    _handle_job_config_file(config_directory, "main", test_data_dir, all_tool_paths, kwds)
+    _handle_file_sources(config_directory, test_data_dir, kwds)
+    _handle_refgenie_config(config_directory, galaxy_root, kwds)
+    _handle_vault_config(config_directory, kwds)
+
+    file_path = kwds.get("file_path") or config_join("files")
+    _ensure_directory(file_path)
+    dependency_dir = kwds.get("tool_dependency_dir") or config_join("deps")
+    _ensure_directory(dependency_dir)
+
+    shed_config_paths = _shed_config_paths(kwds, config_join)
+    shed_tool_conf = shed_config_paths["shed_tool_conf"]
+    shed_tool_path = shed_config_paths["shed_tool_path"]
+    shed_tool_data_table_config = shed_config_paths["shed_tool_data_table_config"]
+    shed_data_manager_config_file = shed_config_paths["shed_data_manager_config_file"]
+    _ensure_directory(shed_tool_path)
+
+    empty_tool_conf = config_join("empty_tool_conf.xml")
+    if embedded and not tool_data_tables:
+        # Installed Galaxy otherwise falls back to checkout-relative sample
+        # tables and emits errors for files that do not exist in wheel mode.
+        empty_tool_data_table_conf = config_join("empty_tool_data_table_conf.xml")
+        write_file(empty_tool_data_table_conf, SHED_TOOL_DATA_TABLE_CONF_TEMPLATE)
+        tool_data_tables = [empty_tool_data_table_conf]
+    tool_conf = config_join("tool_conf.xml")
+    # ``config_directory`` was already consumed positionally and forwarding it
+    # again would raise a duplicate-argument TypeError in both local modes.
+    shed_config_kwds = {key: value for key, value in kwds.items() if key != "config_directory"}
+    sheds_config_path = _configure_sheds_config_file(ctx, config_directory, runnables, **shed_config_kwds)
+    database_location = config_join("galaxy.sqlite")
+    master_api_key = _get_master_api_key(kwds)
+    port = _get_port(kwds)
+    server_name = "main"
+    template_args = dict(
+        port=port,
+        host=kwds.get("host", "127.0.0.1"),
+        server_name=server_name,
+        temp_directory=config_directory,
+        shed_tool_path=shed_tool_path,
+        database_location=database_location,
+        tool_conf=tool_conf,
+        debug=kwds.get("debug", "true"),
+        id_secret=kwds.get("id_secret", hashlib.md5(str(time.time()).encode("utf-8")).hexdigest()),
+        log_level="DEBUG" if ctx.verbose else "INFO",
+    )
+    tool_config_file = f"{tool_conf},{shed_tool_conf}"
+    properties = _shared_galaxy_properties(config_directory, kwds, for_tests=for_tests)
+    properties.update(
+        dict(
+            server_name=server_name,
+            enable_celery_tasks="true",
+            ftp_upload_dir_template="${ftp_upload_dir}",
+            ftp_upload_purge="false",
+            ftp_upload_dir=test_data_dir or os.path.abspath("."),
+            ftp_upload_site="Test Data",
+            check_upload_content="false",
+            tool_dependency_dir=dependency_dir,
+            file_path=file_path,
+            new_file_path="${temp_directory}/tmp",
+            tool_config_file=tool_config_file,
+            tool_sheds_config_file=sheds_config_path,
+            manage_dependency_relationships="false",
+            job_working_directory="${temp_directory}/job_working_directory",
+            template_cache_path="${temp_directory}/compiled_templates",
+            citation_cache_type="file",
+            citation_cache_data_dir="${temp_directory}/citations/data",
+            citation_cache_lock_dir="${temp_directory}/citations/lock",
+            database_auto_migrate="true",
+            enable_beta_tool_formats="true",
+            id_secret="${id_secret}",
+            log_level="${log_level}",
+            debug="${debug}",
+            watch_tools="auto",
+            default_job_shell="/bin/bash",
+            tool_data_table_config_path=",".join(tool_data_tables) if tool_data_tables else None,
+            data_manager_config_file=",".join(data_manager_config_paths) or None,
+            integrated_tool_panel_config="${temp_directory}/integrated_tool_panel_conf.xml",
+            migrated_tools_config=empty_tool_conf,
+            test_data_dir=test_data_dir,
+            shed_tool_data_table_config=shed_tool_data_table_config,
+            shed_data_manager_config_file=shed_data_manager_config_file,
+            outputs_to_working_directory="true",
+            object_store_store_by="uuid",
+        )
+    )
+    _handle_container_resolution(ctx, kwds, properties)
+    properties["database_connection"] = _database_connection(database_location, **kwds)
+    if embedded:
+        _configure_embedded_properties(properties, config_join)
+    else:
+        properties["amqp_internal_connection"] = f"sqlalchemy+sqlite:///{config_join('celery_broker.sqlite')}"
+    if kwds.get("mulled_containers", False):
+        properties["mulled_channels"] = kwds.get("conda_ensure_channels", "")
+    _handle_kwd_overrides(properties, kwds)
+
+    _write_tool_conf(ctx, all_tool_paths, tool_conf)
+    write_file(empty_tool_conf, EMPTY_TOOL_CONF_TEMPLATE)
+    shed_tool_conf_contents = _sub(SHED_TOOL_CONF_TEMPLATE, template_args)
+    _write_shed_config_files(
+        shed_tool_conf,
+        shed_tool_conf_contents,
+        shed_tool_data_table_config,
+        shed_data_manager_config_file,
+    )
+
+    if embedded:
+        env, galaxy_config_file, galaxy_properties = _write_embedded_config(properties, template_args, config_join)
+    else:
+        env, galaxy_config_file, galaxy_properties = _write_checkout_config(
+            properties,
+            template_args,
+            config_join,
+            galaxy_root,
+            server_name,
+            kwds,
+        )
+
+    return _ManagedGalaxyConfigArtifacts(
+        config_directory=config_directory,
+        env=env,
+        test_data_dir=test_data_dir,
+        port=port,
+        server_name=server_name,
+        master_api_key=master_api_key,
+        galaxy_config_file=galaxy_config_file,
+        galaxy_properties=galaxy_properties,
+        kwds=kwds,
+    )
+
+
 @contextlib.contextmanager
 def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
-    """Set up a ``GalaxyConfig`` in an auto-cleaned context."""
+    """Set up a checkout-backed ``GalaxyConfig`` in an auto-cleaned context."""
 
     test_data_dir = _find_test_data(runnables, **kwds)
     tool_data_tables = _find_tool_data_table(runnables, test_data_dir=test_data_dir, **kwds)
@@ -355,20 +591,7 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
         if os.path.isdir(galaxy_root) and install_galaxy:
             raise Exception(f"{galaxy_root} is an existing non-empty directory, cannot install Galaxy again")
 
-    # Duplicate block in docker variant above.
-    if kwds.get("mulled_containers", False):
-        if not kwds.get("docker", False):
-            if ctx.get_option_source("docker") != OptionSource.cli:
-                kwds["docker"] = True
-            else:
-                raise Exception("Specified no docker and mulled containers together.")
-        conda_default_options = ("conda_auto_init", "conda_auto_install")
-        use_conda_options = ("dependency_resolution", "conda_use_local", "conda_prefix", "conda_exec")
-        if not any(kwds.get(_) for _ in use_conda_options) and all(
-            ctx.get_option_source(_) == OptionSource.default for _ in conda_default_options
-        ):
-            # If using mulled_containers and default conda options disable conda resolution
-            kwds["no_dependency_resolution"] = kwds["no_conda_auto_init"] = True
+    _configure_mulled_containers(ctx, kwds)
 
     with _config_directory(ctx, **kwds) as config_directory:
 
@@ -384,159 +607,58 @@ def local_galaxy_config(ctx, runnables, for_tests=False, **kwds):
             galaxy_root = config_join("galaxy-dev")
         if not os.path.isdir(galaxy_root):
             _install_galaxy(ctx, galaxy_root, install_env, kwds)
-
-        server_name = "main"
-        # Once we don't have to support earlier than 18.01 - try putting these files
-        # somewhere better than with Galaxy.
-        log_file = f"{server_name}.log"
-        pid_file = f"{server_name}.pid"
-        ensure_dependency_resolvers_conf_configured(ctx, kwds, os.path.join(config_directory, "resolvers_conf.xml"))
-        all_tool_paths = _all_tool_paths(runnables, galaxy_root=galaxy_root, extra_tools=kwds.get("extra_tools"))
-        kwds["all_in_one_handling"] = True
-        _handle_job_config_file(config_directory, server_name, test_data_dir, all_tool_paths, kwds)
-        _handle_file_sources(config_directory, test_data_dir, kwds)
-        _handle_refgenie_config(config_directory, galaxy_root, kwds)
-        _handle_vault_config(config_directory, kwds)
-        file_path = kwds.get("file_path") or config_join("files")
-        _ensure_directory(file_path)
-
-        tool_dependency_dir = kwds.get("tool_dependency_dir") or config_join("deps")
-        _ensure_directory(tool_dependency_dir)
-
-        shed_config_paths = _shed_config_paths(kwds, config_join)
-        shed_tool_conf = shed_config_paths["shed_tool_conf"]
-        shed_tool_path = shed_config_paths["shed_tool_path"]
-        shed_tool_data_table_config = shed_config_paths["shed_tool_data_table_config"]
-        shed_data_manager_config_file = shed_config_paths["shed_data_manager_config_file"]
-
-        empty_tool_conf = config_join("empty_tool_conf.xml")
-
-        tool_conf = config_join("tool_conf.xml")
-
-        _ensure_directory(shed_tool_path)
-
-        sheds_config_path = _configure_sheds_config_file(ctx, config_directory, runnables, **kwds)
-
-        database_location = config_join("galaxy.sqlite")
-        master_api_key = _get_master_api_key(kwds)
-        dependency_dir = os.path.join(config_directory, "deps")
-        _ensure_directory(shed_tool_path)
-        port = _get_port(kwds)
-        template_args = dict(
-            port=port,
-            host=kwds.get("host", "127.0.0.1"),
-            server_name=server_name,
-            temp_directory=config_directory,
-            shed_tool_path=shed_tool_path,
-            database_location=database_location,
-            tool_conf=tool_conf,
-            debug=kwds.get("debug", "true"),
-            id_secret=kwds.get("id_secret", hashlib.md5(str(time.time()).encode("utf-8")).hexdigest()),
-            log_level="DEBUG" if ctx.verbose else "INFO",
-        )
-        tool_config_file = f"{tool_conf},{shed_tool_conf}"
-        # Setup both galaxy_email and older test user test@bx.psu.edu
-        # as admins for command_line, etc...
-        properties = _shared_galaxy_properties(config_directory, kwds, for_tests=for_tests)
-        properties.update(
-            dict(
-                server_name="main",
-                enable_celery_tasks="true",
-                ftp_upload_dir_template="${ftp_upload_dir}",
-                ftp_upload_purge="false",
-                ftp_upload_dir=test_data_dir or os.path.abspath("."),
-                ftp_upload_site="Test Data",
-                check_upload_content="false",
-                tool_dependency_dir=dependency_dir,
-                file_path=file_path,
-                new_file_path="${temp_directory}/tmp",
-                tool_config_file=tool_config_file,
-                tool_sheds_config_file=sheds_config_path,
-                manage_dependency_relationships="false",
-                job_working_directory="${temp_directory}/job_working_directory",
-                template_cache_path="${temp_directory}/compiled_templates",
-                citation_cache_type="file",
-                citation_cache_data_dir="${temp_directory}/citations/data",
-                citation_cache_lock_dir="${temp_directory}/citations/lock",
-                database_auto_migrate="true",
-                enable_beta_tool_formats="true",
-                id_secret="${id_secret}",
-                log_level="${log_level}",
-                debug="${debug}",
-                watch_tools="auto",
-                default_job_shell="/bin/bash",  # For conda dependency resolution
-                tool_data_table_config_path=",".join(tool_data_tables) if tool_data_tables else None,
-                data_manager_config_file=",".join(data_manager_config_paths)
-                or None,  # without 'or None' may raise IOError in galaxy (see #946)
-                integrated_tool_panel_config=("${temp_directory}/integrated_tool_panel_conf.xml"),
-                migrated_tools_config=empty_tool_conf,
-                test_data_dir=test_data_dir,  # TODO: make gx respect this
-                shed_tool_data_table_config=shed_tool_data_table_config,
-                shed_data_manager_config_file=shed_data_manager_config_file,
-                outputs_to_working_directory="true",  # this makes Galaxy's files dir RO for dockerized testing
-                object_store_store_by="uuid",
-            )
-        )
-        _handle_container_resolution(ctx, kwds, properties)
-        properties["database_connection"] = _database_connection(database_location, **kwds)
-        # Use a separate SQLite database for the Celery message broker to avoid
-        # write lock contention between gunicorn and Celery workers during startup.
-        amqp_broker_path = config_join("celery_broker.sqlite")
-        properties["amqp_internal_connection"] = f"sqlalchemy+sqlite:///{amqp_broker_path}"
-        if kwds.get("mulled_containers", False):
-            properties["mulled_channels"] = kwds.get("conda_ensure_channels", "")
-
-        _handle_kwd_overrides(properties, kwds)
-
-        # TODO: consider following property
-        # watch_tool = False
-        # datatypes_config_file = config/datatypes_conf.xml
-        # welcome_url = /static/welcome.html
-        # logo_url = /
-        # sanitize_all_html = True
-        # serve_xss_vulnerable_mimetypes = False
-        # track_jobs_in_database = None
-        # retry_job_output_collection = 0
-
-        env = _build_env_for_galaxy(properties, template_args)
-        env.update(install_env)
-        env["GALAXY_DEVELOPMENT_ENVIRONMENT"] = "1"
-        # Following are needed in 18.01 to prevent Galaxy from changing log and pid.
-        # https://github.com/galaxyproject/planemo/issues/788
-        env["GALAXY_LOG"] = log_file
-        env["GALAXY_PID"] = pid_file
-        write_galaxy_config(
+        artifacts = _prepare_managed_galaxy_config(
+            ctx=ctx,
+            config_directory=config_directory,
+            runnables=runnables,
+            test_data_dir=test_data_dir,
+            tool_data_tables=tool_data_tables,
+            data_manager_config_paths=data_manager_config_paths,
             galaxy_root=galaxy_root,
-            properties=properties,
-            env=env,
+            for_tests=for_tests,
+            embedded=False,
             kwds=kwds,
-            template_args=template_args,
-            config_join=config_join,
         )
-
-        _write_tool_conf(ctx, all_tool_paths, tool_conf)
-        write_file(empty_tool_conf, EMPTY_TOOL_CONF_TEMPLATE)
-
-        shed_tool_conf_contents = _sub(SHED_TOOL_CONF_TEMPLATE, template_args)
-        _write_shed_config_files(
-            shed_tool_conf,
-            shed_tool_conf_contents,
-            shed_tool_data_table_config,
-            shed_data_manager_config_file,
-        )
+        artifacts.env.update(install_env)
 
         yield LocalGalaxyConfig(
             ctx,
-            config_directory,
-            env,
-            test_data_dir,
-            port,
-            server_name,
-            master_api_key,
+            artifacts.config_directory,
+            artifacts.env,
+            artifacts.test_data_dir,
+            artifacts.port,
+            artifacts.server_name,
+            artifacts.master_api_key,
             runnables,
             galaxy_root,
-            kwds,
+            artifacts.kwds,
         )
+
+
+@contextlib.contextmanager
+def embedded_galaxy_config(ctx, runnables, for_tests=False, **kwds):
+    """Generate configuration for a wheel-installed, in-process Galaxy."""
+
+    test_data_dir = _find_test_data(runnables, **kwds)
+    tool_data_tables = _find_tool_data_table(runnables, test_data_dir=test_data_dir, **kwds)
+    data_manager_config_paths = [r.data_manager_conf_path for r in runnables if r.data_manager_conf_path]
+    _configure_mulled_containers(ctx, kwds)
+    kwds["disable_gxits"] = True
+
+    with _config_directory(ctx, **kwds) as config_directory:
+        artifacts = _prepare_managed_galaxy_config(
+            ctx=ctx,
+            config_directory=config_directory,
+            runnables=runnables,
+            test_data_dir=test_data_dir,
+            tool_data_tables=tool_data_tables,
+            data_manager_config_paths=data_manager_config_paths,
+            galaxy_root=None,
+            for_tests=for_tests,
+            embedded=True,
+            kwds=kwds,
+        )
+        yield EmbeddedGalaxyConfig(ctx, artifacts, runnables)
 
 
 def _init_interactivetools_db(path):
@@ -908,6 +1030,9 @@ class BaseGalaxyConfig(GalaxyInterface):
         self._target_version = UNINITIALIZED
         self._target_user_config = UNINITIALIZED
 
+    def wait_for_serve(self):
+        """Wait while a foreground server remains active, if needed."""
+
     @property
     def gi(self):
         assert self.galaxy_url
@@ -1087,12 +1212,64 @@ class BaseManagedGalaxyConfig(BaseGalaxyConfig):
         self.test_data_dir = test_data_dir
         self.port = port
         self.server_name = server_name
+        self.galaxy_root = None
 
     @property
     def log_file(self):
         """Log file used when planemo serves this Galaxy instance."""
         file_name = f"{self.server_name}.log"
         return file_name
+
+    @property
+    def default_use_path_paste(self):
+        return self.user_is_admin
+
+
+class EmbeddedGalaxyConfig(BaseManagedGalaxyConfig):
+    """Configuration and diagnostics for a wheel-installed Galaxy."""
+
+    def __init__(self, ctx, artifacts, runnables):
+        super().__init__(
+            ctx,
+            artifacts.config_directory,
+            artifacts.env,
+            artifacts.test_data_dir,
+            artifacts.port,
+            artifacts.server_name,
+            artifacts.master_api_key,
+            runnables,
+            artifacts.kwds,
+        )
+        self.galaxy_config_file = artifacts.galaxy_config_file
+        self.galaxy_properties = artifacts.galaxy_properties
+        host = artifacts.kwds.get("host", "127.0.0.1")
+        self.galaxy_url = f"http://{host}:{artifacts.port}"
+
+    @property
+    def log_file(self):
+        return os.path.join(self.config_directory, "embedded.log")
+
+    @property
+    def log_contents(self):
+        if not os.path.exists(self.log_file):
+            return ""
+        with open(self.log_file, errors="replace") as log_fh:
+            return log_fh.read()
+
+    @property
+    def service_log_contents(self) -> Dict[str, str]:
+        contents = "".join(deque(self.log_contents.splitlines(keepends=True), SERVICE_LOG_TAIL_LINES)).rstrip()
+        return {"embedded.log": contents} if contents else {}
+
+    def cleanup(self):
+        shutil.rmtree(self.config_directory, CLEANUP_IGNORE_ERRORS)
+
+    def wait_for_serve(self):
+        # Checkout-backed foreground serving blocks inside Galaxy's subprocess;
+        # the in-process runtime has already yielded and must wait explicitly.
+        from .serve import sleep_for_serve
+
+        sleep_for_serve()
 
 
 class DockerGalaxyConfig(BaseManagedGalaxyConfig):
@@ -1383,12 +1560,6 @@ class LocalGalaxyConfig(BaseManagedGalaxyConfig):
 
     def cleanup(self):
         shutil.rmtree(self.config_directory, CLEANUP_IGNORE_ERRORS)
-
-    @property
-    def default_use_path_paste(self):
-        # If Planemo started a local, native Galaxy instance assume files URLs can be
-        # pasted.
-        return self.user_is_admin
 
 
 def _database_connection(database_location, **kwds):

--- a/planemo/galaxy/embedded.py
+++ b/planemo/galaxy/embedded.py
@@ -3,7 +3,6 @@
 import contextlib
 import copy
 import logging
-import multiprocessing
 import os
 import socket
 import threading
@@ -19,6 +18,7 @@ import click
 from planemo.config import OptionSource
 from planemo.galaxy.config import embedded_galaxy_config
 from planemo.galaxy.ephemeris_sleep import sleep
+from planemo.io import live_runtime_resources
 
 INSTALL_MESSAGE = (
     "No compatible Galaxy release is available yet; install Galaxy packages built from "
@@ -26,7 +26,11 @@ INSTALL_MESSAGE = (
 )
 LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
 WORKER_QUEUES = ("galaxy.internal", "galaxy.external")
+UVICORN_SHUTDOWN_TIMEOUT = 10
+UVICORN_FORCE_EXIT_JOIN_TIMEOUT = 1
+FORK_POOL_JOIN_TIMEOUT = 5
 CLEANUP_DIAGNOSTIC_TIMEOUT = 30
+CLEANUP_DIAGNOSTIC_THREAD_JOIN_TIMEOUT = 1
 
 
 @dataclass(frozen=True)
@@ -259,7 +263,7 @@ def _start_uvicorn(dependencies, asgi_app, sock) -> _UvicornRuntime:
         port=port,
         access_log=False,
         log_config=None,
-        timeout_graceful_shutdown=10,
+        timeout_graceful_shutdown=UVICORN_SHUTDOWN_TIMEOUT,
     )
     server = dependencies.uvicorn_server(uvicorn_config)
     errors: list[BaseException] = []
@@ -278,10 +282,10 @@ def _start_uvicorn(dependencies, asgi_app, sock) -> _UvicornRuntime:
 def _stop_uvicorn(ctx, runtime: _UvicornRuntime):
     runtime.server.should_exit = True
     try:
-        runtime.thread.join(timeout=10)
+        runtime.thread.join(timeout=UVICORN_SHUTDOWN_TIMEOUT)
     except KeyboardInterrupt:
         runtime.server.force_exit = True
-        runtime.thread.join(timeout=1)
+        runtime.thread.join(timeout=UVICORN_FORCE_EXIT_JOIN_TIMEOUT)
     if runtime.thread.is_alive():
         ctx.vlog("Embedded Galaxy's uvicorn thread did not exit within 10 seconds.")
 
@@ -331,7 +335,7 @@ def _stop_fork_pool(celery_app):
     fork_pool = getattr(celery_app, "fork_pool", None)
     if fork_pool is not None:
         fork_pool.stop()
-        fork_pool.join(timeout=5)
+        fork_pool.join(timeout=FORK_POOL_JOIN_TIMEOUT)
 
 
 def _cleanup(ctx, description, operation):
@@ -343,14 +347,15 @@ def _cleanup(ctx, description, operation):
         ctx.vlog(f"Failed while {description}.", exception=exc)
 
 
+def _enter_cleanup_context(cleanup_stack, ctx, description, manager):
+    value = manager.__enter__()
+    cleanup_stack.callback(_cleanup, ctx, description, lambda: manager.__exit__(None, None, None))
+    return value
+
+
 def _report_slow_cleanup(ctx, timeout):
     current_thread = threading.current_thread()
-    thread_names = sorted(
-        thread.name for thread in threading.enumerate() if thread is not current_thread and thread.is_alive()
-    )
-    process_names = sorted(
-        f"{process.name} (pid={process.pid})" for process in multiprocessing.active_children() if process.is_alive()
-    )
+    thread_names, process_names = live_runtime_resources(exclude_threads=(current_thread,))
     active_threads = ", ".join(thread_names) or "none"
     active_processes = ", ".join(process_names) or "none"
     ctx.log(
@@ -371,7 +376,7 @@ def _cleanup_diagnostic_budget(ctx, timeout=CLEANUP_DIAGNOSTIC_TIMEOUT):
     finally:
         timer.cancel()
         with contextlib.suppress(KeyboardInterrupt):
-            timer.join(timeout=1)
+            timer.join(timeout=CLEANUP_DIAGNOSTIC_THREAD_JOIN_TIMEOUT)
 
 
 def _validate_application(dependencies, galaxy_app):
@@ -399,16 +404,31 @@ def serve_embedded(ctx, runnables=None, **kwds):
     kwds["host"] = bound_host
     kwds["port"] = bound_port
     cleanup_stack = contextlib.ExitStack()
-    cleanup_stack.callback(sock.close)
+    cleanup_stack.callback(_cleanup, ctx, "closing the embedded Galaxy socket", sock.close)
     dependencies = None
     web_app = None
     worker_runtime = None
     uvicorn_runtime = None
     previous_global_app = None
     try:
-        config = cleanup_stack.enter_context(embedded_galaxy_config(ctx, runnables, **kwds))
-        cleanup_stack.enter_context(_patched_environment(config.env))
-        cleanup_stack.enter_context(_embedded_logging(ctx, config.log_file))
+        config = _enter_cleanup_context(
+            cleanup_stack,
+            ctx,
+            "cleaning up the embedded Galaxy configuration",
+            embedded_galaxy_config(ctx, runnables, **kwds),
+        )
+        _enter_cleanup_context(
+            cleanup_stack,
+            ctx,
+            "restoring the embedded Galaxy environment",
+            _patched_environment(config.env),
+        )
+        _enter_cleanup_context(
+            cleanup_stack,
+            ctx,
+            "restoring embedded Galaxy logging",
+            _embedded_logging(ctx, config.log_file),
+        )
         dependencies = _load_runtime_dependencies()
         previous_global_app = dependencies.galaxy_app_module.app
         try:
@@ -461,7 +481,7 @@ def serve_embedded(ctx, runnables=None, **kwds):
                 _cleanup(ctx, "shutting down Galaxy", galaxy_app.shutdown)
                 if dependencies.galaxy_app_module.app is galaxy_app:
                     dependencies.galaxy_app_module.app = previous_global_app
-            _cleanup(ctx, "restoring embedded Galaxy state", cleanup_stack.close)
+            cleanup_stack.close()
 
 
 __all__ = (

--- a/planemo/galaxy/embedded.py
+++ b/planemo/galaxy/embedded.py
@@ -39,6 +39,7 @@ class _RuntimeDependencies:
     build_galaxy_web_app: Any
     galaxy_app_module: Any
     celery_app: Any
+    celery_worker_state: Any
     start_worker: Any
     worker_controller: Any
     uvicorn_config: Any
@@ -55,6 +56,7 @@ class _UvicornRuntime:
 @dataclass
 class _CeleryWorkerRuntime:
     context: Any
+    worker_state: Any = None
     controller: Any = None
     entered: bool = False
 
@@ -98,6 +100,7 @@ def _load_runtime_dependencies() -> _RuntimeDependencies:
             start_worker,
             TestWorkController,
         )
+        from celery.worker import state as celery_worker_state
         from galaxy import app as galaxy_app_module
         from galaxy.celery import celery_app
         from galaxy.webapps.galaxy.fast_factory import build_galaxy_web_app
@@ -112,6 +115,7 @@ def _load_runtime_dependencies() -> _RuntimeDependencies:
         build_galaxy_web_app=build_galaxy_web_app,
         galaxy_app_module=galaxy_app_module,
         celery_app=celery_app,
+        celery_worker_state=celery_worker_state,
         start_worker=start_worker,
         worker_controller=TestWorkController,
         uvicorn_config=UvicornConfig,
@@ -293,7 +297,7 @@ def _stop_uvicorn(ctx, runtime: _UvicornRuntime):
 
 def _start_celery_worker(dependencies) -> _CeleryWorkerRuntime:
     """Start Celery while retaining a controller for partial-entry cleanup."""
-    runtime = _CeleryWorkerRuntime(context=None)
+    runtime = _CeleryWorkerRuntime(context=None, worker_state=dependencies.celery_worker_state)
     worker_kwds = {
         "pool": "solo",
         "concurrency": 1,
@@ -316,11 +320,22 @@ def _start_celery_worker(dependencies) -> _CeleryWorkerRuntime:
         runtime.context.__enter__()
         runtime.entered = True
     except BaseException:
-        if runtime.controller is not None:
-            with contextlib.suppress(Exception):
-                runtime.controller.terminate()
+        with contextlib.suppress(Exception):
+            _terminate_celery_worker(runtime)
         raise
     return runtime
+
+
+def _terminate_celery_worker(runtime: _CeleryWorkerRuntime):
+    try:
+        if runtime.controller is not None:
+            runtime.controller.terminate()
+    finally:
+        # celery.contrib.testing.worker leaves this process-global flag set to
+        # integer 0 when its shutdown join times out. Celery treats 0 as a
+        # termination request by identity, poisoning the next in-process worker.
+        if runtime.worker_state is not None:
+            runtime.worker_state.should_terminate = None
 
 
 def _stop_celery_worker(runtime: _CeleryWorkerRuntime):
@@ -328,23 +343,29 @@ def _stop_celery_worker(runtime: _CeleryWorkerRuntime):
         try:
             runtime.context.__exit__(None, None, None)
         except BaseException:
-            if runtime.controller is not None:
-                with contextlib.suppress(Exception):
-                    runtime.controller.terminate()
+            with contextlib.suppress(Exception):
+                _terminate_celery_worker(runtime)
             raise
         finally:
             runtime.entered = False
     elif runtime.controller is not None:
-        runtime.controller.terminate()
+        _terminate_celery_worker(runtime)
 
 
 def _stop_fork_pool(celery_app):
     fork_pool = getattr(celery_app, "fork_pool", None)
     if fork_pool is not None:
-        try:
-            fork_pool.stop()
-        finally:
-            fork_pool.join(timeout=FORK_POOL_JOIN_TIMEOUT)
+        fork_pool.stop()
+
+
+def _join_fork_pool(celery_app):
+    fork_pool = getattr(celery_app, "fork_pool", None)
+    if fork_pool is not None:
+        # Pebble currently ignores this timeout for a stopped ProcessPool and
+        # performs unbounded internal joins. Keep passing the requested budget
+        # in case that behavior is fixed, but rely on the slow-cleanup
+        # diagnostic rather than claiming a hard bound here.
+        fork_pool.join(timeout=FORK_POOL_JOIN_TIMEOUT)
 
 
 def _cleanup(ctx, description, operation):
@@ -490,6 +511,11 @@ def serve_embedded(ctx, runnables=None, **kwds):
                     ctx,
                     "stopping Celery's fork pool",
                     lambda: _stop_fork_pool(dependencies.celery_app),
+                )
+                _cleanup(
+                    ctx,
+                    "joining Celery's fork pool",
+                    lambda: _join_fork_pool(dependencies.celery_app),
                 )
             if web_app is not None:
                 galaxy_app = web_app.galaxy_app

--- a/planemo/galaxy/embedded.py
+++ b/planemo/galaxy/embedded.py
@@ -1,0 +1,426 @@
+"""Lifecycle support for running wheel-installed Galaxy inside Planemo."""
+
+import contextlib
+import copy
+import logging
+import os
+import socket
+import threading
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+import click
+
+from planemo.config import OptionSource
+from planemo.galaxy.config import embedded_galaxy_config
+from planemo.galaxy.ephemeris_sleep import sleep
+
+INSTALL_MESSAGE = (
+    "No compatible Galaxy release is available yet; install Galaxy packages built from "
+    "galaxyproject/galaxy#23360 while developing this engine."
+)
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
+WORKER_QUEUES = ("galaxy.internal", "galaxy.external")
+
+
+@dataclass(frozen=True)
+class _RuntimeDependencies:
+    build_galaxy_web_app: Any
+    galaxy_app_module: Any
+    celery_app: Any
+    start_worker: Any
+    worker_controller: Any
+    uvicorn_config: Any
+    uvicorn_server: Any
+
+
+@dataclass
+class _UvicornRuntime:
+    server: Any
+    thread: threading.Thread
+    errors: list[BaseException]
+
+
+@dataclass
+class _CeleryWorkerRuntime:
+    context: Any
+    controller: Any = None
+    entered: bool = False
+
+
+class _ContextVerboseHandler(logging.Handler):
+    """Send records through Planemo's Rich-aware verbose output path."""
+
+    def __init__(self, ctx):
+        super().__init__()
+        self._ctx = ctx
+
+    def emit(self, record):
+        try:
+            self._ctx.vlog(self.format(record))
+        except Exception:
+            self.handleError(record)
+
+
+class _ContextWarningHandler(logging.Handler):
+    """Keep warnings visible while routine embedded logs stay in the file."""
+
+    def __init__(self, ctx):
+        super().__init__(level=logging.WARNING)
+        self._ctx = ctx
+
+    def emit(self, record):
+        try:
+            concise_record = copy.copy(record)
+            concise_record.exc_info = None
+            concise_record.exc_text = None
+            concise_record.stack_info = None
+            self._ctx.log(self.format(concise_record))
+        except Exception:
+            self.handleError(record)
+
+
+def _load_runtime_dependencies() -> _RuntimeDependencies:
+    """Import the optional runtime only after embedded mode is selected."""
+    try:
+        from celery.contrib.testing.worker import (
+            start_worker,
+            TestWorkController,
+        )
+        from galaxy import app as galaxy_app_module
+        from galaxy.celery import celery_app
+        from galaxy.webapps.galaxy.fast_factory import build_galaxy_web_app
+        from uvicorn import Config as UvicornConfig
+        from uvicorn import Server as UvicornServer
+    except ImportError as exc:
+        raise click.ClickException(
+            f"The embedded_galaxy engine requires Galaxy's application packages. {INSTALL_MESSAGE}"
+        ) from exc
+
+    return _RuntimeDependencies(
+        build_galaxy_web_app=build_galaxy_web_app,
+        galaxy_app_module=galaxy_app_module,
+        celery_app=celery_app,
+        start_worker=start_worker,
+        worker_controller=TestWorkController,
+        uvicorn_config=UvicornConfig,
+        uvicorn_server=UvicornServer,
+    )
+
+
+def _option_source(ctx, name) -> Optional[OptionSource]:
+    return ctx.get_option_source(name, None)
+
+
+def _option_was_selected(ctx, kwds, name, neutral_value) -> bool:
+    value = kwds.get(name, neutral_value)
+    source = _option_source(ctx, name)
+    if source is not None:
+        return source != OptionSource.default and value != neutral_value
+    return value != neutral_value
+
+
+def validate_embedded_options(ctx, kwds):
+    """Reject process and checkout options that have no embedded meaning."""
+    if kwds.get("daemon"):
+        raise click.UsageError("--engine embedded_galaxy only supports foreground operation; --daemon is unavailable.")
+
+    host = kwds.get("host", "127.0.0.1")
+    if host not in LOOPBACK_HOSTS:
+        raise click.UsageError("--engine embedded_galaxy only binds to loopback; use --host 127.0.0.1.")
+
+    checkout_options = {
+        "galaxy_root": None,
+        "cwl_galaxy_root": None,
+        "galaxy_python_version": None,
+        "install_galaxy": False,
+        "skip_venv": False,
+        "no_cache_galaxy": False,
+        "galaxy_branch": "master",
+        "galaxy_source": "https://github.com/galaxyproject/galaxy",
+    }
+    selected = [
+        f"--{name}"
+        for name, neutral_value in checkout_options.items()
+        if _option_was_selected(ctx, kwds, name, neutral_value)
+    ]
+    if selected:
+        options = ", ".join(selected)
+        raise click.UsageError(
+            f"--engine embedded_galaxy uses the installed Galaxy package; unsupported option(s): {options}."
+        )
+
+
+def _bind_socket(host, port) -> socket.socket:
+    bind_host = "127.0.0.1" if host == "localhost" else host
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((bind_host, int(port or 0)))
+    except BaseException:
+        sock.close()
+        raise
+    return sock
+
+
+@contextlib.contextmanager
+def _patched_environment(values: Dict[str, str]):
+    missing = object()
+    previous = {key: os.environ.get(key, missing) for key in values}
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        for key, old_value in previous.items():
+            if old_value is missing:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+@contextlib.contextmanager
+def _embedded_logging(ctx, log_file):
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    verbose_handler = _ContextVerboseHandler(ctx) if ctx.verbose else None
+    warning_handler = None if ctx.verbose else _ContextWarningHandler(ctx)
+    if verbose_handler:
+        verbose_handler.setFormatter(formatter)
+    if warning_handler:
+        warning_handler.setFormatter(formatter)
+
+    logger_names = ("galaxy", "celery", "uvicorn")
+    root_loggers = [logging.getLogger(name) for name in logger_names]
+    family_loggers = list(root_loggers)
+    for candidate in logging.Logger.manager.loggerDict.values():
+        if not isinstance(candidate, logging.Logger):
+            continue
+        if any(candidate.name.startswith(f"{name}.") for name in logger_names):
+            family_loggers.append(candidate)
+    family_loggers = list(dict.fromkeys(family_loggers))
+    galaxy_app_logger = logging.getLogger("galaxy.app")
+    app_guard_handler = logging.NullHandler()
+    previous_levels = {logger: logger.level for logger in family_loggers}
+    previous_propagation = {logger: logger.propagate for logger in family_loggers}
+    previous_handlers = {logger: list(logger.handlers) for logger in family_loggers}
+    try:
+        # UniverseApplication calls basicConfig() when its own logger has no
+        # direct handler. A no-op direct handler prevents it from replacing
+        # Planemo's root logging configuration; records still propagate to the
+        # file and optional verbose handlers on the ``galaxy`` parent.
+        for logger in family_loggers:
+            for handler in previous_handlers[logger]:
+                logger.removeHandler(handler)
+            if logger in root_loggers:
+                logger.setLevel(logging.DEBUG if ctx.verbose else logging.INFO)
+                logger.propagate = False
+            else:
+                logger.setLevel(logging.NOTSET)
+                logger.propagate = True
+        galaxy_app_logger.addHandler(app_guard_handler)
+        for logger in root_loggers:
+            logger.addHandler(file_handler)
+            if verbose_handler:
+                logger.addHandler(verbose_handler)
+            if warning_handler:
+                logger.addHandler(warning_handler)
+        yield
+    finally:
+        galaxy_app_logger.removeHandler(app_guard_handler)
+        for logger in root_loggers:
+            if file_handler in logger.handlers:
+                logger.removeHandler(file_handler)
+            if verbose_handler and verbose_handler in logger.handlers:
+                logger.removeHandler(verbose_handler)
+            if warning_handler and warning_handler in logger.handlers:
+                logger.removeHandler(warning_handler)
+        for logger in family_loggers:
+            logger.setLevel(previous_levels[logger])
+            logger.propagate = previous_propagation[logger]
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+            for handler in previous_handlers[logger]:
+                logger.addHandler(handler)
+        file_handler.close()
+
+
+def _start_uvicorn(dependencies, asgi_app, sock) -> _UvicornRuntime:
+    host, port = sock.getsockname()[:2]
+    uvicorn_config = dependencies.uvicorn_config(
+        asgi_app,
+        host=host,
+        port=port,
+        access_log=False,
+        log_config=None,
+        timeout_graceful_shutdown=10,
+    )
+    server = dependencies.uvicorn_server(uvicorn_config)
+    errors: list[BaseException] = []
+
+    def run_server():
+        try:
+            server.run(sockets=[sock])
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_server, name="planemo-embedded-uvicorn", daemon=True)
+    thread.start()
+    return _UvicornRuntime(server=server, thread=thread, errors=errors)
+
+
+def _stop_uvicorn(ctx, runtime: _UvicornRuntime):
+    runtime.server.should_exit = True
+    try:
+        runtime.thread.join(timeout=10)
+    except KeyboardInterrupt:
+        runtime.server.force_exit = True
+        runtime.thread.join(timeout=1)
+    if runtime.thread.is_alive():
+        ctx.vlog("Embedded Galaxy's uvicorn thread did not exit within 10 seconds.")
+
+
+def _start_celery_worker(dependencies) -> _CeleryWorkerRuntime:
+    """Start Celery while retaining a controller for partial-entry cleanup."""
+    runtime = _CeleryWorkerRuntime(context=None)
+    worker_kwds = {
+        "pool": "solo",
+        "concurrency": 1,
+        "queues": WORKER_QUEUES,
+        "perform_ping_check": False,
+    }
+    if dependencies.worker_controller is not None:
+        controller_class = dependencies.worker_controller
+
+        class PlanemoWorkerController(controller_class):
+            def __init__(self, *args, **kwds):
+                super().__init__(*args, **kwds)
+                runtime.controller = self
+
+        worker_kwds["WorkController"] = PlanemoWorkerController
+
+    runtime.context = dependencies.start_worker(dependencies.celery_app, **worker_kwds)
+    try:
+        runtime.context.__enter__()
+        runtime.entered = True
+    except BaseException:
+        if runtime.controller is not None:
+            with contextlib.suppress(Exception):
+                runtime.controller.terminate()
+        raise
+    return runtime
+
+
+def _stop_celery_worker(runtime: _CeleryWorkerRuntime):
+    if runtime.entered:
+        try:
+            runtime.context.__exit__(None, None, None)
+        finally:
+            runtime.entered = False
+    elif runtime.controller is not None:
+        runtime.controller.terminate()
+
+
+def _stop_fork_pool(celery_app):
+    fork_pool = getattr(celery_app, "fork_pool", None)
+    if fork_pool is not None:
+        fork_pool.stop()
+        fork_pool.join(timeout=5)
+
+
+def _cleanup(ctx, description, operation):
+    try:
+        operation()
+    except KeyboardInterrupt:
+        ctx.vlog(f"Interrupted while {description}; continuing embedded Galaxy cleanup.")
+    except Exception as exc:
+        ctx.vlog(f"Failed while {description}.", exception=exc)
+
+
+def _validate_application(dependencies, galaxy_app):
+    if not galaxy_app.is_job_handler:
+        raise RuntimeError("Embedded Galaxy was not configured as a job handler.")
+    if getattr(galaxy_app.application_stack, "name", None) == "Gunicorn":
+        raise RuntimeError("Embedded Galaxy cannot use the Gunicorn application stack.")
+    if dependencies.galaxy_app_module.app is not galaxy_app:
+        raise RuntimeError("Galaxy did not register the embedded application as its process-global app.")
+
+
+@contextlib.contextmanager
+def serve_embedded(ctx, runnables=None, **kwds):
+    """Construct, serve, and completely tear down one embedded Galaxy app."""
+    if runnables is None:
+        runnables = []
+    validate_embedded_options(ctx, kwds)
+
+    host = kwds.get("host", "127.0.0.1")
+    port = kwds.get("port")
+    if _option_source(ctx, "port") == OptionSource.default:
+        port = 0
+    sock = _bind_socket(host, port)
+    bound_host, bound_port = sock.getsockname()[:2]
+    kwds["host"] = bound_host
+    kwds["port"] = bound_port
+    try:
+        with embedded_galaxy_config(ctx, runnables, **kwds) as config:
+            with _patched_environment(config.env), _embedded_logging(ctx, config.log_file):
+                dependencies = _load_runtime_dependencies()
+                web_app = None
+                worker_runtime = None
+                uvicorn_runtime = None
+                previous_global_app = dependencies.galaxy_app_module.app
+                try:
+                    try:
+                        web_app = dependencies.build_galaxy_web_app(
+                            config.galaxy_properties,
+                            global_conf={"__file__": config.galaxy_config_file},
+                            register_shutdown_at_exit=False,
+                        )
+                    except BaseException:
+                        if dependencies.galaxy_app_module.app is not previous_global_app:
+                            dependencies.galaxy_app_module.app = previous_global_app
+                        raise
+                    galaxy_app = web_app.galaxy_app
+                    _validate_application(dependencies, galaxy_app)
+
+                    worker_runtime = _start_celery_worker(dependencies)
+
+                    uvicorn_runtime = _start_uvicorn(dependencies, web_app.asgi_app, sock)
+                    if not sleep(
+                        config.galaxy_url,
+                        verbose=ctx.verbose,
+                        timeout=kwds.get("galaxy_startup_timeout", 900),
+                    ):
+                        if uvicorn_runtime.errors:
+                            raise RuntimeError(
+                                "Embedded Galaxy's uvicorn server failed during startup."
+                            ) from uvicorn_runtime.errors[0]
+                        raise RuntimeError(
+                            f"Attempted to serve embedded Galaxy at {config.galaxy_url}, but it failed to start."
+                            f"\nGalaxy log contents:\n{config.log_contents}"
+                        )
+                    config.install_workflows()
+                    yield config
+                finally:
+                    if uvicorn_runtime is not None:
+                        _cleanup(ctx, "stopping uvicorn", lambda: _stop_uvicorn(ctx, uvicorn_runtime))
+                    if worker_runtime is not None:
+                        _cleanup(ctx, "stopping the Celery worker", lambda: _stop_celery_worker(worker_runtime))
+                    _cleanup(ctx, "stopping Celery's fork pool", lambda: _stop_fork_pool(dependencies.celery_app))
+                    if web_app is not None:
+                        galaxy_app = web_app.galaxy_app
+                        _cleanup(ctx, "shutting down Galaxy", galaxy_app.shutdown)
+                        if dependencies.galaxy_app_module.app is galaxy_app:
+                            dependencies.galaxy_app_module.app = previous_global_app
+    finally:
+        sock.close()
+
+
+__all__ = (
+    "serve_embedded",
+    "validate_embedded_options",
+)

--- a/planemo/galaxy/embedded.py
+++ b/planemo/galaxy/embedded.py
@@ -190,6 +190,7 @@ def _patched_environment(values: Dict[str, str]):
             if old_value is missing:
                 os.environ.pop(key, None)
             else:
+                assert isinstance(old_value, str)
                 os.environ[key] = old_value
 
 
@@ -308,11 +309,15 @@ def _start_celery_worker(dependencies) -> _CeleryWorkerRuntime:
     if dependencies.worker_controller is not None:
         controller_class = dependencies.worker_controller
 
-        class PlanemoWorkerController(controller_class):
-            def __init__(self, *args, **kwds):
-                super().__init__(*args, **kwds)
-                runtime.controller = self
+        def initialize_controller(self, *args, **kwds):
+            controller_class.__init__(self, *args, **kwds)
+            runtime.controller = self
 
+        PlanemoWorkerController = type(
+            "PlanemoWorkerController",
+            (controller_class,),
+            {"__init__": initialize_controller},
+        )
         worker_kwds["WorkController"] = PlanemoWorkerController
 
     runtime.context = dependencies.start_worker(dependencies.celery_app, **worker_kwds)

--- a/planemo/galaxy/embedded.py
+++ b/planemo/galaxy/embedded.py
@@ -26,6 +26,7 @@ INSTALL_MESSAGE = (
 )
 LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
 WORKER_QUEUES = ("galaxy.internal", "galaxy.external")
+CELERY_WORKER_SHUTDOWN_TIMEOUT = 10
 UVICORN_SHUTDOWN_TIMEOUT = 10
 UVICORN_FORCE_EXIT_JOIN_TIMEOUT = 1
 FORK_POOL_JOIN_TIMEOUT = 5
@@ -287,7 +288,7 @@ def _stop_uvicorn(ctx, runtime: _UvicornRuntime):
         runtime.server.force_exit = True
         runtime.thread.join(timeout=UVICORN_FORCE_EXIT_JOIN_TIMEOUT)
     if runtime.thread.is_alive():
-        ctx.vlog("Embedded Galaxy's uvicorn thread did not exit within 10 seconds.")
+        ctx.vlog(f"Embedded Galaxy's uvicorn thread did not exit within " f"{UVICORN_SHUTDOWN_TIMEOUT:g} seconds.")
 
 
 def _start_celery_worker(dependencies) -> _CeleryWorkerRuntime:
@@ -298,6 +299,7 @@ def _start_celery_worker(dependencies) -> _CeleryWorkerRuntime:
         "concurrency": 1,
         "queues": WORKER_QUEUES,
         "perform_ping_check": False,
+        "shutdown_timeout": CELERY_WORKER_SHUTDOWN_TIMEOUT,
     }
     if dependencies.worker_controller is not None:
         controller_class = dependencies.worker_controller
@@ -325,6 +327,11 @@ def _stop_celery_worker(runtime: _CeleryWorkerRuntime):
     if runtime.entered:
         try:
             runtime.context.__exit__(None, None, None)
+        except BaseException:
+            if runtime.controller is not None:
+                with contextlib.suppress(Exception):
+                    runtime.controller.terminate()
+            raise
         finally:
             runtime.entered = False
     elif runtime.controller is not None:
@@ -334,8 +341,10 @@ def _stop_celery_worker(runtime: _CeleryWorkerRuntime):
 def _stop_fork_pool(celery_app):
     fork_pool = getattr(celery_app, "fork_pool", None)
     if fork_pool is not None:
-        fork_pool.stop()
-        fork_pool.join(timeout=FORK_POOL_JOIN_TIMEOUT)
+        try:
+            fork_pool.stop()
+        finally:
+            fork_pool.join(timeout=FORK_POOL_JOIN_TIMEOUT)
 
 
 def _cleanup(ctx, description, operation):
@@ -367,16 +376,24 @@ def _report_slow_cleanup(ctx, timeout):
 @contextlib.contextmanager
 def _cleanup_diagnostic_budget(ctx, timeout=CLEANUP_DIAGNOSTIC_TIMEOUT):
     """Report live runtime resources if cooperative cleanup exceeds its budget."""
-    timer = threading.Timer(timeout, _report_slow_cleanup, args=(ctx, timeout))
-    timer.name = "planemo-embedded-cleanup-diagnostics"
-    timer.daemon = True
-    timer.start()
+    timer = None
+    timer_started = False
+    try:
+        timer = threading.Timer(timeout, _report_slow_cleanup, args=(ctx, timeout))
+        timer.name = "planemo-embedded-cleanup-diagnostics"
+        timer.daemon = True
+        timer.start()
+        timer_started = True
+    except Exception as exc:
+        with contextlib.suppress(Exception):
+            ctx.vlog("Failed to start embedded Galaxy cleanup diagnostics; continuing cleanup.", exception=exc)
     try:
         yield
     finally:
-        timer.cancel()
-        with contextlib.suppress(KeyboardInterrupt):
-            timer.join(timeout=CLEANUP_DIAGNOSTIC_THREAD_JOIN_TIMEOUT)
+        if timer_started:
+            timer.cancel()
+            with contextlib.suppress(KeyboardInterrupt):
+                timer.join(timeout=CLEANUP_DIAGNOSTIC_THREAD_JOIN_TIMEOUT)
 
 
 def _validate_application(dependencies, galaxy_app):

--- a/planemo/galaxy/embedded.py
+++ b/planemo/galaxy/embedded.py
@@ -3,6 +3,7 @@
 import contextlib
 import copy
 import logging
+import multiprocessing
 import os
 import socket
 import threading
@@ -25,6 +26,7 @@ INSTALL_MESSAGE = (
 )
 LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
 WORKER_QUEUES = ("galaxy.internal", "galaxy.external")
+CLEANUP_DIAGNOSTIC_TIMEOUT = 30
 
 
 @dataclass(frozen=True)
@@ -341,6 +343,37 @@ def _cleanup(ctx, description, operation):
         ctx.vlog(f"Failed while {description}.", exception=exc)
 
 
+def _report_slow_cleanup(ctx, timeout):
+    current_thread = threading.current_thread()
+    thread_names = sorted(
+        thread.name for thread in threading.enumerate() if thread is not current_thread and thread.is_alive()
+    )
+    process_names = sorted(
+        f"{process.name} (pid={process.pid})" for process in multiprocessing.active_children() if process.is_alive()
+    )
+    active_threads = ", ".join(thread_names) or "none"
+    active_processes = ", ".join(process_names) or "none"
+    ctx.log(
+        f"Embedded Galaxy cleanup exceeded {timeout:g} seconds. "
+        f"Active threads: {active_threads}. Active child processes: {active_processes}."
+    )
+
+
+@contextlib.contextmanager
+def _cleanup_diagnostic_budget(ctx, timeout=CLEANUP_DIAGNOSTIC_TIMEOUT):
+    """Report live runtime resources if cooperative cleanup exceeds its budget."""
+    timer = threading.Timer(timeout, _report_slow_cleanup, args=(ctx, timeout))
+    timer.name = "planemo-embedded-cleanup-diagnostics"
+    timer.daemon = True
+    timer.start()
+    try:
+        yield
+    finally:
+        timer.cancel()
+        with contextlib.suppress(KeyboardInterrupt):
+            timer.join(timeout=1)
+
+
 def _validate_application(dependencies, galaxy_app):
     if not galaxy_app.is_job_handler:
         raise RuntimeError("Embedded Galaxy was not configured as a job handler.")
@@ -365,59 +398,70 @@ def serve_embedded(ctx, runnables=None, **kwds):
     bound_host, bound_port = sock.getsockname()[:2]
     kwds["host"] = bound_host
     kwds["port"] = bound_port
+    cleanup_stack = contextlib.ExitStack()
+    cleanup_stack.callback(sock.close)
+    dependencies = None
+    web_app = None
+    worker_runtime = None
+    uvicorn_runtime = None
+    previous_global_app = None
     try:
-        with embedded_galaxy_config(ctx, runnables, **kwds) as config:
-            with _patched_environment(config.env), _embedded_logging(ctx, config.log_file):
-                dependencies = _load_runtime_dependencies()
-                web_app = None
-                worker_runtime = None
-                uvicorn_runtime = None
-                previous_global_app = dependencies.galaxy_app_module.app
-                try:
-                    try:
-                        web_app = dependencies.build_galaxy_web_app(
-                            config.galaxy_properties,
-                            global_conf={"__file__": config.galaxy_config_file},
-                            register_shutdown_at_exit=False,
-                        )
-                    except BaseException:
-                        if dependencies.galaxy_app_module.app is not previous_global_app:
-                            dependencies.galaxy_app_module.app = previous_global_app
-                        raise
-                    galaxy_app = web_app.galaxy_app
-                    _validate_application(dependencies, galaxy_app)
+        config = cleanup_stack.enter_context(embedded_galaxy_config(ctx, runnables, **kwds))
+        cleanup_stack.enter_context(_patched_environment(config.env))
+        cleanup_stack.enter_context(_embedded_logging(ctx, config.log_file))
+        dependencies = _load_runtime_dependencies()
+        previous_global_app = dependencies.galaxy_app_module.app
+        try:
+            web_app = dependencies.build_galaxy_web_app(
+                config.galaxy_properties,
+                global_conf={"__file__": config.galaxy_config_file},
+                register_shutdown_at_exit=False,
+            )
+        except BaseException:
+            if dependencies.galaxy_app_module.app is not previous_global_app:
+                dependencies.galaxy_app_module.app = previous_global_app
+            raise
+        galaxy_app = web_app.galaxy_app
+        _validate_application(dependencies, galaxy_app)
 
-                    worker_runtime = _start_celery_worker(dependencies)
+        worker_runtime = _start_celery_worker(dependencies)
 
-                    uvicorn_runtime = _start_uvicorn(dependencies, web_app.asgi_app, sock)
-                    if not sleep(
-                        config.galaxy_url,
-                        verbose=ctx.verbose,
-                        timeout=kwds.get("galaxy_startup_timeout", 900),
-                    ):
-                        if uvicorn_runtime.errors:
-                            raise RuntimeError(
-                                "Embedded Galaxy's uvicorn server failed during startup."
-                            ) from uvicorn_runtime.errors[0]
-                        raise RuntimeError(
-                            f"Attempted to serve embedded Galaxy at {config.galaxy_url}, but it failed to start."
-                            f"\nGalaxy log contents:\n{config.log_contents}"
-                        )
-                    config.install_workflows()
-                    yield config
-                finally:
-                    if uvicorn_runtime is not None:
-                        _cleanup(ctx, "stopping uvicorn", lambda: _stop_uvicorn(ctx, uvicorn_runtime))
-                    if worker_runtime is not None:
-                        _cleanup(ctx, "stopping the Celery worker", lambda: _stop_celery_worker(worker_runtime))
-                    _cleanup(ctx, "stopping Celery's fork pool", lambda: _stop_fork_pool(dependencies.celery_app))
-                    if web_app is not None:
-                        galaxy_app = web_app.galaxy_app
-                        _cleanup(ctx, "shutting down Galaxy", galaxy_app.shutdown)
-                        if dependencies.galaxy_app_module.app is galaxy_app:
-                            dependencies.galaxy_app_module.app = previous_global_app
+        uvicorn_runtime = _start_uvicorn(dependencies, web_app.asgi_app, sock)
+        if not sleep(
+            config.galaxy_url,
+            verbose=ctx.verbose,
+            timeout=kwds.get("galaxy_startup_timeout", 900),
+        ):
+            if uvicorn_runtime.errors:
+                raise RuntimeError(
+                    "Embedded Galaxy's uvicorn server failed during startup."
+                ) from uvicorn_runtime.errors[0]
+            raise RuntimeError(
+                f"Attempted to serve embedded Galaxy at {config.galaxy_url}, but it failed to start."
+                f"\nGalaxy log contents:\n{config.log_contents}"
+            )
+        config.install_workflows()
+        yield config
     finally:
-        sock.close()
+        with _cleanup_diagnostic_budget(ctx):
+            if uvicorn_runtime is not None:
+                _cleanup(ctx, "stopping uvicorn", lambda: _stop_uvicorn(ctx, uvicorn_runtime))
+            if worker_runtime is not None:
+                _cleanup(ctx, "stopping the Celery worker", lambda: _stop_celery_worker(worker_runtime))
+            if dependencies is not None:
+                _cleanup(
+                    ctx,
+                    "stopping Celery's fork pool",
+                    lambda: _stop_fork_pool(dependencies.celery_app),
+                )
+            if web_app is not None:
+                galaxy_app = web_app.galaxy_app
+                # Galaxy registers model-engine disposal as part of application
+                # shutdown; do not dispose it twice here.
+                _cleanup(ctx, "shutting down Galaxy", galaxy_app.shutdown)
+                if dependencies.galaxy_app_module.app is galaxy_app:
+                    dependencies.galaxy_app_module.app = previous_global_app
+            _cleanup(ctx, "restoring embedded Galaxy state", cleanup_stack.close)
 
 
 __all__ = (

--- a/planemo/galaxy/serve.py
+++ b/planemo/galaxy/serve.py
@@ -9,6 +9,7 @@ from planemo import (
     network_util,
 )
 from .config import galaxy_config
+from .embedded import serve_embedded
 from .ephemeris_sleep import sleep
 from .run import (
     log_galaxy_command,
@@ -57,6 +58,10 @@ def _check_startup_command(config, startup_process, exit_code):
 @contextlib.contextmanager
 def _serve(ctx, runnables, **kwds):
     engine = kwds.get("engine", "galaxy")
+    if engine == "embedded_galaxy":
+        with serve_embedded(ctx, runnables, **kwds) as config:
+            yield config
+        return
     if engine == "docker_galaxy":
         kwds["dockerize"] = True
 

--- a/planemo/io.py
+++ b/planemo/io.py
@@ -4,12 +4,14 @@ import contextlib
 import errno
 import fnmatch
 import math
+import multiprocessing
 import os
 import shutil
 import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from io import StringIO
 from sys import platform as _platform
@@ -62,6 +64,21 @@ def termination_timeout() -> float:
         warn(f"Ignoring invalid {TERMINATION_TIMEOUT_ENVIRON_KEY} [{configured}]")
         return DEFAULT_TERMINATION_TIMEOUT
     return timeout
+
+
+def live_runtime_resources(exclude_threads=(), exclude_pids=()):
+    """Return names of live threads and multiprocessing children not excluded."""
+    excluded_threads = set(exclude_threads)
+    excluded_pids = set(exclude_pids)
+    thread_names = sorted(
+        thread.name for thread in threading.enumerate() if thread not in excluded_threads and thread.is_alive()
+    )
+    process_names = sorted(
+        f"{process.name} (pid={process.pid})"
+        for process in multiprocessing.active_children()
+        if process.pid not in excluded_pids and process.is_alive()
+    )
+    return thread_names, process_names
 
 
 def args_to_str(args):

--- a/planemo/options.py
+++ b/planemo/options.py
@@ -70,7 +70,7 @@ def run_engine_option():
     """Annotate click command as consume the --engine option."""
     return planemo_option(
         "--engine",
-        type=click.Choice(["galaxy", "docker_galaxy", "cwltool", "toil", "external_galaxy"]),
+        type=click.Choice(["galaxy", "embedded_galaxy", "docker_galaxy", "cwltool", "toil", "external_galaxy"]),
         default=None,
         use_global_config=True,
         help=(
@@ -100,7 +100,7 @@ def serve_engine_option():
     """
     return planemo_option(
         "--engine",
-        type=click.Choice(["galaxy", "docker_galaxy", "external_galaxy"]),
+        type=click.Choice(["galaxy", "embedded_galaxy", "docker_galaxy", "external_galaxy"]),
         default="galaxy",
         use_global_config=True,
         use_env_var=True,

--- a/planemo/runnable.py
+++ b/planemo/runnable.py
@@ -205,6 +205,8 @@ def for_path(path: str) -> Union[Runnable, List[Runnable]]:
         runnable_type = RunnableType.galaxy_datamanager
     elif looks_like_a_tool_xml(path):
         runnable_type = RunnableType.galaxy_tool
+    elif is_a_yaml_with_class(path, ["GalaxyTool"]):
+        runnable_type = RunnableType.galaxy_tool
     elif is_a_yaml_with_class(path, ["GalaxyWorkflow"]):
         runnable_type = RunnableType.galaxy_workflow
     elif path.endswith(".ga"):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 addopts = --verbosity=1 --ignore planemo/commands/cmd_test.py
 markers =
+    embedded_galaxy: tests requiring a package-installed embedded Galaxy runtime
     tests_galaxy_branch: test against a specific Galaxy branch

--- a/tests/data/tools/embedded_echo.yml
+++ b/tests/data/tools/embedded_echo.yml
@@ -1,0 +1,20 @@
+class: GalaxyTool
+id: embedded_echo
+name: Embedded echo
+version: "1.0"
+shell_command: echo "$(inputs.message)" > output.txt
+inputs:
+  - name: message
+    type: text
+outputs:
+  output:
+    from_work_dir: output.txt
+    format: txt
+tests:
+  - inputs:
+      message: hello embedded Galaxy
+    outputs:
+      output:
+        asserts:
+          has_text:
+            text: hello embedded Galaxy

--- a/tests/test_cmd_serve.py
+++ b/tests/test_cmd_serve.py
@@ -1,6 +1,4 @@
 import os
-import signal
-import subprocess
 import tempfile
 import time
 import uuid
@@ -16,6 +14,7 @@ from .test_utils import (
     get_entry_point_target,
     launch_and_wait_for_galaxy,
     mark,
+    planemo_subprocess,
     PROJECT_TEMPLATES_DIR,
     run_verbosely,
     safe_rmtree,
@@ -53,24 +52,17 @@ class UsesServeCommand:
             self._check_exit_code(serve_cmd)
 
     def _run_subprocess(self, serve_cmd):
-        serve_cmd.insert(0, "planemo")
-        stdout_file = tempfile.NamedTemporaryFile(mode="wb+", suffix="_planemo_stdout")
-        popen = subprocess.Popen(
-            serve_cmd, env=os.environ.copy(), stdout=stdout_file, stderr=stdout_file, preexec_fn=os.setsid
-        )
+        managed_process = planemo_subprocess(serve_cmd)
+        popen = managed_process.process
         if popen.poll() is not None:
-            stdout_file.seek(0)
+            managed_process.close()
             raise Exception(
-                f"planemo serve command failed. exit_code: {popen.returncode}, output: {stdout_file.read().decode('utf-8')}"
+                f"planemo serve command failed. exit_code: {popen.returncode}, output: {managed_process.read_output()}"
             )
 
         def cleanup():
-            pgrp = os.getpgid(popen.pid)
-            os.killpg(pgrp, signal.SIGINT)
-            stdout_file.seek(0)
-            print(stdout_file.read().decode("utf-8"))
-            popen.terminate()
-            popen.kill()
+            managed_process.close()
+            print(managed_process.read_output())
 
         self._cleanup_hooks.append(cleanup)
 

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os
 import sys
+import threading
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -255,6 +256,29 @@ def test_partial_worker_entry_terminates_the_captured_controller():
         embedded._start_celery_worker(dependencies)
 
     assert events == ["controller created", "controller terminated"]
+
+
+def test_slow_cleanup_reports_live_runtime_resources():
+    reported = threading.Event()
+
+    class DiagnosticContext(_Context):
+        def log(self, message, *args):
+            super().log(message, *args)
+            reported.set()
+
+    ctx = DiagnosticContext()
+    with embedded._cleanup_diagnostic_budget(ctx, timeout=0.01):
+        assert reported.wait(timeout=1)
+
+    assert len(ctx.messages) == 1
+    message = ctx.messages[0]
+    assert "cleanup exceeded 0.01 seconds" in message
+    assert "Active threads:" in message
+    assert "MainThread" in message
+    assert "Active child processes:" in message
+    assert not any(
+        thread.name == "planemo-embedded-cleanup-diagnostics" and thread.is_alive() for thread in threading.enumerate()
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -343,6 +343,47 @@ def test_embedded_test_reuses_one_application_for_inner_test_groups():
     assert engine._active_embedded_runnable_uris == set()
 
 
+def test_galaxy_test_results_remain_paired_with_mixed_case_types():
+    from planemo.engine.galaxy import EmbeddedGalaxyEngine
+    from planemo.engine.interface import BaseEngine
+    from planemo.runnable import ExternalGalaxyToolTestCase
+
+    config = object()
+    native_runnable = SimpleNamespace(uri="native")
+    native_case = ExternalGalaxyToolTestCase(native_runnable, "native", "1.0", 0, {})
+    expanded_case_one = ExternalGalaxyToolTestCase(native_runnable, "native", "1.0", 0, {})
+    expanded_case_two = ExternalGalaxyToolTestCase(native_runnable, "native", "1.0", 1, {})
+    workflow_case = SimpleNamespace(runnable=SimpleNamespace(uri="workflow"))
+    native_results = {
+        expanded_case_one: {"id": "native-0", "status": "success"},
+        expanded_case_two: {"id": "native-1", "status": "success"},
+    }
+    workflow_result = object()
+    engine = EmbeddedGalaxyEngine(_Context(), engine="embedded_galaxy")
+    engine._active_embedded_config = config
+    engine._active_embedded_runnable_uris = {"native"}
+
+    with (
+        patch.object(BaseEngine, "_run_test_cases", return_value=[workflow_result]),
+        patch(
+            "planemo.engine.galaxy.expand_test_cases",
+            return_value=[expanded_case_one, expanded_case_two],
+        ),
+        patch.object(
+            engine,
+            "_run_galaxy_tool_test_case",
+            side_effect=lambda config, case, timeout, register: register(native_results[case]),
+        ),
+    ):
+        results = engine._collect_test_results([native_case, workflow_case], test_timeout=30)
+
+    assert results == [
+        (expanded_case_one, native_results[expanded_case_one]),
+        (expanded_case_two, native_results[expanded_case_two]),
+        (workflow_case, workflow_result),
+    ]
+
+
 def test_embedded_test_rejects_unsupported_runnable_before_startup():
     from planemo.engine.galaxy import EmbeddedGalaxyEngine
 

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -168,6 +168,7 @@ def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
         "concurrency": 1,
         "queues": ("galaxy.internal", "galaxy.external"),
         "perform_ping_check": False,
+        "shutdown_timeout": 10,
     }
     assert app_module.app is None
     assert os.environ.get("GALAXY_CONFIG_FILE") == old_config_file
@@ -258,6 +259,48 @@ def test_partial_worker_entry_terminates_the_captured_controller():
     assert events == ["controller created", "controller terminated"]
 
 
+def test_worker_exit_failure_terminates_the_captured_controller():
+    events = []
+
+    class FailingWorkerContext:
+        def __exit__(self, exc_type, exc, traceback):
+            events.append("worker exit")
+            raise RuntimeError("worker shutdown failed")
+
+    class Controller:
+        def terminate(self):
+            events.append("controller terminated")
+
+    runtime = embedded._CeleryWorkerRuntime(
+        context=FailingWorkerContext(),
+        controller=Controller(),
+        entered=True,
+    )
+
+    with pytest.raises(RuntimeError, match="worker shutdown failed"):
+        embedded._stop_celery_worker(runtime)
+
+    assert events == ["worker exit", "controller terminated"]
+    assert runtime.entered is False
+
+
+def test_fork_pool_join_is_attempted_after_stop_failure():
+    events = []
+
+    class FailingForkPool:
+        def stop(self):
+            events.append("pool stop")
+            raise RuntimeError("pool stop failed")
+
+        def join(self, timeout):
+            events.append(("pool join", timeout))
+
+    with pytest.raises(RuntimeError, match="pool stop failed"):
+        embedded._stop_fork_pool(SimpleNamespace(fork_pool=FailingForkPool()))
+
+    assert events == ["pool stop", ("pool join", embedded.FORK_POOL_JOIN_TIMEOUT)]
+
+
 def test_slow_cleanup_reports_live_runtime_resources():
     reported = threading.Event()
 
@@ -279,6 +322,26 @@ def test_slow_cleanup_reports_live_runtime_resources():
     assert not any(
         thread.name == "planemo-embedded-cleanup-diagnostics" and thread.is_alive() for thread in threading.enumerate()
     )
+
+
+def test_cleanup_continues_if_diagnostic_thread_cannot_start(monkeypatch):
+    events = []
+
+    class FailingTimer:
+        def __init__(self, *args, **kwds):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread allocation failed")
+
+    monkeypatch.setattr(threading, "Timer", FailingTimer)
+    ctx = _Context()
+
+    with embedded._cleanup_diagnostic_budget(ctx):
+        events.append("cleanup ran")
+
+    assert events == ["cleanup ran"]
+    assert ctx.messages == ["Failed to start embedded Galaxy cleanup diagnostics; continuing cleanup."]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -1,0 +1,399 @@
+"""Unit tests for the embedded Galaxy lifecycle."""
+
+import contextlib
+import logging
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import click
+import pytest
+
+from planemo.config import OptionSource
+from planemo.galaxy import embedded
+
+
+class _Context:
+    verbose = False
+
+    def __init__(self, option_sources=None):
+        self.messages = []
+        self.option_sources = option_sources or {}
+
+    def get_option_source(self, name, default=None):
+        return self.option_sources.get(name, default)
+
+    def vlog(self, message, *args, **kwds):
+        self.messages.append(message)
+
+    def log(self, message, *args):
+        self.messages.append(message)
+
+
+class _WorkerContext:
+    def __init__(self, events):
+        self.events = events
+
+    def __enter__(self):
+        self.events.append("worker enter")
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.events.append("worker exit")
+
+
+class _ForkPool:
+    def __init__(self, events):
+        self.events = events
+
+    def stop(self):
+        self.events.append("pool stop")
+
+    def join(self, timeout):
+        self.events.append(("pool join", timeout))
+
+
+def _lifecycle_fakes(tmp_path, events, *, is_job_handler=True):
+    app = SimpleNamespace(
+        is_job_handler=is_job_handler,
+        application_stack=SimpleNamespace(name="Webless"),
+    )
+    app.shutdown = lambda: events.append("app shutdown")
+    app_module = SimpleNamespace(app=None)
+    celery_app = SimpleNamespace(fork_pool=_ForkPool(events))
+
+    def build_galaxy_web_app(properties, global_conf, register_shutdown_at_exit):
+        events.append(
+            (
+                "build",
+                properties,
+                global_conf,
+                register_shutdown_at_exit,
+                os.environ.get("GALAXY_CONFIG_FILE"),
+            )
+        )
+        app_module.app = app
+        return SimpleNamespace(galaxy_app=app, asgi_app=object())
+
+    def start_worker(celery_application, **kwds):
+        events.append(("worker config", celery_application, kwds))
+        return _WorkerContext(events)
+
+    dependencies = embedded._RuntimeDependencies(
+        build_galaxy_web_app=build_galaxy_web_app,
+        galaxy_app_module=app_module,
+        celery_app=celery_app,
+        start_worker=start_worker,
+        worker_controller=None,
+        uvicorn_config=None,
+        uvicorn_server=None,
+    )
+    config_file = tmp_path / "galaxy.yml"
+    config_file.write_text("galaxy: {}")
+    log_file = tmp_path / "embedded.log"
+    config = SimpleNamespace(
+        env={"GALAXY_CONFIG_FILE": str(config_file)},
+        galaxy_config_file=str(config_file),
+        galaxy_properties={"server_name": "main"},
+        galaxy_url="http://localhost:12345",
+        log_file=str(log_file),
+        log_contents="",
+    )
+    config.install_workflows = lambda: events.append("install workflows")
+
+    @contextlib.contextmanager
+    def config_context(ctx, runnables, **kwds):
+        events.append(("config enter", kwds["port"], kwds["host"]))
+        try:
+            yield config
+        finally:
+            events.append("config exit")
+
+    uvicorn_runtime = SimpleNamespace(errors=[])
+    return dependencies, config_context, uvicorn_runtime, app_module, config_file
+
+
+def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
+    events = []
+    dependencies, config_context, uvicorn_runtime, app_module, config_file = _lifecycle_fakes(tmp_path, events)
+    ctx = _Context({"port": OptionSource.default})
+    old_config_file = os.environ.get("GALAXY_CONFIG_FILE")
+
+    def start_uvicorn(deps, asgi_app, sock):
+        events.append("uvicorn start")
+        return uvicorn_runtime
+
+    def wait_until_ready(url, verbose, timeout):
+        events.append(("ready", url, verbose, timeout, os.environ.get("GALAXY_CONFIG_FILE")))
+        return True
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        patch.object(embedded, "_start_uvicorn", side_effect=start_uvicorn),
+        patch.object(embedded, "_stop_uvicorn", side_effect=lambda ctx, runtime: events.append("uvicorn stop")),
+        patch.object(embedded, "sleep", side_effect=wait_until_ready),
+    ):
+        with embedded.serve_embedded(ctx, [], galaxy_startup_timeout=17, port=9090, host="localhost"):
+            events.append("body")
+
+    event_names = [event if isinstance(event, str) else event[0] for event in events]
+    assert event_names == [
+        "config enter",
+        "build",
+        "worker config",
+        "worker enter",
+        "uvicorn start",
+        "ready",
+        "install workflows",
+        "body",
+        "uvicorn stop",
+        "worker exit",
+        "pool stop",
+        "pool join",
+        "app shutdown",
+        "config exit",
+    ]
+    assert events[0][1] != 9090
+    assert events[0][2] == "127.0.0.1"
+    build_event = events[1]
+    assert build_event[1] == {"server_name": "main"}
+    assert build_event[2] == {"__file__": str(config_file)}
+    assert build_event[3] is False
+    assert build_event[4] == str(config_file)
+    worker_kwds = events[2][2]
+    assert worker_kwds == {
+        "pool": "solo",
+        "concurrency": 1,
+        "queues": ("galaxy.internal", "galaxy.external"),
+        "perform_ping_check": False,
+    }
+    assert app_module.app is None
+    assert os.environ.get("GALAXY_CONFIG_FILE") == old_config_file
+
+
+def test_application_validation_failure_still_shuts_down_app(tmp_path):
+    events = []
+    dependencies, config_context, _, app_module, _ = _lifecycle_fakes(
+        tmp_path,
+        events,
+        is_job_handler=False,
+    )
+    ctx = _Context()
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        pytest.raises(RuntimeError, match="not configured as a job handler"),
+    ):
+        with embedded.serve_embedded(ctx, []):
+            pytest.fail("unreachable")
+
+    assert "worker enter" not in events
+    assert "app shutdown" in events
+    assert app_module.app is None
+
+
+def test_builder_failure_restores_the_previous_global_app(tmp_path):
+    events = []
+    dependencies, config_context, _, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    leaked_partial_app = object()
+
+    def fail_during_build(*args, **kwds):
+        app_module.app = leaked_partial_app
+        raise RuntimeError("assembly failed")
+
+    dependencies = embedded._RuntimeDependencies(
+        build_galaxy_web_app=fail_during_build,
+        galaxy_app_module=dependencies.galaxy_app_module,
+        celery_app=dependencies.celery_app,
+        start_worker=dependencies.start_worker,
+        worker_controller=dependencies.worker_controller,
+        uvicorn_config=dependencies.uvicorn_config,
+        uvicorn_server=dependencies.uvicorn_server,
+    )
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        pytest.raises(RuntimeError, match="assembly failed"),
+    ):
+        with embedded.serve_embedded(_Context(), []):
+            pytest.fail("unreachable")
+
+    assert app_module.app is None
+
+
+def test_partial_worker_entry_terminates_the_captured_controller():
+    events = []
+
+    class CapturableController:
+        def __init__(self, *args, **kwds):
+            events.append("controller created")
+
+        def terminate(self):
+            events.append("controller terminated")
+
+    class FailingWorkerContext:
+        def __init__(self, controller_class):
+            self.controller_class = controller_class
+
+        def __enter__(self):
+            self.controller_class()
+            raise RuntimeError("worker startup failed")
+
+    def start_worker(celery_app, **kwds):
+        return FailingWorkerContext(kwds["WorkController"])
+
+    dependencies = SimpleNamespace(
+        celery_app=object(),
+        start_worker=start_worker,
+        worker_controller=CapturableController,
+    )
+
+    with pytest.raises(RuntimeError, match="worker startup failed"):
+        embedded._start_celery_worker(dependencies)
+
+    assert events == ["controller created", "controller terminated"]
+
+
+@pytest.mark.parametrize(
+    ("kwds", "message"),
+    [
+        ({"daemon": True}, "foreground"),
+        ({"host": "0.0.0.0"}, "loopback"),
+        ({"galaxy_root": "/checkout"}, "--galaxy_root"),
+        ({"install_galaxy": True}, "--install_galaxy"),
+    ],
+)
+def test_embedded_option_validation(kwds, message):
+    with pytest.raises(click.UsageError, match=message):
+        embedded.validate_embedded_options(_Context(), kwds)
+
+
+def test_embedded_engine_factory_registration():
+    from planemo.engine.factory import (
+        build_engine,
+        is_galaxy_engine,
+    )
+    from planemo.engine.galaxy import (
+        EmbeddedGalaxyEngine,
+        EmbeddedGalaxyEngineWithSingularityDB,
+    )
+
+    ctx = _Context()
+
+    assert is_galaxy_engine(engine="embedded_galaxy")
+    assert isinstance(build_engine(ctx, engine="embedded_galaxy"), EmbeddedGalaxyEngine)
+    assert isinstance(
+        build_engine(ctx, engine="embedded_galaxy", database_type="postgres_singularity"),
+        EmbeddedGalaxyEngineWithSingularityDB,
+    )
+
+
+def test_missing_runtime_explains_the_unreleased_development_prerequisite():
+    with (
+        patch.dict(sys.modules, {"celery.contrib.testing.worker": None}),
+        pytest.raises(click.ClickException, match="galaxyproject/galaxy#23360"),
+    ):
+        embedded._load_runtime_dependencies()
+
+
+def test_embedded_test_reuses_one_application_for_inner_test_groups():
+    from planemo.engine.galaxy import EmbeddedGalaxyEngine
+    from planemo.engine.interface import BaseEngine
+
+    events = []
+    config = object()
+
+    @contextlib.contextmanager
+    def fake_serve(ctx, runnables, **kwds):
+        events.append(("serve enter", runnables))
+        try:
+            yield config
+        finally:
+            events.append("serve exit")
+
+    native = SimpleNamespace(uri="native")
+    workflow = SimpleNamespace(uri="workflow")
+
+    def fake_base_test(engine, runnables, test_timeout):
+        with engine.ensure_runnables_served([native]) as first_config:
+            events.append(("native", first_config))
+        with engine.ensure_runnables_served([workflow]) as second_config:
+            events.append(("workflow", second_config))
+        return "results"
+
+    engine = EmbeddedGalaxyEngine(_Context(), engine="embedded_galaxy")
+    with (
+        patch("planemo.engine.galaxy.serve_embedded", fake_serve),
+        patch.object(BaseEngine, "test", fake_base_test),
+    ):
+        with patch.object(engine, "_check_can_run_all") as check_can_run_all:
+            assert engine.test([native, workflow], test_timeout=30) == "results"
+
+    assert events == [
+        ("serve enter", [native, workflow]),
+        ("native", config),
+        ("workflow", config),
+        "serve exit",
+    ]
+    check_can_run_all.assert_called()
+    assert engine._active_embedded_config is None
+    assert engine._active_embedded_runnable_uris == set()
+
+
+def test_embedded_test_rejects_unsupported_runnable_before_startup():
+    from planemo.engine.galaxy import EmbeddedGalaxyEngine
+
+    engine = EmbeddedGalaxyEngine(_Context(), engine="embedded_galaxy")
+    with (
+        patch.object(engine, "_check_can_run_all", side_effect=ValueError("unsupported")),
+        patch("planemo.engine.galaxy.serve_embedded") as serve,
+        pytest.raises(ValueError, match="unsupported"),
+    ):
+        engine.test([SimpleNamespace(uri="unsupported")], test_timeout=30)
+
+    serve.assert_not_called()
+
+
+def test_embedded_logging_is_scoped_and_keeps_details_in_file(tmp_path):
+    ctx = _Context()
+    galaxy_logger = logging.getLogger("galaxy")
+    child_logger = logging.getLogger("galaxy.existing_child")
+    child_handler = logging.NullHandler()
+    child_logger.addHandler(child_handler)
+    child_logger.setLevel(logging.WARNING)
+    child_logger.propagate = False
+    original_level = galaxy_logger.level
+    original_propagate = galaxy_logger.propagate
+    original_handlers = list(galaxy_logger.handlers)
+    root_handlers = list(logging.getLogger().handlers)
+    log_file = tmp_path / "embedded.log"
+
+    with embedded._embedded_logging(ctx, str(log_file)):
+        assert galaxy_logger.propagate is False
+        assert not any(handler in galaxy_logger.handlers for handler in original_handlers)
+        child_logger.info("file detail")
+        galaxy_logger.warning("visible warning")
+        try:
+            raise RuntimeError("logged failure")
+        except RuntimeError:
+            galaxy_logger.exception("visible failure")
+
+    log_contents = log_file.read_text()
+    assert "file detail" in log_contents
+    assert "visible warning" in log_contents
+    assert "Traceback" in log_contents
+    assert len(ctx.messages) == 2
+    assert "visible warning" in ctx.messages[0]
+    assert "visible failure" in ctx.messages[1]
+    assert "Traceback" not in ctx.messages[1]
+    assert galaxy_logger.level == original_level
+    assert galaxy_logger.propagate is original_propagate
+    assert galaxy_logger.handlers == original_handlers
+    assert logging.getLogger().handlers == root_handlers
+    assert child_logger.level == logging.WARNING
+    assert child_logger.propagate is False
+    assert child_logger.handlers == [child_handler]
+    child_logger.removeHandler(child_handler)

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -1,8 +1,10 @@
 """Unit tests for the embedded Galaxy lifecycle."""
 
 import contextlib
+import http.client
 import logging
 import os
+import socket
 import sys
 import threading
 from dataclasses import replace
@@ -114,14 +116,22 @@ def _lifecycle_fakes(tmp_path, events, *, is_job_handler=True):
             events.append("config exit")
 
     uvicorn_runtime = SimpleNamespace(errors=[])
-    return dependencies, config_context, uvicorn_runtime, app_module, config_file
+    return dependencies, config_context, uvicorn_runtime, app_module, config_file, config
 
 
-def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
+def _assert_relative_order(events, *expected):
+    event_names = [event if isinstance(event, str) else event[0] for event in events]
+    positions = [event_names.index(name) for name in expected]
+    assert positions == sorted(positions)
+
+
+def test_embedded_lifecycle_preserves_startup_and_cleanup_contract(tmp_path):
     events = []
-    dependencies, config_context, uvicorn_runtime, app_module, config_file = _lifecycle_fakes(tmp_path, events)
+    dependencies, config_context, uvicorn_runtime, app_module, config_file, _ = _lifecycle_fakes(tmp_path, events)
     ctx = _Context({"port": OptionSource.default})
     old_config_file = os.environ.get("GALAXY_CONFIG_FILE")
+    previous_global_app = object()
+    app_module.app = previous_global_app
 
     def start_uvicorn(deps, asgi_app, sock):
         events.append("uvicorn start")
@@ -141,8 +151,8 @@ def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
         with embedded.serve_embedded(ctx, [], galaxy_startup_timeout=17, port=9090, host="localhost"):
             events.append("body")
 
-    event_names = [event if isinstance(event, str) else event[0] for event in events]
-    assert event_names == [
+    _assert_relative_order(
+        events,
         "config enter",
         "build",
         "worker config",
@@ -157,7 +167,7 @@ def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
         "pool join",
         "app shutdown",
         "config exit",
-    ]
+    )
     assert events[0][1] != 9090
     assert events[0][2] == "127.0.0.1"
     build_event = events[1]
@@ -173,13 +183,13 @@ def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
         "perform_ping_check": False,
         "shutdown_timeout": 10,
     }
-    assert app_module.app is None
+    assert app_module.app is previous_global_app
     assert os.environ.get("GALAXY_CONFIG_FILE") == old_config_file
 
 
 def test_readiness_failure_preserves_error_and_completes_cleanup(tmp_path):
     events = []
-    dependencies, config_context, uvicorn_runtime, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    dependencies, config_context, uvicorn_runtime, app_module, _, _ = _lifecycle_fakes(tmp_path, events)
 
     class FailingForkPool:
         def stop(self):
@@ -217,7 +227,7 @@ def test_readiness_failure_preserves_error_and_completes_cleanup(tmp_path):
 
 def test_uvicorn_startup_failure_is_retained_as_cause(tmp_path):
     events = []
-    dependencies, config_context, uvicorn_runtime, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    dependencies, config_context, uvicorn_runtime, app_module, _, _ = _lifecycle_fakes(tmp_path, events)
     server_error = RuntimeError("uvicorn thread crashed")
     uvicorn_runtime.errors.append(server_error)
 
@@ -240,7 +250,7 @@ def test_uvicorn_startup_failure_is_retained_as_cause(tmp_path):
 
 def test_first_interrupt_propagates_after_complete_cleanup(tmp_path):
     events = []
-    dependencies, config_context, uvicorn_runtime, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    dependencies, config_context, uvicorn_runtime, app_module, _, _ = _lifecycle_fakes(tmp_path, events)
     interrupt = KeyboardInterrupt("foreground interrupted")
 
     with (
@@ -265,6 +275,40 @@ def test_first_interrupt_propagates_after_complete_cleanup(tmp_path):
         "config exit",
     ]
     assert app_module.app is None
+
+
+@pytest.mark.parametrize("failure_location", ["install_workflows", "command_body"])
+def test_post_startup_failures_preserve_error_and_cleanup(tmp_path, failure_location):
+    events = []
+    dependencies, config_context, uvicorn_runtime, app_module, _, config = _lifecycle_fakes(tmp_path, events)
+    previous_global_app = object()
+    app_module.app = previous_global_app
+    failure = RuntimeError(f"failure in {failure_location}")
+
+    if failure_location == "install_workflows":
+
+        def fail_install():
+            raise failure
+
+        config.install_workflows = fail_install
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        patch.object(embedded, "_start_uvicorn", return_value=uvicorn_runtime),
+        patch.object(embedded, "_stop_uvicorn", side_effect=lambda ctx, runtime: events.append("uvicorn stop")),
+        patch.object(embedded, "sleep", return_value=True),
+        pytest.raises(RuntimeError) as raised,
+    ):
+        with embedded.serve_embedded(_Context(), []):
+            if failure_location == "command_body":
+                raise failure
+
+    assert raised.value is failure
+    _assert_relative_order(
+        events, "uvicorn stop", "worker exit", "pool stop", "pool join", "app shutdown", "config exit"
+    )
+    assert app_module.app is previous_global_app
 
 
 def test_second_interrupt_forces_uvicorn_exit():
@@ -296,9 +340,68 @@ def test_second_interrupt_forces_uvicorn_exit():
     ]
 
 
+def test_uvicorn_adapter_serves_prebound_socket_and_stops():
+    uvicorn = pytest.importorskip("uvicorn")
+
+    async def asgi_app(scope, receive, send):
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+        else:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b'{"version_major":"test"}'})
+
+    sock = embedded._bind_socket("127.0.0.1", 0)
+    host, port = sock.getsockname()[:2]
+    dependencies = SimpleNamespace(uvicorn_config=uvicorn.Config, uvicorn_server=uvicorn.Server)
+    runtime = embedded._start_uvicorn(dependencies, asgi_app, sock)
+    try:
+        assert embedded.sleep(f"http://{host}:{port}", timeout=5)
+        connection = http.client.HTTPConnection(host, port, timeout=2)
+        try:
+            connection.request("GET", "/")
+            response = connection.getresponse()
+            assert response.status == 200
+            assert response.read() == b'{"version_major":"test"}'
+        finally:
+            connection.close()
+    finally:
+        embedded._stop_uvicorn(_Context(), runtime)
+        sock.close()
+
+    assert not runtime.thread.is_alive()
+    with pytest.raises(OSError):
+        socket.create_connection((host, port), timeout=1)
+
+
+def test_patched_environment_restores_existing_and_missing_values(monkeypatch):
+    existing_key = "PLANEMO_TEST_EMBEDDED_EXISTING"
+    missing_key = "PLANEMO_TEST_EMBEDDED_MISSING"
+    monkeypatch.setenv(existing_key, "before")
+    monkeypatch.delenv(missing_key, raising=False)
+
+    with embedded._patched_environment({existing_key: "during", missing_key: "created"}):
+        assert os.environ[existing_key] == "during"
+        assert os.environ[missing_key] == "created"
+
+    assert os.environ[existing_key] == "before"
+    assert missing_key not in os.environ
+
+
 def test_application_validation_failure_still_shuts_down_app(tmp_path):
     events = []
-    dependencies, config_context, _, app_module, _ = _lifecycle_fakes(
+    dependencies, config_context, _, app_module, _, _ = _lifecycle_fakes(
         tmp_path,
         events,
         is_job_handler=False,
@@ -320,7 +423,7 @@ def test_application_validation_failure_still_shuts_down_app(tmp_path):
 
 def test_builder_failure_restores_the_previous_global_app(tmp_path):
     events = []
-    dependencies, config_context, _, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    dependencies, config_context, _, app_module, _, _ = _lifecycle_fakes(tmp_path, events)
     leaked_partial_app = object()
 
     def fail_during_build(*args, **kwds):

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import threading
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -172,6 +173,125 @@ def test_embedded_lifecycle_orders_startup_and_cleanup(tmp_path):
     }
     assert app_module.app is None
     assert os.environ.get("GALAXY_CONFIG_FILE") == old_config_file
+
+
+def test_readiness_failure_preserves_error_and_completes_cleanup(tmp_path):
+    events = []
+    dependencies, config_context, uvicorn_runtime, app_module, _ = _lifecycle_fakes(tmp_path, events)
+
+    class FailingForkPool:
+        def stop(self):
+            events.append("pool stop")
+            raise RuntimeError("pool stop failed")
+
+        def join(self, timeout):
+            events.append(("pool join", timeout))
+
+    dependencies = replace(dependencies, celery_app=SimpleNamespace(fork_pool=FailingForkPool()))
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        patch.object(embedded, "_start_uvicorn", return_value=uvicorn_runtime),
+        patch.object(embedded, "_stop_uvicorn", side_effect=lambda ctx, runtime: events.append("uvicorn stop")),
+        patch.object(embedded, "sleep", return_value=False),
+        pytest.raises(RuntimeError, match="failed to start") as raised,
+    ):
+        with embedded.serve_embedded(_Context(), [], galaxy_startup_timeout=0):
+            pytest.fail("unreachable")
+
+    assert raised.value.__cause__ is None
+    event_names = [event if isinstance(event, str) else event[0] for event in events]
+    assert event_names[-6:] == [
+        "uvicorn stop",
+        "worker exit",
+        "pool stop",
+        "pool join",
+        "app shutdown",
+        "config exit",
+    ]
+    assert app_module.app is None
+
+
+def test_uvicorn_startup_failure_is_retained_as_cause(tmp_path):
+    events = []
+    dependencies, config_context, uvicorn_runtime, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    server_error = RuntimeError("uvicorn thread crashed")
+    uvicorn_runtime.errors.append(server_error)
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        patch.object(embedded, "_start_uvicorn", return_value=uvicorn_runtime),
+        patch.object(embedded, "_stop_uvicorn", side_effect=lambda ctx, runtime: events.append("uvicorn stop")),
+        patch.object(embedded, "sleep", return_value=False),
+        pytest.raises(RuntimeError, match="uvicorn server failed") as raised,
+    ):
+        with embedded.serve_embedded(_Context(), []):
+            pytest.fail("unreachable")
+
+    assert raised.value.__cause__ is server_error
+    assert "app shutdown" in events
+    assert events[-1] == "config exit"
+    assert app_module.app is None
+
+
+def test_first_interrupt_propagates_after_complete_cleanup(tmp_path):
+    events = []
+    dependencies, config_context, uvicorn_runtime, app_module, _ = _lifecycle_fakes(tmp_path, events)
+    interrupt = KeyboardInterrupt("foreground interrupted")
+
+    with (
+        patch.object(embedded, "embedded_galaxy_config", config_context),
+        patch.object(embedded, "_load_runtime_dependencies", return_value=dependencies),
+        patch.object(embedded, "_start_uvicorn", return_value=uvicorn_runtime),
+        patch.object(embedded, "_stop_uvicorn", side_effect=lambda ctx, runtime: events.append("uvicorn stop")),
+        patch.object(embedded, "sleep", return_value=True),
+        pytest.raises(KeyboardInterrupt) as raised,
+    ):
+        with embedded.serve_embedded(_Context(), []):
+            raise interrupt
+
+    assert raised.value is interrupt
+    event_names = [event if isinstance(event, str) else event[0] for event in events]
+    assert event_names[-6:] == [
+        "uvicorn stop",
+        "worker exit",
+        "pool stop",
+        "pool join",
+        "app shutdown",
+        "config exit",
+    ]
+    assert app_module.app is None
+
+
+def test_second_interrupt_forces_uvicorn_exit():
+    class InterruptingJoin:
+        def __init__(self):
+            self.join_timeouts = []
+            self.alive = True
+
+        def join(self, timeout):
+            self.join_timeouts.append(timeout)
+            if len(self.join_timeouts) == 1:
+                raise KeyboardInterrupt()
+            self.alive = False
+
+        def is_alive(self):
+            return self.alive
+
+    server = SimpleNamespace(should_exit=False, force_exit=False)
+    thread = InterruptingJoin()
+    runtime = embedded._UvicornRuntime(server=server, thread=thread, errors=[])
+
+    embedded._stop_uvicorn(_Context(), runtime)
+
+    assert server.should_exit is True
+    assert server.force_exit is True
+    assert thread.join_timeouts == [
+        embedded.UVICORN_SHUTDOWN_TIMEOUT,
+        embedded.UVICORN_FORCE_EXIT_JOIN_TIMEOUT,
+    ]
 
 
 def test_application_validation_failure_still_shuts_down_app(tmp_path):

--- a/tests/test_embedded_galaxy.py
+++ b/tests/test_embedded_galaxy.py
@@ -63,6 +63,7 @@ def _lifecycle_fakes(tmp_path, events, *, is_job_handler=True):
     app.shutdown = lambda: events.append("app shutdown")
     app_module = SimpleNamespace(app=None)
     celery_app = SimpleNamespace(fork_pool=_ForkPool(events))
+    celery_worker_state = SimpleNamespace(should_terminate=None)
 
     def build_galaxy_web_app(properties, global_conf, register_shutdown_at_exit):
         events.append(
@@ -85,6 +86,7 @@ def _lifecycle_fakes(tmp_path, events, *, is_job_handler=True):
         build_galaxy_web_app=build_galaxy_web_app,
         galaxy_app_module=app_module,
         celery_app=celery_app,
+        celery_worker_state=celery_worker_state,
         start_worker=start_worker,
         worker_controller=None,
         uvicorn_config=None,
@@ -329,6 +331,7 @@ def test_builder_failure_restores_the_previous_global_app(tmp_path):
         build_galaxy_web_app=fail_during_build,
         galaxy_app_module=dependencies.galaxy_app_module,
         celery_app=dependencies.celery_app,
+        celery_worker_state=dependencies.celery_worker_state,
         start_worker=dependencies.start_worker,
         worker_controller=dependencies.worker_controller,
         uvicorn_config=dependencies.uvicorn_config,
@@ -348,6 +351,7 @@ def test_builder_failure_restores_the_previous_global_app(tmp_path):
 
 def test_partial_worker_entry_terminates_the_captured_controller():
     events = []
+    worker_state = SimpleNamespace(should_terminate=None)
 
     class CapturableController:
         def __init__(self, *args, **kwds):
@@ -369,6 +373,7 @@ def test_partial_worker_entry_terminates_the_captured_controller():
 
     dependencies = SimpleNamespace(
         celery_app=object(),
+        celery_worker_state=worker_state,
         start_worker=start_worker,
         worker_controller=CapturableController,
     )
@@ -377,14 +382,17 @@ def test_partial_worker_entry_terminates_the_captured_controller():
         embedded._start_celery_worker(dependencies)
 
     assert events == ["controller created", "controller terminated"]
+    assert worker_state.should_terminate is None
 
 
 def test_worker_exit_failure_terminates_the_captured_controller():
     events = []
+    worker_state = SimpleNamespace(should_terminate=None)
 
     class FailingWorkerContext:
         def __exit__(self, exc_type, exc, traceback):
             events.append("worker exit")
+            worker_state.should_terminate = 0
             raise RuntimeError("worker shutdown failed")
 
     class Controller:
@@ -393,6 +401,7 @@ def test_worker_exit_failure_terminates_the_captured_controller():
 
     runtime = embedded._CeleryWorkerRuntime(
         context=FailingWorkerContext(),
+        worker_state=worker_state,
         controller=Controller(),
         entered=True,
     )
@@ -402,9 +411,10 @@ def test_worker_exit_failure_terminates_the_captured_controller():
 
     assert events == ["worker exit", "controller terminated"]
     assert runtime.entered is False
+    assert worker_state.should_terminate is None
 
 
-def test_fork_pool_join_is_attempted_after_stop_failure():
+def test_fork_pool_stop_and_join_failures_are_reported_independently():
     events = []
 
     class FailingForkPool:
@@ -414,11 +424,15 @@ def test_fork_pool_join_is_attempted_after_stop_failure():
 
         def join(self, timeout):
             events.append(("pool join", timeout))
+            raise RuntimeError("pool join failed")
 
-    with pytest.raises(RuntimeError, match="pool stop failed"):
-        embedded._stop_fork_pool(SimpleNamespace(fork_pool=FailingForkPool()))
+    celery_app = SimpleNamespace(fork_pool=FailingForkPool())
+    ctx = _Context()
+    embedded._cleanup(ctx, "stopping the pool", lambda: embedded._stop_fork_pool(celery_app))
+    embedded._cleanup(ctx, "joining the pool", lambda: embedded._join_fork_pool(celery_app))
 
     assert events == ["pool stop", ("pool join", embedded.FORK_POOL_JOIN_TIMEOUT)]
+    assert ctx.messages == ["Failed while stopping the pool.", "Failed while joining the pool."]
 
 
 def test_slow_cleanup_reports_live_runtime_resources():

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -1,0 +1,60 @@
+"""Opt-in integration coverage for package-installed embedded Galaxy.
+
+Run with ``PLANEMO_TEST_EMBEDDED_GALAXY=1`` in an environment containing a
+Galaxy build with galaxyproject/galaxy#23360.
+"""
+
+import json
+import os
+import threading
+
+from .test_utils import (
+    CliTestCase,
+    skip_unless_environ,
+    TEST_TOOLS_DIR,
+)
+
+
+class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
+    @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
+    def test_yaml_tool_runs_through_embedded_worker(self):
+        tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
+
+        with self._isolate() as test_directory:
+            report_path = os.path.join(test_directory, "embedded-report.json")
+            result = self._check_exit_code(
+                [
+                    "test",
+                    "--engine",
+                    "embedded_galaxy",
+                    "--no_dependency_resolution",
+                    "--test_output_json",
+                    report_path,
+                    tool_path,
+                ]
+            )
+
+            with open(report_path) as report_fh:
+                report = json.load(report_fh)
+
+        # The Click result is the command's authoritative exit status. Galaxy's
+        # raw structured report may leave its optional ``exit_code`` field null;
+        # Planemo derives the command result from the report summary.
+        assert result.exit_code == 0
+        assert report["summary"] == {
+            "num_errors": 0,
+            "num_failures": 0,
+            "num_skips": 0,
+            "num_tests": 1,
+        }
+        test_data = report["tests"][0]["data"]
+        assert test_data["status"] == "success"
+        assert test_data["job"]["state"] == "ok"
+        assert test_data["job"]["tool_id"] == "embedded_echo"
+
+        from galaxy import app as galaxy_app_module
+
+        assert galaxy_app_module.app is None
+        assert not any(
+            thread.name == "planemo-embedded-uvicorn" and thread.is_alive() for thread in threading.enumerate()
+        )

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -148,7 +148,8 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
                     )
             finally:
                 for celery_app, task_name in registered_probe_tasks:
-                    celery_app.tasks.unregister(task_name)
+                    if task_name in celery_app.tasks:
+                        celery_app.tasks.unregister(task_name)
 
             with open(report_path) as report_fh:
                 report = json.load(report_fh)
@@ -168,14 +169,13 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         assert len(celery_state_reads) == 4
         assert all(state != "SUCCESS" for state in celery_state_reads[:2])
         assert celery_state_reads[-2:] == ["SUCCESS", "SUCCESS"]
-        assert all(task_name not in celery_app.tasks for celery_app, task_name in registered_probe_tasks)
         assert all(test["data"]["status"] == "success" for test in report["tests"])
         tool_jobs = [test["data"]["job"] for test in report["tests"] if test["data"].get("job")]
         assert {job["tool_id"] for job in tool_jobs} == {"cat", "embedded_echo"}
         assert all(job["state"] == "ok" for job in tool_jobs)
-        tool_job_pids = [int(job["external_id"]) for job in tool_jobs]
-        assert len(tool_job_pids) == len(tool_jobs)
-        assert not any(psutil.pid_exists(pid) for pid in tool_job_pids)
+        tool_job_pids = {int(job["external_id"]) for job in tool_jobs}
+        live_child_pids = {child.pid for child in psutil.Process().children(recursive=True)}
+        assert tool_job_pids.isdisjoint(live_child_pids)
         # Pydantic's report model serializes optional fields as null, so select
         # by the authoritative runnable type rather than key presence.
         workflow_results = [test for test in report["tests"] if test["test_type"] == "galaxy_workflow"]

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -24,7 +24,9 @@ from .test_utils import (
 
 class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
     @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
-    def test_tools_upload_and_workflow_share_one_embedded_application(self):
+    def test_one_embedded_application_covers_full_acceptance_and_cleanup(self):
+        # Keep these cases in one command: Galaxy's process-global state means
+        # splitting the acceptance scenarios would stop enforcing one construction.
         xml_tool_path = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml")
         yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
         workflow_path = os.path.join(TEST_DATA_DIR, "wf2.ga")
@@ -36,6 +38,7 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         )
 
         from planemo.galaxy import embedded
+        from planemo.io import live_runtime_resources
 
         load_runtime_dependencies = embedded._load_runtime_dependencies
         baseline_threads = set(threading.enumerate())
@@ -44,14 +47,23 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         celery_state_reads = []
         celery_results = []
         config_directories = []
+        probe_started = threading.Event()
+        probe_can_finish = threading.Event()
 
         def load_counted_runtime_dependencies():
             dependencies = load_runtime_dependencies()
             build_galaxy_web_app = dependencies.build_galaxy_web_app
             start_worker = dependencies.start_worker
 
-            @dependencies.celery_app.task(name="planemo.embedded_result_backend_probe")
+            # Celery's registry is process-global and outlives this test. A
+            # test-local name prevents a later invocation reusing this closure.
+            probe_task_name = f"planemo.embedded_result_backend_probe_{id(probe_started)}"
+
+            @dependencies.celery_app.task(name=probe_task_name)
             def result_backend_probe():
+                probe_started.set()
+                if not probe_can_finish.wait(timeout=30):
+                    raise TimeoutError("Embedded result-backend probe was not released.")
                 return "probe complete"
 
             def counted_build(*args, **kwds):
@@ -66,7 +78,12 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
 
                 with start_worker(celery_app, **kwds) as worker:
                     result = result_backend_probe.delay()
-                    celery_state_reads.extend((result.state, result.state))
+                    if not probe_started.wait(timeout=30):
+                        raise TimeoutError("Embedded result-backend probe did not start.")
+                    try:
+                        celery_state_reads.extend((result.state, result.state))
+                    finally:
+                        probe_can_finish.set()
                     with allow_join_result():
                         celery_results.append(result.get(timeout=30))
                     celery_state_reads.extend((result.state, result.state))
@@ -79,6 +96,11 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
             )
 
         with self._isolate() as test_directory:
+            # The source is a workflow-lint fixture with an intentionally
+            # invalid tool version and a content-specific test. Keep this
+            # acceptance test focused on repairing/installing the Tool Shed
+            # dependency and executing it, without changing that fixture's
+            # separate contract.
             shed_workflow_path = os.path.join(test_directory, "embedded-shed-workflow.ga")
             shutil.copyfile(shed_workflow_source, shed_workflow_path)
             shed_tests_path = shed_workflow_path.replace(".ga", "-tests.yml")
@@ -125,6 +147,7 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         assert construction_count == 1
         assert celery_results == ["probe complete"]
         assert len(celery_state_reads) == 4
+        assert all(state != "SUCCESS" for state in celery_state_reads[:2])
         assert celery_state_reads[-2:] == ["SUCCESS", "SUCCESS"]
         assert all(test["data"]["status"] == "success" for test in report["tests"])
         tool_jobs = [test["data"]["job"] for test in report["tests"] if test["data"].get("job")]
@@ -143,13 +166,9 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         from galaxy import app as galaxy_app_module
 
         assert galaxy_app_module.app is None
-        remaining_threads = sorted(
-            thread.name for thread in threading.enumerate() if thread not in baseline_threads and thread.is_alive()
-        )
-        remaining_child_processes = sorted(
-            f"{process.name} (pid={process.pid})"
-            for process in multiprocessing.active_children()
-            if process.pid not in baseline_child_pids and process.is_alive()
+        remaining_threads, remaining_child_processes = live_runtime_resources(
+            exclude_threads=baseline_threads,
+            exclude_pids=baseline_child_pids,
         )
         assert remaining_threads == []
         assert remaining_child_processes == []

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -11,8 +11,6 @@ import os
 import shutil
 import signal
 import socket
-import subprocess
-import sys
 import threading
 from dataclasses import replace
 from unittest.mock import patch
@@ -22,49 +20,18 @@ import pytest
 
 from planemo import network_util
 from planemo.galaxy.ephemeris_sleep import sleep
-from planemo.io import (
-    process_group_exists,
-    terminate_process_group,
-)
+from planemo.io import process_group_exists
 from .test_utils import (
     CliTestCase,
+    planemo_subprocess,
     PROJECT_TEMPLATES_DIR,
     skip_unless_environ,
     TEST_DATA_DIR,
     TEST_TOOLS_DIR,
 )
 
-PLANEMO_CLI_ENTRYPOINT = "from planemo.cli import planemo; planemo()"
 SUBPROCESS_STARTUP_TIMEOUT = 120
 SUBPROCESS_EXIT_TIMEOUT = 45
-
-
-@contextlib.contextmanager
-def _planemo_subprocess(arguments, cwd, log_path):
-    environment = os.environ.copy()
-    executable_directory = os.path.dirname(sys.executable)
-    environment["PATH"] = os.pathsep.join((executable_directory, environment.get("PATH", "")))
-    with open(log_path, "w+") as log_fh:
-        process = subprocess.Popen(
-            [sys.executable, "-c", PLANEMO_CLI_ENTRYPOINT, *arguments],
-            cwd=cwd,
-            env=environment,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
-        try:
-            yield process, log_fh
-        finally:
-            log_fh.flush()
-            if process.poll() is None or process_group_exists(process.pid):
-                terminate_process_group(process.pid, timeout=5, reap=process.poll)
-
-
-def _subprocess_log(log_fh):
-    log_fh.flush()
-    log_fh.seek(0)
-    return log_fh.read()
 
 
 class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
@@ -256,9 +223,10 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
                 yaml_tool_path,
                 job_path,
             ]
-            with _planemo_subprocess(command, test_directory, process_log) as (process, log_fh):
+            with planemo_subprocess(command, test_directory, process_log) as managed_process:
+                process = managed_process.process
                 return_code = process.wait(timeout=SUBPROCESS_STARTUP_TIMEOUT)
-                process_output = _subprocess_log(log_fh)
+                process_output = managed_process.read_output()
                 assert return_code == 0, process_output
                 assert not process_group_exists(process.pid), process_output
 
@@ -286,14 +254,15 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
                 str(port),
                 yaml_tool_path,
             ]
-            with _planemo_subprocess(command, test_directory, process_log) as (process, log_fh):
+            with planemo_subprocess(command, test_directory, process_log) as managed_process:
+                process = managed_process.process
                 galaxy_url = f"http://127.0.0.1:{port}"
                 if not sleep(galaxy_url, timeout=SUBPROCESS_STARTUP_TIMEOUT):
-                    raise AssertionError(f"Embedded Galaxy did not become ready.\n{_subprocess_log(log_fh)}")
+                    raise AssertionError(f"Embedded Galaxy did not become ready.\n{managed_process.read_output()}")
 
                 process.send_signal(signal.SIGINT)
                 return_code = process.wait(timeout=SUBPROCESS_EXIT_TIMEOUT)
-                process_output = _subprocess_log(log_fh)
+                process_output = managed_process.read_output()
                 assert return_code == 1, process_output
                 assert "Aborted!" in process_output
                 assert not process_group_exists(process.pid), process_output

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -4,18 +4,12 @@ Run with ``PLANEMO_TEST_EMBEDDED_GALAXY=1`` in an environment containing a
 Galaxy build with galaxyproject/galaxy#23360.
 """
 
-import contextlib
 import json
-import multiprocessing
 import os
 import shutil
 import signal
 import socket
-import threading
-from dataclasses import replace
-from unittest.mock import patch
 
-import psutil
 import pytest
 
 from planemo import network_util
@@ -31,14 +25,16 @@ from .test_utils import (
 )
 
 SUBPROCESS_STARTUP_TIMEOUT = 120
+SUBPROCESS_TEST_TIMEOUT = 300
 SUBPROCESS_EXIT_TIMEOUT = 45
 
 
+@pytest.mark.embedded_galaxy
 class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
     @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
-    def test_one_embedded_application_covers_full_acceptance_and_cleanup(self):
-        # Keep these cases in one command: Galaxy's process-global state means
-        # splitting the acceptance scenarios would stop enforcing one construction.
+    def test_cli_test_covers_xml_yaml_and_workflows_in_one_process(self):
+        # Keep these cases in one command to exercise Planemo's mixed-runnable
+        # path while respecting Galaxy's one-application-per-process constraint.
         xml_tool_path = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml")
         yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
         workflow_path = os.path.join(TEST_DATA_DIR, "wf2.ga")
@@ -48,67 +44,6 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
             "basic_wf_iwc_invalid_version",
             "Super-simple-workflow.ga",
         )
-
-        from planemo.galaxy import embedded
-        from planemo.io import live_runtime_resources
-
-        load_runtime_dependencies = embedded._load_runtime_dependencies
-        baseline_threads = set(threading.enumerate())
-        baseline_child_pids = {process.pid for process in multiprocessing.active_children()}
-        construction_count = 0
-        celery_state_reads = []
-        celery_results = []
-        config_directories = []
-        probe_started = threading.Event()
-        probe_can_finish = threading.Event()
-        registered_probe_tasks = []
-
-        def load_counted_runtime_dependencies():
-            dependencies = load_runtime_dependencies()
-            build_galaxy_web_app = dependencies.build_galaxy_web_app
-            start_worker = dependencies.start_worker
-
-            # Celery's registry is process-global and outlives this test. A
-            # test-local name prevents a later invocation reusing this closure.
-            probe_task_name = f"planemo.embedded_result_backend_probe_{id(probe_started)}"
-
-            @dependencies.celery_app.task(name=probe_task_name)
-            def result_backend_probe():
-                probe_started.set()
-                if not probe_can_finish.wait(timeout=30):
-                    raise TimeoutError("Embedded result-backend probe was not released.")
-                return "probe complete"
-
-            registered_probe_tasks.append((dependencies.celery_app, result_backend_probe.name))
-
-            def counted_build(*args, **kwds):
-                nonlocal construction_count
-                construction_count += 1
-                config_directories.append(os.path.dirname(kwds["global_conf"]["__file__"]))
-                return build_galaxy_web_app(*args, **kwds)
-
-            @contextlib.contextmanager
-            def start_worker_with_result_backend_probe(celery_app, **kwds):
-                from celery.result import allow_join_result
-
-                with start_worker(celery_app, **kwds) as worker:
-                    result = result_backend_probe.delay()
-                    if not probe_started.wait(timeout=30):
-                        raise TimeoutError("Embedded result-backend probe did not start.")
-                    try:
-                        celery_state_reads.extend((result.state, result.state))
-                    finally:
-                        probe_can_finish.set()
-                    with allow_join_result():
-                        celery_results.append(result.get(timeout=30))
-                    celery_state_reads.extend((result.state, result.state))
-                    yield worker
-
-            return replace(
-                dependencies,
-                build_galaxy_web_app=counted_build,
-                start_worker=start_worker_with_result_backend_probe,
-            )
 
         with self._isolate() as test_directory:
             # The source is a workflow-lint fixture with an intentionally
@@ -130,52 +65,39 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
           n: 5
 """)
             report_path = os.path.join(test_directory, "embedded-report.json")
-            try:
-                with patch.object(embedded, "_load_runtime_dependencies", load_counted_runtime_dependencies):
-                    result = self._check_exit_code(
-                        [
-                            "test",
-                            "--engine",
-                            "embedded_galaxy",
-                            "--no_dependency_resolution",
-                            "--test_output_json",
-                            report_path,
-                            xml_tool_path,
-                            yaml_tool_path,
-                            workflow_path,
-                            shed_workflow_path,
-                        ]
-                    )
-            finally:
-                for celery_app, task_name in registered_probe_tasks:
-                    if task_name in celery_app.tasks:
-                        celery_app.tasks.unregister(task_name)
+            process_log = os.path.join(test_directory, "planemo-test.log")
+            command = [
+                "test",
+                "--engine",
+                "embedded_galaxy",
+                "--no_dependency_resolution",
+                "--test_output_json",
+                report_path,
+                xml_tool_path,
+                yaml_tool_path,
+                workflow_path,
+                shed_workflow_path,
+            ]
+            with planemo_subprocess(command, test_directory, process_log) as managed_process:
+                process = managed_process.process
+                return_code = process.wait(timeout=SUBPROCESS_TEST_TIMEOUT)
+                process_output = managed_process.read_output()
+                assert return_code == 0, process_output
+                assert not process_group_exists(process.pid), process_output
 
             with open(report_path) as report_fh:
                 report = json.load(report_fh)
 
-        # The Click result is the command's authoritative exit status. Galaxy's
-        # raw structured report may leave its optional ``exit_code`` field null;
-        # Planemo derives the command result from the report summary.
-        assert result.exit_code == 0
         assert report["summary"] == {
             "num_errors": 0,
             "num_failures": 0,
             "num_skips": 0,
             "num_tests": 4,
         }
-        assert construction_count == 1
-        assert celery_results == ["probe complete"]
-        assert len(celery_state_reads) == 4
-        assert all(state != "SUCCESS" for state in celery_state_reads[:2])
-        assert celery_state_reads[-2:] == ["SUCCESS", "SUCCESS"]
         assert all(test["data"]["status"] == "success" for test in report["tests"])
         tool_jobs = [test["data"]["job"] for test in report["tests"] if test["data"].get("job")]
         assert {job["tool_id"] for job in tool_jobs} == {"cat", "embedded_echo"}
         assert all(job["state"] == "ok" for job in tool_jobs)
-        tool_job_pids = {int(job["external_id"]) for job in tool_jobs}
-        live_child_pids = {child.pid for child in psutil.Process().children(recursive=True)}
-        assert tool_job_pids.isdisjoint(live_child_pids)
         # Pydantic's report model serializes optional fields as null, so select
         # by the authoritative runnable type rather than key presence.
         workflow_results = [test for test in report["tests"] if test["test_type"] == "galaxy_workflow"]
@@ -186,57 +108,47 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
             "completed",
         }
 
-        from galaxy import app as galaxy_app_module
-
-        assert galaxy_app_module.app is None
-        remaining_threads, remaining_child_processes = live_runtime_resources(
-            exclude_threads=baseline_threads,
-            exclude_pids=baseline_child_pids,
-        )
-        assert remaining_threads == []
-        assert remaining_child_processes == []
-        assert len(config_directories) == 1
-        assert not os.path.exists(config_directories[0])
-
     @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
-    def test_run_uses_a_fresh_embedded_galaxy_process(self):
+    def test_repeated_runs_use_fresh_embedded_galaxy_processes(self):
         yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
 
         with self._isolate() as test_directory:
-            job_path = os.path.join(test_directory, "embedded-job.json")
-            output_directory = os.path.join(test_directory, "outputs")
-            output_json = os.path.join(test_directory, "run-outputs.json")
-            process_log = os.path.join(test_directory, "planemo-run.log")
-            with open(job_path, "w") as job_fh:
-                json.dump({"message": "hello from planemo run"}, job_fh)
+            for invocation in range(2):
+                expected_message = f"hello from planemo run {invocation}"
+                job_path = os.path.join(test_directory, f"embedded-job-{invocation}.json")
+                output_directory = os.path.join(test_directory, f"outputs-{invocation}")
+                output_json = os.path.join(test_directory, f"run-outputs-{invocation}.json")
+                process_log = os.path.join(test_directory, f"planemo-run-{invocation}.log")
+                with open(job_path, "w") as job_fh:
+                    json.dump({"message": expected_message}, job_fh)
 
-            command = [
-                "run",
-                "--engine",
-                "embedded_galaxy",
-                "--no_dependency_resolution",
-                "--download_outputs",
-                "--output_directory",
-                output_directory,
-                "--output_json",
-                output_json,
-                yaml_tool_path,
-                job_path,
-            ]
-            with planemo_subprocess(command, test_directory, process_log) as managed_process:
-                process = managed_process.process
-                return_code = process.wait(timeout=SUBPROCESS_STARTUP_TIMEOUT)
-                process_output = managed_process.read_output()
-                assert return_code == 0, process_output
-                assert not process_group_exists(process.pid), process_output
+                command = [
+                    "run",
+                    "--engine",
+                    "embedded_galaxy",
+                    "--no_dependency_resolution",
+                    "--download_outputs",
+                    "--output_directory",
+                    output_directory,
+                    "--output_json",
+                    output_json,
+                    yaml_tool_path,
+                    job_path,
+                ]
+                with planemo_subprocess(command, test_directory, process_log) as managed_process:
+                    process = managed_process.process
+                    return_code = process.wait(timeout=SUBPROCESS_STARTUP_TIMEOUT)
+                    process_output = managed_process.read_output()
+                    assert return_code == 0, process_output
+                    assert not process_group_exists(process.pid), process_output
 
-            with open(output_json) as output_fh:
-                run_outputs = json.load(output_fh)
-            assert "output" in run_outputs
-            output_files = [path for path in os.scandir(output_directory) if path.is_file()]
-            assert len(output_files) == 1
-            with open(output_files[0].path) as output_fh:
-                assert output_fh.read().strip() == "hello from planemo run"
+                with open(output_json) as output_fh:
+                    run_outputs = json.load(output_fh)
+                assert "output" in run_outputs
+                output_files = [path for path in os.scandir(output_directory) if path.is_file()]
+                assert len(output_files) == 1
+                with open(output_files[0].path) as output_fh:
+                    assert output_fh.read().strip() == expected_message
 
     @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
     def test_foreground_serve_exits_cleanly_on_sigint(self):

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -9,10 +9,23 @@ import json
 import multiprocessing
 import os
 import shutil
+import signal
+import socket
+import subprocess
+import sys
 import threading
 from dataclasses import replace
 from unittest.mock import patch
 
+import psutil
+import pytest
+
+from planemo import network_util
+from planemo.galaxy.ephemeris_sleep import sleep
+from planemo.io import (
+    process_group_exists,
+    terminate_process_group,
+)
 from .test_utils import (
     CliTestCase,
     PROJECT_TEMPLATES_DIR,
@@ -20,6 +33,38 @@ from .test_utils import (
     TEST_DATA_DIR,
     TEST_TOOLS_DIR,
 )
+
+PLANEMO_CLI_ENTRYPOINT = "from planemo.cli import planemo; planemo()"
+SUBPROCESS_STARTUP_TIMEOUT = 120
+SUBPROCESS_EXIT_TIMEOUT = 45
+
+
+@contextlib.contextmanager
+def _planemo_subprocess(arguments, cwd, log_path):
+    environment = os.environ.copy()
+    executable_directory = os.path.dirname(sys.executable)
+    environment["PATH"] = os.pathsep.join((executable_directory, environment.get("PATH", "")))
+    with open(log_path, "w+") as log_fh:
+        process = subprocess.Popen(
+            [sys.executable, "-c", PLANEMO_CLI_ENTRYPOINT, *arguments],
+            cwd=cwd,
+            env=environment,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            yield process, log_fh
+        finally:
+            log_fh.flush()
+            if process.poll() is None or process_group_exists(process.pid):
+                terminate_process_group(process.pid, timeout=5, reap=process.poll)
+
+
+def _subprocess_log(log_fh):
+    log_fh.flush()
+    log_fh.seek(0)
+    return log_fh.read()
 
 
 class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
@@ -49,6 +94,7 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         config_directories = []
         probe_started = threading.Event()
         probe_can_finish = threading.Event()
+        registered_probe_tasks = []
 
         def load_counted_runtime_dependencies():
             dependencies = load_runtime_dependencies()
@@ -65,6 +111,8 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
                 if not probe_can_finish.wait(timeout=30):
                     raise TimeoutError("Embedded result-backend probe was not released.")
                 return "probe complete"
+
+            registered_probe_tasks.append((dependencies.celery_app, result_backend_probe.name))
 
             def counted_build(*args, **kwds):
                 nonlocal construction_count
@@ -115,21 +163,25 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
           n: 5
 """)
             report_path = os.path.join(test_directory, "embedded-report.json")
-            with patch.object(embedded, "_load_runtime_dependencies", load_counted_runtime_dependencies):
-                result = self._check_exit_code(
-                    [
-                        "test",
-                        "--engine",
-                        "embedded_galaxy",
-                        "--no_dependency_resolution",
-                        "--test_output_json",
-                        report_path,
-                        xml_tool_path,
-                        yaml_tool_path,
-                        workflow_path,
-                        shed_workflow_path,
-                    ]
-                )
+            try:
+                with patch.object(embedded, "_load_runtime_dependencies", load_counted_runtime_dependencies):
+                    result = self._check_exit_code(
+                        [
+                            "test",
+                            "--engine",
+                            "embedded_galaxy",
+                            "--no_dependency_resolution",
+                            "--test_output_json",
+                            report_path,
+                            xml_tool_path,
+                            yaml_tool_path,
+                            workflow_path,
+                            shed_workflow_path,
+                        ]
+                    )
+            finally:
+                for celery_app, task_name in registered_probe_tasks:
+                    celery_app.tasks.unregister(task_name)
 
             with open(report_path) as report_fh:
                 report = json.load(report_fh)
@@ -149,10 +201,14 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         assert len(celery_state_reads) == 4
         assert all(state != "SUCCESS" for state in celery_state_reads[:2])
         assert celery_state_reads[-2:] == ["SUCCESS", "SUCCESS"]
+        assert all(task_name not in celery_app.tasks for celery_app, task_name in registered_probe_tasks)
         assert all(test["data"]["status"] == "success" for test in report["tests"])
         tool_jobs = [test["data"]["job"] for test in report["tests"] if test["data"].get("job")]
         assert {job["tool_id"] for job in tool_jobs} == {"cat", "embedded_echo"}
         assert all(job["state"] == "ok" for job in tool_jobs)
+        tool_job_pids = [int(job["external_id"]) for job in tool_jobs]
+        assert len(tool_job_pids) == len(tool_jobs)
+        assert not any(psutil.pid_exists(pid) for pid in tool_job_pids)
         # Pydantic's report model serializes optional fields as null, so select
         # by the authoritative runnable type rather than key presence.
         workflow_results = [test for test in report["tests"] if test["test_type"] == "galaxy_workflow"]
@@ -174,3 +230,72 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         assert remaining_child_processes == []
         assert len(config_directories) == 1
         assert not os.path.exists(config_directories[0])
+
+    @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
+    def test_run_uses_a_fresh_embedded_galaxy_process(self):
+        yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
+
+        with self._isolate() as test_directory:
+            job_path = os.path.join(test_directory, "embedded-job.json")
+            output_directory = os.path.join(test_directory, "outputs")
+            output_json = os.path.join(test_directory, "run-outputs.json")
+            process_log = os.path.join(test_directory, "planemo-run.log")
+            with open(job_path, "w") as job_fh:
+                json.dump({"message": "hello from planemo run"}, job_fh)
+
+            command = [
+                "run",
+                "--engine",
+                "embedded_galaxy",
+                "--no_dependency_resolution",
+                "--download_outputs",
+                "--output_directory",
+                output_directory,
+                "--output_json",
+                output_json,
+                yaml_tool_path,
+                job_path,
+            ]
+            with _planemo_subprocess(command, test_directory, process_log) as (process, log_fh):
+                return_code = process.wait(timeout=SUBPROCESS_STARTUP_TIMEOUT)
+                process_output = _subprocess_log(log_fh)
+                assert return_code == 0, process_output
+                assert not process_group_exists(process.pid), process_output
+
+            with open(output_json) as output_fh:
+                run_outputs = json.load(output_fh)
+            assert "output" in run_outputs
+            output_files = [path for path in os.scandir(output_directory) if path.is_file()]
+            assert len(output_files) == 1
+            with open(output_files[0].path) as output_fh:
+                assert output_fh.read().strip() == "hello from planemo run"
+
+    @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
+    def test_foreground_serve_exits_cleanly_on_sigint(self):
+        yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
+
+        with self._isolate() as test_directory:
+            port = network_util.get_free_port()
+            process_log = os.path.join(test_directory, "planemo-serve.log")
+            command = [
+                "serve",
+                "--engine",
+                "embedded_galaxy",
+                "--no_dependency_resolution",
+                "--port",
+                str(port),
+                yaml_tool_path,
+            ]
+            with _planemo_subprocess(command, test_directory, process_log) as (process, log_fh):
+                galaxy_url = f"http://127.0.0.1:{port}"
+                if not sleep(galaxy_url, timeout=SUBPROCESS_STARTUP_TIMEOUT):
+                    raise AssertionError(f"Embedded Galaxy did not become ready.\n{_subprocess_log(log_fh)}")
+
+                process.send_signal(signal.SIGINT)
+                return_code = process.wait(timeout=SUBPROCESS_EXIT_TIMEOUT)
+                process_output = _subprocess_log(log_fh)
+                assert return_code == 1, process_output
+                assert "Aborted!" in process_output
+                assert not process_group_exists(process.pid), process_output
+                with pytest.raises(OSError):
+                    socket.create_connection(("127.0.0.1", port), timeout=1)

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -6,6 +6,7 @@ Galaxy build with galaxyproject/galaxy#23360.
 
 import contextlib
 import json
+import multiprocessing
 import os
 import shutil
 import threading
@@ -37,9 +38,12 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         from planemo.galaxy import embedded
 
         load_runtime_dependencies = embedded._load_runtime_dependencies
+        baseline_threads = set(threading.enumerate())
+        baseline_child_pids = {process.pid for process in multiprocessing.active_children()}
         construction_count = 0
         celery_state_reads = []
         celery_results = []
+        config_directories = []
 
         def load_counted_runtime_dependencies():
             dependencies = load_runtime_dependencies()
@@ -53,6 +57,7 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
             def counted_build(*args, **kwds):
                 nonlocal construction_count
                 construction_count += 1
+                config_directories.append(os.path.dirname(kwds["global_conf"]["__file__"]))
                 return build_galaxy_web_app(*args, **kwds)
 
             @contextlib.contextmanager
@@ -138,6 +143,15 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         from galaxy import app as galaxy_app_module
 
         assert galaxy_app_module.app is None
-        assert not any(
-            thread.name == "planemo-embedded-uvicorn" and thread.is_alive() for thread in threading.enumerate()
+        remaining_threads = sorted(
+            thread.name for thread in threading.enumerate() if thread not in baseline_threads and thread.is_alive()
         )
+        remaining_child_processes = sorted(
+            f"{process.name} (pid={process.pid})"
+            for process in multiprocessing.active_children()
+            if process.pid not in baseline_child_pids and process.is_alive()
+        )
+        assert remaining_threads == []
+        assert remaining_child_processes == []
+        assert len(config_directories) == 1
+        assert not os.path.exists(config_directories[0])

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -4,8 +4,10 @@ Run with ``PLANEMO_TEST_EMBEDDED_GALAXY=1`` in an environment containing a
 Galaxy build with galaxyproject/galaxy#23360.
 """
 
+import contextlib
 import json
 import os
+import shutil
 import threading
 from dataclasses import replace
 from unittest.mock import patch
@@ -25,24 +27,66 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         xml_tool_path = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml")
         yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
         workflow_path = os.path.join(TEST_DATA_DIR, "wf2.ga")
+        shed_workflow_source = os.path.join(
+            TEST_DATA_DIR,
+            "wf_repos",
+            "basic_wf_iwc_invalid_version",
+            "Super-simple-workflow.ga",
+        )
 
         from planemo.galaxy import embedded
 
         load_runtime_dependencies = embedded._load_runtime_dependencies
         construction_count = 0
+        celery_state_reads = []
+        celery_results = []
 
         def load_counted_runtime_dependencies():
             dependencies = load_runtime_dependencies()
             build_galaxy_web_app = dependencies.build_galaxy_web_app
+            start_worker = dependencies.start_worker
+
+            @dependencies.celery_app.task(name="planemo.embedded_result_backend_probe")
+            def result_backend_probe():
+                return "probe complete"
 
             def counted_build(*args, **kwds):
                 nonlocal construction_count
                 construction_count += 1
                 return build_galaxy_web_app(*args, **kwds)
 
-            return replace(dependencies, build_galaxy_web_app=counted_build)
+            @contextlib.contextmanager
+            def start_worker_with_result_backend_probe(celery_app, **kwds):
+                from celery.result import allow_join_result
+
+                with start_worker(celery_app, **kwds) as worker:
+                    result = result_backend_probe.delay()
+                    celery_state_reads.extend((result.state, result.state))
+                    with allow_join_result():
+                        celery_results.append(result.get(timeout=30))
+                    celery_state_reads.extend((result.state, result.state))
+                    yield worker
+
+            return replace(
+                dependencies,
+                build_galaxy_web_app=counted_build,
+                start_worker=start_worker_with_result_backend_probe,
+            )
 
         with self._isolate() as test_directory:
+            shed_workflow_path = os.path.join(test_directory, "embedded-shed-workflow.ga")
+            shutil.copyfile(shed_workflow_source, shed_workflow_path)
+            shed_tests_path = shed_workflow_path.replace(".ga", "-tests.yml")
+            with open(shed_tests_path, "w") as shed_tests:
+                shed_tests.write("""- doc: Exercise an installed Tool Shed workflow
+  job:
+    n_rows: 5
+  outputs:
+    outfile:
+      asserts:
+        has_n_lines:
+          n: 5
+""")
             report_path = os.path.join(test_directory, "embedded-report.json")
             with patch.object(embedded, "_load_runtime_dependencies", load_counted_runtime_dependencies):
                 result = self._check_exit_code(
@@ -56,6 +100,7 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
                         xml_tool_path,
                         yaml_tool_path,
                         workflow_path,
+                        shed_workflow_path,
                     ]
                 )
 
@@ -70,9 +115,12 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
             "num_errors": 0,
             "num_failures": 0,
             "num_skips": 0,
-            "num_tests": 3,
+            "num_tests": 4,
         }
         assert construction_count == 1
+        assert celery_results == ["probe complete"]
+        assert len(celery_state_reads) == 4
+        assert celery_state_reads[-2:] == ["SUCCESS", "SUCCESS"]
         assert all(test["data"]["status"] == "success" for test in report["tests"])
         tool_jobs = [test["data"]["job"] for test in report["tests"] if test["data"].get("job")]
         assert {job["tool_id"] for job in tool_jobs} == {"cat", "embedded_echo"}
@@ -80,9 +128,9 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
         # Pydantic's report model serializes optional fields as null, so select
         # by the authoritative runnable type rather than key presence.
         workflow_results = [test for test in report["tests"] if test["test_type"] == "galaxy_workflow"]
-        assert len(workflow_results) == 1
-        assert workflow_results[0]["data"]["invocation_details"]
-        assert workflow_results[0]["data"]["invocation_details"]["details"]["invocation_state"] in {
+        assert len(workflow_results) == 2
+        assert all(result["data"]["invocation_details"] for result in workflow_results)
+        assert {result["data"]["invocation_details"]["details"]["invocation_state"] for result in workflow_results} <= {
             "scheduled",
             "completed",
         }

--- a/tests/test_embedded_galaxy_integration.py
+++ b/tests/test_embedded_galaxy_integration.py
@@ -7,32 +7,57 @@ Galaxy build with galaxyproject/galaxy#23360.
 import json
 import os
 import threading
+from dataclasses import replace
+from unittest.mock import patch
 
 from .test_utils import (
     CliTestCase,
+    PROJECT_TEMPLATES_DIR,
     skip_unless_environ,
+    TEST_DATA_DIR,
     TEST_TOOLS_DIR,
 )
 
 
 class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
     @skip_unless_environ("PLANEMO_TEST_EMBEDDED_GALAXY")
-    def test_yaml_tool_runs_through_embedded_worker(self):
-        tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
+    def test_tools_upload_and_workflow_share_one_embedded_application(self):
+        xml_tool_path = os.path.join(PROJECT_TEMPLATES_DIR, "demo", "cat.xml")
+        yaml_tool_path = os.path.join(TEST_TOOLS_DIR, "embedded_echo.yml")
+        workflow_path = os.path.join(TEST_DATA_DIR, "wf2.ga")
+
+        from planemo.galaxy import embedded
+
+        load_runtime_dependencies = embedded._load_runtime_dependencies
+        construction_count = 0
+
+        def load_counted_runtime_dependencies():
+            dependencies = load_runtime_dependencies()
+            build_galaxy_web_app = dependencies.build_galaxy_web_app
+
+            def counted_build(*args, **kwds):
+                nonlocal construction_count
+                construction_count += 1
+                return build_galaxy_web_app(*args, **kwds)
+
+            return replace(dependencies, build_galaxy_web_app=counted_build)
 
         with self._isolate() as test_directory:
             report_path = os.path.join(test_directory, "embedded-report.json")
-            result = self._check_exit_code(
-                [
-                    "test",
-                    "--engine",
-                    "embedded_galaxy",
-                    "--no_dependency_resolution",
-                    "--test_output_json",
-                    report_path,
-                    tool_path,
-                ]
-            )
+            with patch.object(embedded, "_load_runtime_dependencies", load_counted_runtime_dependencies):
+                result = self._check_exit_code(
+                    [
+                        "test",
+                        "--engine",
+                        "embedded_galaxy",
+                        "--no_dependency_resolution",
+                        "--test_output_json",
+                        report_path,
+                        xml_tool_path,
+                        yaml_tool_path,
+                        workflow_path,
+                    ]
+                )
 
             with open(report_path) as report_fh:
                 report = json.load(report_fh)
@@ -45,12 +70,22 @@ class EmbeddedGalaxyIntegrationTestCase(CliTestCase):
             "num_errors": 0,
             "num_failures": 0,
             "num_skips": 0,
-            "num_tests": 1,
+            "num_tests": 3,
         }
-        test_data = report["tests"][0]["data"]
-        assert test_data["status"] == "success"
-        assert test_data["job"]["state"] == "ok"
-        assert test_data["job"]["tool_id"] == "embedded_echo"
+        assert construction_count == 1
+        assert all(test["data"]["status"] == "success" for test in report["tests"])
+        tool_jobs = [test["data"]["job"] for test in report["tests"] if test["data"].get("job")]
+        assert {job["tool_id"] for job in tool_jobs} == {"cat", "embedded_echo"}
+        assert all(job["state"] == "ok" for job in tool_jobs)
+        # Pydantic's report model serializes optional fields as null, so select
+        # by the authoritative runnable type rather than key presence.
+        workflow_results = [test for test in report["tests"] if test["test_type"] == "galaxy_workflow"]
+        assert len(workflow_results) == 1
+        assert workflow_results[0]["data"]["invocation_details"]
+        assert workflow_results[0]["data"]["invocation_details"]["details"]["invocation_state"] in {
+            "scheduled",
+            "completed",
+        }
 
         from galaxy import app as galaxy_app_module
 

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -10,8 +10,10 @@ from planemo.galaxy.config import (
     _all_tool_paths,
     _shared_galaxy_properties,
     _shed_config_paths,
+    embedded_galaxy_config,
     galaxy_config,
     get_refgenie_config,
+    local_galaxy_config,
     tail_log_directory,
     write_galaxy_config,
 )
@@ -179,6 +181,110 @@ def test_tool_evaluation_strategy_default_not_set():
     with TempDirectoryContext() as tdc:
         props = _shared_galaxy_properties(tdc.temp_directory, {}, for_tests=False)
     assert "tool_evaluation_strategy" not in props
+
+
+def test_embedded_galaxy_config_is_checkout_independent(tmp_path):
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    test_data = tmp_path / "test-data"
+    test_data.mkdir()
+    tool_path = os.path.join(os.path.dirname(__file__), "data", "tools", "two_tests.xml")
+    dependency_dir = tmp_path / "custom-dependencies"
+    ctx = create_test_context()
+
+    with embedded_galaxy_config(
+        ctx,
+        [for_path(tool_path)],
+        config_directory=str(config_directory),
+        test_data=str(test_data),
+        tool_dependency_dir=str(dependency_dir),
+        host="127.0.0.1",
+    ) as config:
+        with open(config.galaxy_config_file) as config_fh:
+            config_data = yaml.safe_load(config_fh)
+        file_properties = config_data["galaxy"]
+        properties = config.galaxy_properties
+
+        assert "gravity" not in config_data
+        assert properties["auto_configure_logging"] is False
+        assert properties["configure_logging"] is False
+        assert "configure_logging" not in file_properties
+        assert properties["enable_celery_tasks"] is True
+        assert properties["interactivetools_enable"] is False
+        assert properties["monitor_thread_join_timeout"] == 5
+        assert "use_display_applications" not in properties
+        assert properties["watch_tools"] is False
+        assert properties["tool_data_table_config_path"].endswith("empty_tool_data_table_conf.xml")
+        assert properties["amqp_internal_connection"] == (f"sqlalchemy+sqlite:///{config_directory / 'control.sqlite'}")
+        assert properties["celery_conf"] == {
+            "broker_url": "memory://",
+            "result_backend": "rpc://localhost",
+            "worker_hijack_root_logger": False,
+        }
+        assert properties["bootstrap_admin_api_key"] == config.master_api_key
+        assert "master_api_key" not in properties
+        assert all(value is not None for value in properties.values())
+        assert properties["tool_dependency_dir"] == str(dependency_dir)
+        assert dependency_dir.is_dir()
+        assert "tour_config_dir" not in properties
+        assert config.galaxy_url.startswith("http://127.0.0.1:")
+        assert config.env["GALAXY_CONFIG_FILE"] == config.galaxy_config_file
+        assert "GALAXY_DEVELOPMENT_ENVIRONMENT" not in config.env
+
+        with open(properties["job_config_file"]) as job_config_fh:
+            job_config = yaml.safe_load(job_config_fh)
+        assert "handling" not in job_config
+
+
+def test_embedded_test_configuration_uses_explicit_empty_plugin_directories(tmp_path):
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    ctx = create_test_context()
+
+    with embedded_galaxy_config(
+        ctx,
+        [],
+        for_tests=True,
+        config_directory=str(config_directory),
+    ) as config:
+        properties = config.galaxy_properties
+
+        assert properties["tour_config_dir"] == str(config_directory / "empty")
+        assert properties["visualization_plugins_directory"] == str(config_directory / "empty")
+        assert properties["interactive_environment_plugins_directory"] == str(config_directory / "empty")
+
+
+def test_shared_config_refactor_preserves_checkout_runtime(tmp_path):
+    galaxy_root = tmp_path / "galaxy"
+    galaxy_package = galaxy_root / "lib" / "galaxy"
+    galaxy_package.mkdir(parents=True)
+    (galaxy_package / "version.py").write_text('VERSION = "25.0.1"')
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    test_data = tmp_path / "test-data"
+    test_data.mkdir()
+    dependency_dir = tmp_path / "checkout-dependencies"
+    ctx = create_test_context()
+
+    with local_galaxy_config(
+        ctx,
+        [],
+        galaxy_root=str(galaxy_root),
+        config_directory=str(config_directory),
+        test_data=str(test_data),
+        tool_dependency_dir=str(dependency_dir),
+        disable_gxits=True,
+    ) as config:
+        with open(config.env["GALAXY_CONFIG_FILE"]) as config_fh:
+            config_data = yaml.safe_load(config_fh)
+
+        assert config_data["gravity"]["galaxy_root"] == str(galaxy_root)
+        assert config_data["gravity"]["gx_it_proxy"] == {"enable": False}
+        assert config.env["GALAXY_DEVELOPMENT_ENVIRONMENT"] == "1"
+        assert config.env["GALAXY_CONFIG_OVERRIDE_TOOL_DEPENDENCY_DIR"] == str(dependency_dir)
+        assert dependency_dir.is_dir()
+        with open(config.env["GALAXY_CONFIG_OVERRIDE_JOB_CONFIG_FILE"]) as job_config_fh:
+            assert "handling" not in yaml.safe_load(job_config_fh)
 
 
 @contextlib.contextmanager

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -3,6 +3,7 @@
 import contextlib
 import json
 import os
+import shutil
 
 import yaml
 
@@ -14,6 +15,7 @@ from planemo.galaxy.config import (
     galaxy_config,
     get_refgenie_config,
     local_galaxy_config,
+    SERVICE_LOG_TAIL_LINES,
     tail_log_directory,
     write_galaxy_config,
 )
@@ -252,6 +254,29 @@ def test_embedded_test_configuration_uses_explicit_empty_plugin_directories(tmp_
         assert properties["tour_config_dir"] == str(config_directory / "empty")
         assert properties["visualization_plugins_directory"] == str(config_directory / "empty")
         assert properties["interactive_environment_plugins_directory"] == str(config_directory / "empty")
+
+
+def test_embedded_no_cleanup_preserves_config_and_bounded_log_tail():
+    ctx = create_test_context()
+    config = None
+    config_directory = None
+    lines = [f"embedded log line {index}" for index in range(SERVICE_LOG_TAIL_LINES + 5)]
+
+    try:
+        with embedded_galaxy_config(ctx, [], no_cleanup=True) as config:
+            config_directory = config.config_directory
+            with open(config.log_file, "w") as log_fh:
+                log_fh.write("\n".join(lines) + "\n")
+
+            service_logs = config.service_log_contents
+            assert list(service_logs) == ["embedded.log"]
+            assert service_logs["embedded.log"].splitlines() == lines[-SERVICE_LOG_TAIL_LINES:]
+
+        assert os.path.isdir(config_directory)
+        assert config.log_contents.splitlines() == lines
+    finally:
+        if config_directory:
+            shutil.rmtree(config_directory, ignore_errors=True)
 
 
 def test_shared_config_refactor_preserves_checkout_runtime(tmp_path):

--- a/tests/test_galaxy_config.py
+++ b/tests/test_galaxy_config.py
@@ -279,6 +279,18 @@ def test_embedded_no_cleanup_preserves_config_and_bounded_log_tail():
             shutil.rmtree(config_directory, ignore_errors=True)
 
 
+def test_embedded_config_removes_its_generated_directory():
+    ctx = create_test_context()
+    config_directory = None
+
+    with embedded_galaxy_config(ctx, []) as config:
+        config_directory = config.config_directory
+        assert os.path.isdir(config_directory)
+
+    assert config_directory is not None
+    assert not os.path.exists(config_directory)
+
+
 def test_shared_config_refactor_preserves_checkout_runtime(tmp_path):
     galaxy_root = tmp_path / "galaxy"
     galaxy_package = galaxy_root / "lib" / "galaxy"

--- a/tests/test_runnable.py
+++ b/tests/test_runnable.py
@@ -1,0 +1,15 @@
+"""Tests for runnable type detection."""
+
+# Planemo's normal startup loads the Galaxy package before importing runnable.
+from planemo.galaxy import galaxy_config  # noqa: F401
+from planemo.runnable import (
+    for_path,
+    RunnableType,
+)
+
+
+def test_yaml_galaxy_tool_is_a_runnable(tmp_path):
+    tool_path = tmp_path / "minimal.yml"
+    tool_path.write_text("class: GalaxyTool\nid: minimal\nname: Minimal\nversion: '1.0'\n")
+
+    assert for_path(str(tool_path)).type == RunnableType.galaxy_tool

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 import traceback
 from concurrent.futures import (
@@ -60,11 +61,86 @@ PROJECT_TEMPLATES_DIR = os.path.join(TEST_DIR, os.path.pardir, "project_template
 CWL_DRAFT3_DIR = os.path.join(PROJECT_TEMPLATES_DIR, "cwl_draft3_spec")
 NON_ZERO_EXIT_CODE = object()
 CWLTOOL_CACHE_ENV_PROP = "PLANEMO_CWLTOOL_CACHE_DIRECTORY"
+PLANEMO_CLI_ENTRYPOINT = "from planemo.cli import planemo; planemo()"
+
+
+class _PlanemoSubprocess:
+    def __init__(self, arguments, cwd=None, log_path=None):
+        environment = os.environ.copy()
+        executable_directory = os.path.dirname(sys.executable)
+        existing_path = environment.get("PATH")
+        environment["PATH"] = (
+            os.pathsep.join((executable_directory, existing_path)) if existing_path else executable_directory
+        )
+        if log_path:
+            self._log_fh = open(log_path, "w+")
+        else:
+            self._log_fh = tempfile.NamedTemporaryFile(mode="w+", suffix="_planemo_stdout")
+        try:
+            self.process = subprocess.Popen(
+                [sys.executable, "-c", PLANEMO_CLI_ENTRYPOINT, *arguments],
+                cwd=cwd,
+                env=environment,
+                stdout=self._log_fh,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        except Exception:
+            self._log_fh.close()
+            raise
+        self._closed = False
+        self._output = None
+
+    def read_output(self):
+        if self._output is not None:
+            return self._output
+        self._log_fh.flush()
+        self._log_fh.seek(0)
+        return self._log_fh.read()
+
+    def close(self):
+        if self._closed:
+            return
+        try:
+            if self.process.poll() is None or io.process_group_exists(self.process.pid):
+                io.terminate_process_group(
+                    self.process.pid,
+                    reap=self.process.poll,
+                )
+        finally:
+            try:
+                self._output = self.read_output()
+            finally:
+                self._log_fh.close()
+                self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
+
+def planemo_subprocess(arguments, cwd=None, log_path=None):
+    """Start a logged Planemo CLI process in an independently managed group."""
+    return _PlanemoSubprocess(arguments, cwd=cwd, log_path=log_path)
 
 
 def test_sleep_fails_immediately_for_invalid_url():
     with pytest.raises(requests_lib.exceptions.InvalidURL):
         sleep("http://::1:9090")
+
+
+def test_planemo_subprocess_captures_cli_output():
+    with planemo_subprocess(["--help"]) as managed_process:
+        assert managed_process.process.wait(timeout=30) == 0
+        process_output = managed_process.read_output()
+        assert "Usage:" in process_output
+        process_group_id = managed_process.process.pid
+
+    assert not io.process_group_exists(process_group_id)
+    assert managed_process.read_output() == process_output
+    managed_process.close()
 
 
 SIGTERM_IGNORING_PROCESS = """

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     unit: coverage
     unit: flask
     unit: responses
+    unit: uvicorn
     mypy: mypy
 
 setenv =


### PR DESCRIPTION
Requires a release of Galaxy containing [#23360](https://github.com/galaxyproject/galaxy/pull/23360).

Opening a WIP PR just because we've done a lot of work not a reflection of it being close to being ready. I really dislike the tests in here and I'm unsure if the Galaxy layer should be proxied through Gravity or not. A lot of the complexity in planemo/galaxy/embedded.py seems not particularly Planemo-specific and I wonder if Gravity or a new galaxy-launcher-library project could absorb the complexity and isolate it from Planemo. Rest of this writeup is agent stuff. -John

## Summary

This adds an opt-in `--engine embedded_galaxy` mode for `planemo run`, `planemo test`, and foreground `planemo serve`.

Instead of cloning or launching a Galaxy checkout, the engine loads a coherent, package-installed Galaxy into Planemo's Python process. Planemo still talks to Galaxy through its existing HTTP/BioBlend interfaces, so tool execution, workflow execution, reporting, profiles, dependency resolution, and Tool Shed installation continue to use the established Planemo paths.

The engine is deliberately opt-in and does not change the existing `galaxy`, `docker_galaxy`, `external_galaxy`, or `uvx_galaxy` engines.

## Motivation

The managed Galaxy engine provides strong isolation but pays for checkout and subprocess startup. Package-installed Galaxy can provide a substantially lighter authoring and testing loop if Planemo owns the complete in-process lifecycle and leaves no global state, worker, server, child process, or temporary configuration behind.

This work also makes YAML Galaxy tools valid `GalaxyTool` runnables, fixing the existing mismatch where discovery yielded YAML tool sources that `for_path()` later rejected.

## Implementation

- Registers `embedded_galaxy` in the engine factory and relevant CLI choices, with validation for unsupported checkout, daemon, non-loopback, and interactive-tool options.
- Extracts checkout-independent managed-Galaxy configuration shared by the existing local and embedded engines.
- Builds Galaxy lazily with `build_galaxy_web_app(..., register_shutdown_at_exit=False)` and restores Galaxy's process-global application reference on every exit path.
- Pre-binds one loopback socket and serves Galaxy's ASGI application on a dedicated uvicorn thread, avoiding the probe/close/bind race.
- Starts one in-process Celery worker with the `solo` pool and both `galaxy.internal` and `galaxy.external` queues, using in-memory transport and the RPC result backend.
- Reuses the existing Galaxy engine's HTTP execution, workflow, profile, reporting, dependency-resolution, PostgreSQL/Singularity, and Tool Shed installation paths.
- Keeps mixed tool/workflow tests inside one Galaxy construction rather than attempting multiple application lifecycles in one process.
- Captures Galaxy, Celery, and uvicorn logs in the generated configuration directory while preserving Planemo's normal and Rich verbose output behavior.
- Performs ordered, failure-tolerant teardown of uvicorn, Celery, Galaxy's fork pool, the Galaxy application, logging/environment state, and temporary configuration.
- Clears Celery's process-global termination flag after a timed-out worker shutdown so a failed worker cannot poison the next in-process invocation.
- Reports live threads and multiprocessing children when cooperative cleanup exceeds 30 seconds. This is diagnostic rather than a hard bound: Pebble currently performs unbounded internal joins after a process pool is stopped.

## Scope and limitations

Version 1 supports local tools and workflows, Tool Shed installs, profiles/PostgreSQL, and the existing Conda/container dependency resolvers.

It does not:

- become the default engine;
- embed a Galaxy source checkout;
- support daemon mode or non-loopback binding;
- run gx-it-proxy, interactive tools, Celery beat, or periodic maintenance;
- promise two independent Galaxy application constructions in one Python process; or
- expose Galaxy's application object as a public Planemo API.

## Test coverage

Fast lifecycle and configuration coverage includes:

- option validation and lazy optional-runtime imports;
- generated checkout-free Galaxy configuration;
- startup and teardown ordering;
- construction, readiness, uvicorn, partial-worker, and cleanup-action failures;
- first and second `Ctrl-C` behavior;
- process-global Galaxy and Celery state restoration;
- logging restoration, bounded failure-log replay, and `--no_cleanup` preservation;
- fork-pool, thread, child-process, socket, and temporary-directory cleanup; and
- one application construction for mixed tool/workflow inputs.

Opt-in tests against Galaxy packages built with #23360 prove:

- XML and YAML tool execution;
- real Celery-backed upload execution;
- local and Tool Shed-installed workflow execution;
- two consecutive `planemo run` output downloads in fresh subprocesses;
- foreground `planemo serve` readiness and SIGINT cleanup; and
- no surviving Planemo-owned process group or listening socket after subprocess exit, plus focused restoration checks for global Galaxy/Celery state, logging, threads, and generated configuration.

Latest focused results:

```text
50 passed, 6 skipped
real embedded acceptance suite against Galaxy dev: 3 passed
mixed XML/YAML/upload/workflow/Tool Shed acceptance: passed
real repeated subprocess run and foreground serve acceptance: passed
black, isort, ruff, flake8, and whitespace checks: passed
```

## Before marking ready for review
	
- [x] Rebase onto `master` after Planemo #1687 merges and confirm the PR contains only the embedded-engine work.
- [ ] Use the first Galaxy release containing #23360 to add `planemo[embedded_galaxy]` with a one-series upper bound.
- [ ] Add optional-dependency containment and resolver checks.
- [ ] Add user documentation and Linux per-PR integration coverage against the released package set.
- [ ] Record comparable cold and warm startup timings for `galaxy` and `embedded_galaxy`.
- [x] Incorporate the separate mypy cleanup and run `tox -e mypy` cleanly.
- [ ] Run the existing-engine and full Planemo regression suites after the final rebase.

## Suggested reviewer path

1. Engine registration, option validation, and YAML runnable recognition.
2. Shared managed-Galaxy configuration extraction and parity tests.
3. `planemo/galaxy/embedded.py` startup, logging, and ordered teardown.
4. Engine reuse for run/test/workflow/Tool Shed execution and the one-application test path.
5. Concrete package-installed acceptance tests and subprocess cleanup assertions.



